### PR TITLE
Provide sane defaults for mmu_vendor=Tradrack

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -303,7 +303,7 @@ class Mmu:
             self.cad_gate0_pos = 0.5
             self.cad_gate_width = 17.
             self.cad_bypass_offset = 0 # Doesn't have bypass
-            self.cad_last_gate_offset = 1. # TODO this is a guess
+            self.cad_last_gate_offset = 0. # This can vary a lot depending on the length of the rail
 
             self.gate_parking_distance = 17. # Using Gate switch (had user reports from 15 - 17.5)
             self.encoder_default_resolution = bmg_circ / (2 * 12) # If fitted, assumed to by Binky
@@ -314,7 +314,7 @@ class Mmu:
             #            would need to be set and `gate_parking_distance` set back to original
             if "e" in self.mmu_version_string:
                 self.gate_parking_distance = 39. # Assume using encoder if we have it
-                self.gate_endstop_to_encoder = 15. # TODO this is a guess
+                self.gate_endstop_to_encoder = 25.
 
         elif self.mmu_vendor.lower() == self.VENDOR_PRUSA.lower():
             raise self.config.error("Support for Prusa systems is comming soon! You can try with vendor=Other and configure `cad` dimensions (see doc)")


### PR DESCRIPTION
The 25mm endstop-to-encoder distance was determined empirically by homing to the gate endstop and advancing the filament 1mm at a time until the encoder detects movement.  This might not match the CAD 100% because of the different shapes of the detection mechanisms; the gate sensor uses a 4mm bearing ball and the encoder a BMG gear, so they might need different amounts of filament movement to trigger.

The last gate offset is likely typically 0 if you follow the official tradrack instructions, but might be higher if a longer rail is used.  For example, in my case I have a 600mm rail which supports 34 filament lanes, by using a MGN9H block and allowing the block to slide ~3mm off the rail (where the rubber lubrication block is, before the bearings in the block risk being lost).  The movable rail stopper can be used to position the rail block correctly. This means that there's really 0mm distance between the last gate and end-of-travel.