### PR TITLE
potential fix to a bug where tip forming is skipped due to misplaced filament state after manual intervention

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -4417,7 +4417,7 @@ class Mmu:
 
         if self._is_mmu_paused():
             # Sanity check we are ready to go
-            if self._is_printing() and self.filament_pos != self.FILAMENT_POS_LOADED:
+            if self._is_in_print() and self.filament_pos != self.FILAMENT_POS_LOADED:
                 if self._check_sensor("toolhead") is True:
                     self._set_filament_pos_state(self.FILAMENT_POS_LOADED, silent=True)
                     self._log_always("Automatically set filament state to LOADED based on toolhead sensor")


### PR DESCRIPTION
The original condition is basically dead code that gets blocked by the outer `_is_mmu_paused`! 
If I understand correctly, `is_in_print` should be the correct condition and it was basically a typo? 

Either ways, I think this fixes a problem where during a MMU_PAUSE, I manually intervened but the MMU lost track of the filament state (since I extruded manually)