### PR TITLE
Add support for specifying the distance between the gate endstop and encoder

### DIFF
--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -108,6 +108,7 @@ gate_homing_max: 70			# Maximum move distance to home to the gate (actual move d
 gate_unload_buffer: 50			# Amount to reduce the fast unload so that filament doesn't overshoot when parking
 gate_load_retries: 2			# Number of times MMU will attempt to grab the filament on initial load (max 5)
 gate_parking_distance: {gate_parking_distance}		# Advanced: Specifies parking postion in the gate (distance from gate endstop/encoder)
+gate_endstop_to_encoder_distance: 0     # Advanced: If there's both a gate endstop and encoder, this specifies the distance between them (the endstop must be before the encoder)
 
 
 # Bowden tube loading/unloading --------------------------------------------------------------------------------------------


### PR DESCRIPTION
In my mission to make loading/unloading more reliable for my setup (see also #74), I realized that if both a gate endstop and encoder is defined, there seems to be an implicit assumption in the code that once the filament has reached the gate endstop, that it will engage with the encoder. 

This is usually not the case and I figured it would be helpful to make the distance between the encoder and gate endstop customizable.  This hopefully removes the error during for example bowden length calibration where the initial loading distance before the filament reaches the encoder seems to (wrongly) count towards the "slippage" of the filament.

This change is by no means complete; I might have missed places in the code and docs that need updating.  Feel free to leave comments and I will try to address them!