### PR TITLE
fix _get_max_movement() on ERCF v2 for homing

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -1548,7 +1548,7 @@ class Mmu:
         n = gate if gate >= 0 else (self.mmu_num_gates - 1)
         if self.mmu_version >= 2.0:
             max_movement = self.cad_gate0_pos + (n * self.cad_gate_width)
-            max_movement += (self.cad_last_gate_offset - self.cad_bypass_offset) if gate == self.TOOL_GATE_BYPASS else 0.
+            max_movement += (self.cad_last_gate_offset - self.cad_bypass_offset) if gate < 0 else 0.
         else:
             max_movement = self.cad_gate0_pos + (n * self.cad_gate_width) + (n//3) * self.cad_block_width
 


### PR DESCRIPTION
_home_selector() allows a max movement of "_get_max_movement(-1)" for homing.  _get_max_movement() was only compensating for the bypass offset if the parameter was -2 (TOOL_GATE_BYPASS)

This PR will allow a max movement that does consider the bypass offset (for ERCF v2+) if the target gate is anything less than 0, which includes UNKNOWN (used by _home_selector) as well as BYPASS.  

The change purposely assumes any other negative "gate" value would indicate some type of unknown or undefined gate which would allow movement to/from the bypass.

Fixes https://github.com/moggieuk/Happy-Hare/issues/27