### PR TITLE
Temp logic updates and misc bugfixes

### DIFF
--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -208,13 +208,13 @@ persistence_level: 3
 
 # Misc configurable, but fairly fixed values -----------------------------------------------------------------------------
 #
-extruder: extruder		# Name of the toolhead extruder that MMU is using
+extruder: extruder		    # Name of the toolhead extruder that MMU is using
 timeout_pause: 72000		# Time out in seconds used by the MMU_PAUSE
-disable_heater: 600		# Delay in seconds after which the hotend heater is disabled in the MMU_PAUSE state
-min_temp_extruder: 200		# Used to ensure we can move the extruder and form tips
-z_hop_height_error: 5	        # Height in mm of z_hop move on pause to avoid blob on print
+disable_heater: 600		    # Delay in seconds after which the hotend heater is disabled in the MMU_PAUSE state
+default_extruder_temp: 200  # The baseline temperature for performing swaps and forming tips outside of a print
+z_hop_height_error: 5	    # Height in mm of z_hop move on pause to avoid blob on print
 z_hop_height_toolchange: 0	# Height in mm of z_hop move on toolchange or runout to avoid blob on print
-z_hop_speed: 15			# mm/s Speed of z_hop move
+z_hop_speed: 15			    # mm/s Speed of z_hop move
 slicer_tip_park_pos: 0		# This specifies the position of filament in extruder after slicer tip forming move
 gcode_load_sequence: 0		# Advanced: Gcode loading sequence 1=enabled, 0=internal logic (default)
 gcode_unload_sequence: 0	# Advanced: Gcode unloading sequence, 1=enabled, 0=internal logic (default)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -247,6 +247,7 @@ persistence_level: 3
 ```
 
 This section contains an eclectic set of remaining options. Ask on discord if any aren't clear, however a couple warrant further explantion:<br>
+`default_extruder_temp` - This is the default temperature for performing swaps and tip forming when outside of a print. It's also a fallback in the event that your printer tries to print with an unsafe temperature after a pause. When printing, the slicer will be responsible for setting the temperature. You may want to set this to a middleground temperature that works "well enough" with the full range of filaments you regularly print.<br>
 `slicer_tip_park_pos` - If you use the default slicer tip shaping logic then it will leave the filament at a particular place in the extruder. Unfortunately Happy Hare has no way to detect this like it can when it takes care of tip shaping. This parameter usually exists in the slicer and setting it will pass on to Happy Hare for more efficient subsequent unloading.<br>
 `auto_calibrate_gates` - discussed in main readme but avoids having to calibrate since that are automatically calibrated on first use.<br>
 `strict_filament_recovery` - Occassionaly Happy Hare will be forced to try to figure our where the filament is. It employs various mechanisms to achive this depending on the capability of the MMU. Some of this steps are invasive (e.g. warming the extruder when it is cold) and are therefore skipped by default. Enabling this option will force extra detection steps.
@@ -255,13 +256,13 @@ This section contains an eclectic set of remaining options. Ask on discord if an
 ```yml
 # Misc configurable, but fairly fixed values -----------------------------------------------------------------------------
 #
-extruder: extruder		# Name of the toolhead extruder that MMU is using
+extruder: extruder		    # Name of the toolhead extruder that MMU is using
 timeout_pause: 72000		# Time out in seconds used by the MMU_PAUSE
-disable_heater: 600		# Delay in seconds after which the hotend heater is disabled in the MMU_PAUSE state
-min_temp_extruder: 200		# Used to ensure we can move the extruder and form tips
+disable_heater: 600		    # Delay in seconds after which the hotend heater is disabled in the MMU_PAUSE state
+default_extruder_temp: 200	# The baseline temperature for performing swaps and forming tips outside of a print
 z_hop_height_error: 5		# Height in mm of z_hop move on pause to avoid blob on print
 z_hop_height_toolchange: 0	# Height in mm of z_hop move on runout or toolchange to avoid blob on print
-z_hop_speed: 15			# mm/s Speed of z_hop move
+z_hop_speed: 15			    # mm/s Speed of z_hop move
 slicer_tip_park_pos: 0		# This specifies the position of filament in extruder after slicer tip forming move
 gcode_load_sequence: 0		# Advanced: Gcode loading sequence 1=enabled, 0=internal logic (default)
 gcode_unload_sequence: 0	# Advanced: Gcode unloading sequence, 1=enabled, 0=internal logic (default)

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -236,7 +236,7 @@ class Mmu:
         self.timeout_pause = config.getint('timeout_pause', 72000)
         self.timeout_unlock = config.getint('timeout_unlock', -1)
         self.disable_heater = config.getint('disable_heater', 600)
