### PR TITLE
Update MMU_SYNC_GEAR_MOTOR to allow specifying print state

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,10 +579,11 @@ Synchronizion during printing is controlled by `sync_to_extruder` in `mmu_parame
 
 If the `sync_to_extruder` feature is activated, the gear stepper will automatically coordinate with the extruder stepper following a successful tool change. Any MMU operation that necessitates exclusive gear stepper movement (like buzzing the gear stepper to verify filament engagement), will automatically disengage the sync. Generally, you don't need to manually manage the coordination/discoordination of the gear stepper — Happy Hare handles these actions. If the printer enters MMU_PAUSE state (due to a filament jam or runout, for example), synchronization is automatically disengaged and the servo lifted. Upon resuming a print synchronization will automatically be resumed however if you wist to enable it whilst operating the MMU during a pause use the `MMU_SYNC_GEAR_MOTOR` command.
 
-    The `MMU_SYNC_GEAR_MOTOR sync={0|1} servo={0|1}` command functions as follows:
-    - Defaults to `sync=1` and `servo=1`
+    The `MMU_SYNC_GEAR_MOTOR sync={0|1} servo={0|1} in_print={0|1}` command functions as follows:
+    - Defaults to `sync=1`, `servo=1`, and `in_print` is determined automatically
     - If `sync=1` and `servo=1`, it triggers the servo and executes the synchronization
     - If `sync=1` and `servo=0`, it performs only the synchronization
+    - In either of the above cases, `in_print=1` performs the synchronization and sets gear stepper current to `sync_gear_current`
     - If `sync=0` and `servo=1`, it disengages and lifts the servo
     - If `sync=0` and `servo=0`, it only disengages the synchronization
 

--- a/doc/command_ref.md
+++ b/doc/command_ref.md
@@ -72,7 +72,7 @@ Firstly you can get a quick reminder of commands using the `MMU_HELP` command fr
   | ------- | ----------- | ---------- |
   | `MMU_SERVO` | Set the servo to specified postion or a sepcific angle for testing.  | `POS=[up\|down\|move]` Move servo to predetermined position <br>`ANGLE=..` Move servo to specified angle |
   | `MMU_MOTORS_OFF` | Turn off both MMU motors | None |
-  | `MMU_SYNC_GEAR_MOTOR` | Explicitly override the synchronization of extruder and gear motors. Note that synchronization is set automatically so this will only be sticky until the next tool change | `SYNC=[0\|1]` Turn gear/extruder synchronization on/off (default 1) <br>`SERVO=[0\|1]` If 1 (the default) servo will engage if SYNC=1 or disengage if SYNC=0 otherwise servo position will not change |
+  | `MMU_SYNC_GEAR_MOTOR` | Explicitly override the synchronization of extruder and gear motors. Note that synchronization is set automatically so this will only be sticky until the next tool change | `SYNC=[0\|1]` Turn gear/extruder synchronization on/off (default 1) <br>`SERVO=[0\|1]` If 1 (the default) servo will engage if SYNC=1 or disengage if SYNC=0 otherwise servo position will not change <br>`IN_PRINT=[0\|1]` If 1, gear stepper current will be set according to `sync_gear_current`. If 0, gear stepper current is set to 100%. The default is automatically determined based on print state but can be overridden with this argument. Only meaningful if `SYNC=1` |
   
   <br>
 

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -1320,7 +1320,7 @@ class Mmu:
         servo = gcmd.get_int('SERVO', 1, minval=0, maxval=1)
         sync = gcmd.get_int('SYNC', 1, minval=0, maxval=1)
         in_print = gcmd.get_int('IN_PRINT', fallback_print_state, minval=0, maxval=1)
-        self._sync_gear_to_extruder(sync, servo=servo, in_print=in_print)
+        self._sync_gear_to_extruder(sync, servo=servo, in_print=bool(in_print))
 
 
 #########################

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -1316,9 +1316,11 @@ class Mmu:
     def cmd_MMU_SYNC_GEAR_MOTOR(self, gcmd):
         if self._check_is_disabled(): return
         if self._check_in_bypass(): return
+        fallback_print_state = 1 if self._is_in_print() or self._is_in_pause() else 0
         servo = gcmd.get_int('SERVO', 1, minval=0, maxval=1)
         sync = gcmd.get_int('SYNC', 1, minval=0, maxval=1)
-        self._sync_gear_to_extruder(sync, servo)
+        in_print = gcmd.get_int('IN_PRINT', fallback_print_state, minval=0, maxval=1)
+        self._sync_gear_to_extruder(sync, servo=servo, in_print=in_print)
 
 
 #########################


### PR DESCRIPTION
**Issue:**

When calling `MMU_SYNC_GEAR_MOTOR` during a print, the gear current is set to 100%

**Fix Description:**

`cmd_MMU_SYNC_GEAR_MOTOR` and accompanying docs have been updated to allow manually specifying whether it should treat `_sync_gear_to_extruder` like you're in a print. The default is automatically determined based on current print state

**GitHub Issues Resolved:**

None