### PR TITLE
Confirm self.paused_extruder_temp is set on cmd_MMU_RESUME

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -3874,7 +3874,9 @@ class Mmu:
             else:
                 self._log_always("State does not indicate flament is LOADED.  Please run `MMU_RECOVER LOADED=1` first")
                 return
-
+        # In case a manual pause was called where we do not intercept and set the extruder temp
+        if self.paused_extruder_temp == 0:
+            self.paused_extruder_temp = self.printer.lookup_object(self.extruder_name).heater.target_temp
         # Important to wait for stable temperature to resume exactly how we paused
         self._ensure_safe_extruder_temperature(self.paused_extruder_temp, wait=True)
         self.paused_extruder_temp = 0. # Reset so doesn't remain set when print is finished


### PR DESCRIPTION
Fix for issue #36 - When a manual pause is issued, we don't currently intercept the macro, and so do not set self.paused_extruder_temp - this causes the target_temp to be set to the default extruder temp when RESUME is called and intercepted by Happy Hare.

This ensures that no matter how the PAUSE macro is called, self.paused_extruder_temp will be set.