### PR TITLE
Reset servo state when manually setting angles/turning motors off

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -671,13 +671,13 @@ class Mmu:
         self.tool_selected = self._next_tool = self._last_tool = self.TOOL_UNKNOWN
         self._last_toolchange = "Unknown"
         self.gate_selected = self.GATE_UNKNOWN # We keep record of gate selected in case user messes with mapping in print
-        self.servo_state = self.servo_angle = self.SERVO_UNKNOWN_STATE
         self.filament_pos = self.FILAMENT_POS_UNKNOWN
         self.filament_direction = self.counting_direction = self.DIRECTION_UNKNOWN
         self.filament_distance = self.last_filament_distance = 0. # Current absolute distance from gate (load) or nozzle (unload)
         self.action = self.ACTION_IDLE
         self.calibrating = False
         self.saved_toolhead_position = False
+        self._servo_reset_state()
         self._reset_statistics()
 
     def _load_persisted_state(self):
@@ -1169,8 +1169,13 @@ class Mmu:
 # SERVO AND MOTOR FUNCTIONS #
 #############################
 
+    def _servo_reset_state(self):
+        self.servo_state = self.SERVO_UNKNOWN_STATE
+        self.servo_angle = self.SERVO_UNKNOWN_STATE
+
     def _servo_set_angle(self, angle):
         self.servo.set_value(angle=angle, duration=self.servo_duration)
+        self.servo_angle = angle
         self.servo_state = self.SERVO_UNKNOWN_STATE
 
     def _servo_down(self, buzz_gear=True):
@@ -1267,6 +1272,7 @@ class Mmu:
     def cmd_MMU_MOTORS_OFF(self, gcmd):
         if self._check_is_disabled(): return
         self._motors_off()
+        self._servo_reset_state()
         self._servo_auto()
 
     cmd_MMU_TEST_BUZZ_MOTOR_help = "Simple buzz the selected motor (default gear) for setup testing"


### PR DESCRIPTION
**Issue:**

There are two main things this PR addresses: 
1. When manually setting a servo angle via `MMU_SERVO ANGLE=<something>`, the internal angle state is not updated. This means that if the next servo command would bring it to its old state, no movement would be issued since it doesn't think it ever left that position. Simple repro case (may have to adjust values for your setup):

```
MMU_SERVO POS=move ; moves
MMU_SERVO ANGLE=50 ; moves
MMU_SERVO POS=move ; does not move
```

2. When turning off the motors, the servo will not move if it thinks it's in the correct state. This would normally be fine, but I've run into issues where the servo gets bound up on something and it would help if it tried to get back into its safe position when the other motors get turned off.

**Fix Description:**

1. When calling `MMU_SERVO ANGLE=<something>`, the internal angle state is now updated to the requested angle
2. The servo state is now reset when motors are turned off but before `self._servo_auto()` is called. This should result in re-attempting getting into the safe position even if it thinks it's already there.

More generally, I think this angle stuff could be handled more gracefully if the servo's current position could be read. I briefly tried adding that functionality to `mmu_servo.py`, but that seemed outside the scope of this simple change. I also couldn't figure out how to load up these files in a REPL for testing, but that's beside the point.

**GitHub Issues Resolved:**

None