### PR TITLE
Rename MoveQueue to LookAheadQueue  to fix compatibility with latest Klipper

### DIFF
--- a/extras/mmu_toolhead.py
+++ b/extras/mmu_toolhead.py
@@ -31,7 +31,7 @@ class MmuToolHead(toolhead.ToolHead, object):
         self.all_mcus = [m for n, m in self.printer.lookup_objects(module='mcu')]
 
         self.mcu = self.all_mcus[0]
-        self.move_queue = toolhead.LookAheadQueue(self) # Happy Hare: Use base class MoveQueue
+        self.move_queue = toolhead.LookAheadQueue(self) # Happy Hare: Use base class LookAheadQueue
         self.move_queue.set_flush_time(toolhead.BUFFER_TIME_HIGH) # Happy Hare: Use base class
         self.commanded_pos = [0., 0., 0., 0.]
 

--- a/extras/mmu_toolhead.py
+++ b/extras/mmu_toolhead.py
@@ -31,8 +31,8 @@ class MmuToolHead(toolhead.ToolHead, object):
         self.all_mcus = [m for n, m in self.printer.lookup_objects(module='mcu')]
 
         self.mcu = self.all_mcus[0]
-        self.move_queue = toolhead.LookAheadQueue(self) # Happy Hare: Use base class LookAheadQueue
-        self.move_queue.set_flush_time(toolhead.BUFFER_TIME_HIGH) # Happy Hare: Use base class
+        self.lookahead = toolhead.LookAheadQueue(self) # Happy Hare: Use base class LookAheadQueue
+        self.lookahead.set_flush_time(toolhead.BUFFER_TIME_HIGH) # Happy Hare: Use base class
         self.commanded_pos = [0., 0., 0., 0.]
 
         self.gear_motion_queue = self.extruder_synced_to_gear = None # Happy Hare: For bi-directional syncing of gear and extruder

--- a/extras/mmu_toolhead.py
+++ b/extras/mmu_toolhead.py
@@ -31,7 +31,7 @@ class MmuToolHead(toolhead.ToolHead, object):
         self.all_mcus = [m for n, m in self.printer.lookup_objects(module='mcu')]
 
         self.mcu = self.all_mcus[0]
-        self.move_queue = toolhead.MoveQueue(self) # Happy Hare: Use base class MoveQueue
+        self.move_queue = toolhead.LookAheadQueue(self) # Happy Hare: Use base class MoveQueue
         self.move_queue.set_flush_time(toolhead.BUFFER_TIME_HIGH) # Happy Hare: Use base class
         self.commanded_pos = [0., 0., 0., 0.]
 


### PR DESCRIPTION
[this commit](https://github.com/Klipper3d/klipper/commit/6cc409f6fb9f62226c56adcf80be32a0d2601ab1) breaks Happy Hare. This pull request fixes it.