### PR TITLE
check that target_temp_override is >=  klipper_minimum_temp

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -2029,8 +2029,13 @@ class Mmu:
         current_target_temp = extruder.heater.target_temp
         klipper_minimum_temp = extruder.get_heater().min_extrude_temp
 
+        # Check type for safety
+        if (isinstance(target_temp_override, int) or isinstance(target_temp_override, float)) is False:
+            self._log_error("Invalid target_temp_override type: %s" % type(target_temp_override))
+            target_temp_override = -1
+
         # Determine correct target temp and hint as to where from to aid debugging
-        if target_temp_override > -1:
+        if target_temp_override >= klipper_minimum_temp:
             new_target_temp = target_temp_override
             source = "resume"
         elif self.is_paused_locked:


### PR DESCRIPTION
Fix for issue #36

target_temp_override is passed in as 0 from self.paused_extruder_temp (separate issue), evaluating to the first if statement and causing new_target_temp to be assigned 0.

This ultimately leads to the new extruder temp being set to the MMU's default temp. I don't see a reason in any scenario where checking if target_temp_override >= klipper_minimum_temp could cause issues, as we shouldn't be printing below that temp anyway.

Tested in my setup (RPi4, RatOS, RatRig 3.1 300mm) and fixed my issue.