### PR TITLE
Fixes issue #184 - Filametrix cut with restore position tries to return to 0,0 usually destroying pin located near there.

### DIFF
--- a/config/base/mmu_cut_tip.cfg
+++ b/config/base/mmu_cut_tip.cfg
@@ -103,6 +103,7 @@ gcode:
 
     {% if ("xy" not in printer.toolhead.homed_axes) %}
         G28 X Y
+        SAVE_GCODE_STATE NAME=_MMU_CUT_TIP_state # Re-save the state otherwise 0,0 will be stored.  This will save the position after home (usually the z-pin)
     {% endif %}
 
     SET_PRESSURE_ADVANCE ADVANCE=0 # Temporarily disable pressure advance. Happy Hare will restore it


### PR DESCRIPTION
Adds a save state command.