### PR TITLE
Addresses issue where if your start_up macros changes extruder temp m…

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -2273,8 +2273,7 @@ class Mmu:
 
     def _mmu_pause(self, reason, force_in_print=False):
         run_pause_macro = False
-        if not self.paused_extruder_temp: # Only save the initial pause temp
-            self.paused_extruder_temp = self.printer.lookup_object(self.extruder_name).heater.target_temp
+        self.paused_extruder_temp = self.printer.lookup_object(self.extruder_name).heater.target_temp
         self.resume_to_state = "printing" if self._is_in_print() else "ready"
 
         if self._is_printing(force_in_print) and not self._is_mmu_paused():


### PR DESCRIPTION
Addresses issue where if your start_up macros changes extruder temp multiple times before printing; _mmu_pause saves the first target_temp, and ignores the others. This creates a problem for resume/unlock/pause where for e.g. the wrong extruder target_temp value is stored in "paused_extruder_temp" causing undesired behavior.

  -- I think anytime the _mmu_pause function is called, it should use the last/current extruder target_temp.