### PR TITLE
Update blobifier.cfg

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -38,13 +38,13 @@
 ##########################################################################################
 # The servo hardware configuration. Change the values to your needs.
 # 
-[servo blobifier]
+[mmu_servo blobifier]
 # Pin for the servo.
 pin: PG14
-# Adjust this value until a 'BLOBIFIER_SERVO POS=in' retracts the tray fully without a 
+# Adjust this value until a 'BLOBIFIER_SERVO POS=out' extends the tray fully without a 
 # buzzing sound
 minimum_pulse_width: 0.00053
-# Adjust this value until a 'BLOBIFIER_SERVO POS=out' extends the tray fully without a 
+# Adjust this value until a 'BLOBIFIER_SERVO POS=in' retracts the tray fully without a 
 # buzzing sound
 maximum_pulse_width: 0.0023
 # Leave this value at 180


### PR DESCRIPTION
Replaced servo with mmu_servo to resolve multiple issues encountered with Klipper's default servo library, particularly the WIDTH=0 issue, which was causing unexpected servo movements. 

Additionally, corrected an inaccurate comment regarding minimum_pulse_width; it actually controls the servo's outward position, contrary to the previous assertion. The comment has been updated to reflect its true function.