-        self.min_temp_extruder = config.getfloat('min_temp_extruder', 180.)
+        self.default_extruder_temp = config.getfloat('default_extruder_temp', 180.)
         self.gcode_load_sequence = config.getint('gcode_load_sequence', 0)
         self.gcode_unload_sequence = config.getint('gcode_unload_sequence', 0)
         self.z_hop_height_error = config.getfloat('z_hop_height_error', 5., minval=0.)
@@ -2046,12 +2046,12 @@ class Mmu:
             target_temp = current_target_temp
             source = "current"
 
-        if ensure_min and target_temp < self.min_temp_extruder:
-            target_temp = self.min_temp_extruder
+        if ensure_min and target_temp < self.default_extruder_temp:
+            target_temp = self.default_extruder_temp
             source = "minimum"
 
         if target_temp > current_target_temp:
-            if target_temp == self.min_temp_extruder:
+            if target_temp == self.default_extruder_temp:
                 # We use error channel to aviod heating surprise and will cause popup in Klipperscreen
                 self._log_error("Heating extruder to %s temp (%.1f)" % (source, target_temp))
             else:
@@ -2059,7 +2059,7 @@ class Mmu:
         self.gcode.run_script_from_command("SET_HEATER_TEMPERATURE HEATER=extruder TARGET=%.1f" % target_temp)
 
         # Optionally wait until temperature is stable or at minimum saftey temp and extruder can move
-        if wait or (ensure_min and current_temp < self.min_temp_extruder):
+        if wait or (ensure_min and current_temp < self.default_extruder_temp):
             if abs(target_temp - current_temp) > 1:
                 current_action = self._set_action(self.ACTION_HEATING)
                 self._log_info("Waiting for extruder to reach target temperature (%.1f)" % target_temp)

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -2647,7 +2647,7 @@ class Mmu:
     cmd_MMU_STEP_SET_FILAMENT_help = "User composable loading step: Set filament position state"
     def cmd_MMU_STEP_SET_FILAMENT(self, gcmd):
         state = gcmd.get_int('STATE', )
-        slient = gcmd.get_int('SILENT', 0)
+        silent = gcmd.get_int('SILENT', 0)
         if state >= self.FILAMENT_POS_UNLOADED and state <= self.FILAMENT_POS_LOADED:
             self._set_filament_pos(state, silent)
         else:

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -13,7 +13,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 #
 import logging, logging.handlers, threading, queue, time
-import textwrap, math, os.path, re, json
+import math, os.path, re
 from random import randint
 import chelper
 

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -236,7 +236,7 @@ class Mmu:
         self.timeout_pause = config.getint('timeout_pause', 72000)
         self.timeout_unlock = config.getint('timeout_unlock', -1)
         self.disable_heater = config.getint('disable_heater', 600)
-        self.default_extruder_temp = config.getfloat('default_extruder_temp', 180.)
+        self.default_extruder_temp = config.getfloat('default_extruder_temp', 200.)
         self.gcode_load_sequence = config.getint('gcode_load_sequence', 0)
         self.gcode_unload_sequence = config.getint('gcode_unload_sequence', 0)
         self.z_hop_height_error = config.getfloat('z_hop_height_error', 5., minval=0.)


### PR DESCRIPTION
**Issues:**

- `_ensure_safe_extruder_temperature` would set the wrong temperature coming out of a pause if `min_temp_extruder` is greater than the current printing temperature
- In certain conditions, `MMU_STEP_SET_FILAMENT` would fail due to referencing an undefined variable

**Fix Description:**

- `_ensure_safe_extruder_temperature` now uses Klipper's `min_extrude_temp` as the baseline for safety
- `min_temp_extruder` has been renamed and repurposed to `default_extruder_temp`. This now represents a sensible baseline for actions out-of-print as well as a workable fallback if the target temperature somehow gets set to an unsafe value during Happy Hare operations
-  The typo in `MMU_STEP_SET_FILAMENT` has been resolved

**Bonus Nachos:**

- A new helper, `_wrap_action`, has been introduced to simplify state maintenance when making quick changes to state (eg: changing to heating before restoring old state). I've included it as a proof-of-concept and it can be applied in more places if there's interest 

**GitHub Issues Resolved:**

None