### PR TITLE
Fix typo preventing sync multipliers from updating

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -5381,8 +5381,8 @@ class Mmu:
         self.sync_form_tip = gcmd.get_int('SYNC_FORM_TIP', self.sync_form_tip, minval=0, maxval=1)
         self.sync_to_extruder = gcmd.get_int('SYNC_TO_EXTRUDER', self.sync_to_extruder, minval=0, maxval=1)
         self.sync_feedback_enable = gcmd.get_int('SYNC_FEEDBACK_ENABLE', self.sync_feedback_enable, minval=0, maxval=1)
-        self.sync_multiplier_high = gcmd.get_float('SYNC_MULTIPLER_HIGH', self.sync_multiplier_high, minval=1., maxval=2.)
-        self.sync_multiplier_low = gcmd.get_float('SYNC_MULTIPLER_LOW', self.sync_multiplier_low, minval=0.5, maxval=1.)
+        self.sync_multiplier_high = gcmd.get_float('SYNC_MULTIPLIER_HIGH', self.sync_multiplier_high, minval=1., maxval=2.)
+        self.sync_multiplier_low = gcmd.get_float('SYNC_MULTIPLIER_LOW', self.sync_multiplier_low, minval=0.5, maxval=1.)
 
         # TMC current control
         self.sync_gear_current = gcmd.get_int('SYNC_GEAR_CURRENT', self.sync_gear_current, minval=10, maxval=100)


### PR DESCRIPTION
Simple typo fix. Was having issues using the `MMU_TEST_CONFIG` command to update these two runtime values. Aaaand... then I found out why :D 