### PR TITLE
Fix unable to resume after clog

### DIFF
--- a/config/optional/client_macros.cfg
+++ b/config/optional/client_macros.cfg
@@ -12,6 +12,7 @@ description: Pause the print and park
 gcode:
     {% if printer.pause_resume.is_paused %}
         RESPOND MSG="Print is already paused"
+        BASE_PAUSE
     {% else %}
         {% if printer.extruder.can_extrude %}
             G92 E0
@@ -30,8 +31,8 @@ gcode:
         RESPOND MSG="Print is not paused. Resume ignored"
     {% else %}
         _MMU_RESTORE_POSITION
-        BASE_RESUME
     {% endif %}
+    BASE_RESUME
 
 [gcode_macro CANCEL_PRINT]
 rename_existing: BASE_CANCEL_PRINT
@@ -43,4 +44,3 @@ gcode:
     TURN_OFF_HEATERS
     M107 ; Fan off
     BASE_CANCEL_PRINT
-


### PR DESCRIPTION
Calling through to base even if mmu state isn't paused.

The root issue is that fluidd supplies its own pause and resume macros.

Happy hare also provides pause and resume, but only calls through to the base resume in the case that the mmu internal state is paused.  This is insufficient for supporting the state also being maintained by fluidd.  This change ALWAYS calls through and allows the fluidd macro to update the UI and begin printing.