### PR TITLE
Fix springback calculations when using an extruder endstop

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -1756,7 +1756,10 @@ class Mmu:
                 measured_movement = self._get_encoder_distance(dwell=True) + self._get_encoder_dead_space()
                 spring = self._servo_up(measure=True)
                 reference = measured_movement - spring
-                if spring > 0:
+
+                # When homing using collision, we expect the filament to spring back.
+                # When homing to a "real" endstop, we don't expect any spring back to happen.
+                if not (self.extruder_homing_endstop == self.ENDSTOP_EXTRUDER_COLLISION and spring == 0):
                     msg = "Pass #%d: Filament homed to extruder, encoder measured %.1fmm, " % (i+1, measured_movement)
                     msg += "filament sprung back %.1fmm" % spring
                     msg += "\n- Bowden calibration based on this pass is %.1f" % reference


### PR DESCRIPTION
When homing to an extruder endstop, we don't expect any springback to happen, since the filament is just hanging out happily in its PTFE tube