### PR TITLE
Add support for Repetier-Server install overrides

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1513,7 +1513,7 @@ usage() {
     echo "-i for interactive install"
     echo "-d for uninstall"
     echo "-z skip github check"
-    echo "-r specify Repetier-Server <stub> to override printer.cfg and klipper.service"
+    echo "-r specify Repetier-Server <stub> to override printer.cfg and klipper.service names"
     echo "(no flags for safe re-install / upgrade)"
     echo
     exit 1


### PR DESCRIPTION
Add new ``-r`` install.sh arg to allow ``printer.cfg`` and ``klipper.service`` references to be overridden when installing HH onto Repetier-Server.  

Repetier-Server supports multiple klipper instances and generates unique names for ``klipper.service`` and ``printer.cfg`` using a stub/instance reference. This allows users to specify the "stub" used to set this correctly.

For example - use ``-r LK5_Pro_ERCF`` to set klipper.service to ``klipper_LK5_Pro_ERCF.service`` & printer.cfg to ``LK5_Pro_ERCF.cfg``

``./install.sh -k /opt/klipper/LK5_Pro_ERCF -c /var/lib/Repetier-Server/database/klipper -m /opt/klipper/LK5_Pro_ERCF/moonraker -r LK5_Pro_ERCF -i``

Usage: ./install.sh [-k <klipper_home_dir>] [-c <klipper_config_dir>] [-m <moonraker_home_dir>] [-b <branch>] [-r \<Repetier-Server stub\>] [-i] [-d] [-z]

-i for interactive install
-d for uninstall
-z skip github check
-r specify Repetier-Server \<stub\> to override printer.cfg and klipper.service names
(no flags for safe re-install / upgrade)

Resolves #204