### PR TITLE
Fix string formatting in log

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -3060,7 +3060,7 @@ class Mmu:
                             self._log_info("Warning: Possible encoder malfunction (free-spinning) during final filament parking")
                         self._set_filament_pos_state(self.FILAMENT_POS_UNLOADED)
                         return
-                self._log_debug("Filament did not clear encoder even after moving %.1fmm" (self.encoder_move_step_size * max_steps))
+                self._log_debug("Filament did not clear encoder even after moving %.1fmm" % (self.encoder_move_step_size * max_steps))
         else:
             _,homed,_,_ = self._trace_filament_move("Reverse homing to gate sensor", -homing_max, motor="gear", homing_move=-1, endstop_name=self.ENDSTOP_GATE)
             if homed:


### PR DESCRIPTION
Ran into this as I'm doing test prints and trying to tweak some things.  If this log line is encountered as-is, klipper will crash with the following stack trace:

```
Traceback (most recent call last):
  File "/home/pi/klipper/klippy/gcode.py", line 211, in _process_commands
    handler(gcmd)
  File "/home/pi/klipper/klippy/extras/gcode_macro.py", line 189, in cmd
    self.template.run_gcode_from_command(kwparams)
  File "/home/pi/klipper/klippy/extras/gcode_macro.py", line 68, in run_gcode_from_command
    self.gcode.run_script_from_command(self.render(context))
  File "/home/pi/klipper/klippy/gcode.py", line 226, in run_script_from_command
    self._process_commands(script.split('\n'), need_ack=False)
  File "/home/pi/klipper/klippy/gcode.py", line 211, in _process_commands
    handler(gcmd)
  File "/home/pi/klipper/klippy/gcode.py", line 137, in <lambda>
    func = lambda params: origfunc(self._get_extended_params(params))
  File "/home/pi/klipper/klippy/extras/mmu.py", line 4522, in cmd_MMU_CHANGE_TOOL
    if self._change_tool(tool, self._is_printing(force_in_print), skip_tip):
  File "/home/pi/klipper/klippy/extras/mmu.py", line 4325, in _change_tool
    self._unload_tool(skip_tip=skip_tip)
  File "/home/pi/klipper/klippy/extras/mmu.py", line 4276, in _unload_tool
    self._unload_sequence(skip_tip=skip_tip)
  File "/home/pi/klipper/klippy/extras/mmu.py", line 3505, in _unload_sequence
    self._unload_gate()
  File "/home/pi/klipper/klippy/extras/mmu.py", line 3063, in _unload_gate
    self._log_debug("Filament did not clear encoder even after moving %.1fmm" (self.encoder_move_step_size * max_steps))
TypeError: 'str' object is not callable
```

This change should avoid the crash and allow Happy Hare to raise the MmuError