### PR TITLE
allow custom value of park_pos in tip_forming macro

### DIFF
--- a/config/base/mmu_software.cfg
+++ b/config/base/mmu_software.cfg
@@ -104,6 +104,13 @@ variable_final_eject: 0                # Default 0, enable during standalone tun
 # Park filament ready to eject
 variable_parking_distance: 0           # Final filament parking position after final cooling move, 0 will leave filament where it naturally ends up
 
+# The parking position 
+variable_output_park_pos: -1       # The parking position of the filament relative to the nozzle. This is an output variable decided by this macro. 
+                                   # A negative value means to use the default value
+                                   # The default tip forming procedure will automatically calculate the parking position based on the total moved distance of the extruder. 
+                                   # In some tip forming setups (e.g. filament cutter), the tip forming procedure can decide its own parking position. 
+                                   # To do that, set this variable to a positive value.
+
 gcode:
 # Initialize Paramaters
     {% set UNLOADING_SPEED_START = params.UNLOADING_SPEED_START|default(printer['gcode_macro _MMU_FORM_TIP_STANDALONE']['unloading_speed_start']) %}
@@ -211,6 +218,7 @@ gcode:
     G92 E0
     G90
 
+    {% set output_park_pos = -1 %} # use the default parking distance inference
 
 ###########################################################################
 # Callback macros for modifying Happy Hare behavour

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -3420,7 +3420,9 @@ class Mmu:
             self.toolhead.dwell(0.2)
             self.toolhead.wait_moves()
             delta = self._get_encoder_distance() - initial_encoder_position
-            park_pos = initial_extruder_position - self.mmu_extruder_stepper.stepper.get_commanded_position()
+            park_pos = self.printer.lookup_object("gcode_macro _MMU_FORM_TIP_STANDALONE").variables.get("output_park_pos", -1)
+            if park_pos < 0:
+                park_pos = initial_extruder_position - self.mmu_extruder_stepper.stepper.get_commanded_position()
             self._log_trace("After tip formation, extruder moved: %.2f, encoder moved %.2f" % (park_pos, delta))
             self._set_encoder_distance(initial_encoder_position + park_pos)
             self.filament_distance += park_pos


### PR DESCRIPTION
Allows tip forming macro to set a custom value of park_pos. This is useful for tip forming routines like filament cutters, where the park pos should be managed by the cut macro. 