### PR TITLE
MMU gate endstop fixes

### DIFF
--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -155,7 +155,7 @@ bowden_pre_unload_error_tolerance: 50
 # Possible homing_endtop names:
 #   collision      - Detect the collision with the extruder gear by monitoring encoder movement
 #   mmu_gear_touch - Use touch (stallguard) detection when the gear stepper hits the extruder
-#   mmu_extruder   - If you have a "filament entry" endstop configured
+#   extruder       - If you have a "filament entry" endstop configured
 # Note the homing_endstop will be ignored if a toolhead sensor is available unless `extruder_force_homing: 1`
 #
 extruder_homing_max: 50			# Maximum distance to advance in order to attempt to home the extruder

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -140,8 +140,8 @@ class Mmu:
     ENDSTOP_EXTRUDER_TOUCH     = "mmu_ext_touch"
     ENDSTOP_GEAR_TOUCH         = "mmu_gear_touch"
     ENDSTOP_GATE               = "mmu_gate"
-    ENDSTOP_EXTRUDER           = "mmu_extruder"
-    ENDSTOP_TOOLHEAD           = "mmu_toolhead"
+    ENDSTOP_EXTRUDER           = "extruder"
+    ENDSTOP_TOOLHEAD           = "toolhead"
     ENDSTOP_SELECTOR_TOUCH     = "mmu_sel_touch"
     ENDSTOP_SELECTOR_HOME      = "mmu_sel_home"
 

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -667,11 +667,10 @@ class Mmu:
                 pin_params = ppins.parse_pin(sensor_pin, True, True)
                 share_name = "%s:%s" % (pin_params['chip_name'], pin_params['pin'])
                 ppins.allow_multi_use_pin(share_name)
-                mcu_endstop = self.gear_rail.add_extra_endstop(sensor_pin, ("mmu_%s" % name) if not name.startswith('mmu_') else name)
+                mcu_endstop = self.gear_rail.add_extra_endstop(sensor_pin, name)
  
                 # This ensures rapid stopping of extruder stepper when endstop is hit on synced homing
-                if name in ["toolhead", "gate", "extruder"]:
-                    mcu_endstop.add_stepper(self.mmu_extruder_stepper.stepper)
+                mcu_endstop.add_stepper(self.mmu_extruder_stepper.stepper)
 
         # Get servo and (optional) encoder setup -----
         self.servo = self.printer.lookup_object('mmu_servo mmu_servo', None)

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -371,7 +371,7 @@ class Mmu:
         self.default_gate_spool_id = list(config.getintlist('gate_spool_id', []))
 
         # Configuration for gate loading and unloading
-        self.gate_homing_endstop = config.get('gate_homing_endstop', self.ENDSTOP_ENCODER) # "encoder" or endstop name e.g. "mmu_gate"
+        self.gate_homing_endstop = config.get('gate_homing_endstop', self.ENDSTOP_ENCODER) # "encoder" or "mmu_gate"
         if self.gate_homing_endstop not in self.GATE_ENDSTOPS:
             raise self.config.error("gate_homing_endstop is invalid. Options are: %s" % self.GATE_ENDSTOPS)
         self.gate_endstop_to_encoder = config.getfloat('gate_endstop_to_encoder', self.gate_endstop_to_encoder, minval=0.)


### PR DESCRIPTION
Attempts to address MMU gate endstop naming inconsistencies by using shared variables/constants to hold the endstop names.

Fixes #114.