### PR TITLE
Ensure sync state after no-op tool change

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -3485,6 +3485,7 @@ class Mmu:
         initial_tool_string = "Unknown" if self.tool_selected < 0 else ("T%d" % self.tool_selected)
         if tool == self.tool_selected and self.tool_to_gate_map[tool] == self.gate_selected and self.filament_pos == self.FILAMENT_POS_LOADED:
             self._log_always("Tool T%d is already ready" % tool)
+            self._sync_gear_to_extruder(self.sync_to_extruder, servo=True, in_print=True)
             return
 
         if self.filament_pos == self.FILAMENT_POS_UNLOADED:

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -3366,7 +3366,7 @@ class Mmu:
                 # Not synchronous gear/extruder movement
                 return (delta > self.encoder_min or filament_present == 1), park_pos
         finally:
-            self._sync_gear_to_extruder(self.sync_to_extruder, servo=True, in_print=self._is_in_print())
+            self._sync_gear_to_extruder(self.sync_to_extruder, servo=True, in_print=self._is_in_print() or self._is_in_pause())
             self._set_action(current_action)
 
 

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -3366,7 +3366,7 @@ class Mmu:
                 # Not synchronous gear/extruder movement
                 return (delta > self.encoder_min or filament_present == 1), park_pos
         finally:
-            self._sync_gear_to_extruder(self.sync_to_extruder, servo=True, in_print=self._is_in_print() or self._is_in_pause())
+            self._sync_gear_to_extruder(False)
             self._set_action(current_action)
 
 

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -3366,7 +3366,7 @@ class Mmu:
                 # Not synchronous gear/extruder movement
                 return (delta > self.encoder_min or filament_present == 1), park_pos
         finally:
-            self._sync_gear_to_extruder(False)
+            self._sync_gear_to_extruder(self.sync_to_extruder, servo=True, in_print=self._is_in_print())
             self._set_action(current_action)
 
 


### PR DESCRIPTION
**Issue:**

When using the MMU in a way that calls `_change_tool` when the desired tool is currently selected, extruder sync would be lost, causing filament to bind and trigger clog detection once you started printing. Steps to repro:

1. Enable print syncing in your MMU config. It shouldn't matter, but I have loads synced and unloads/tip forming is unsynced
2. Before a print, select and load tool 0 (`T0`)
3. In your `PRINT_START` macro, call `MMU_CHANGE_TOOL STANDALONE=1 TOOL=0`
    - NOTE: this disables sync
    - NOTE: sync would be re-enabled if this switched tools, but in `_change_tool` there's an early return if the MMU is aware of its state and if the tool you're switching to is the one that's currently selected
4. See that the servo is in the down position but the gear is not synced, causing binding and other unpleasantness

**Fix Description:**

`_change_tool` has been updated to set the correct sync state in its early return

**GitHub Issues Resolved:**

None