### PR TITLE
Add ability to specify alternative service name from kiauh install

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ Note that the installer will look for Klipper install and config in standard loc
 ```
 ./install.sh -k /opt/klipper/LK5_Pro_ERCF -c /var/lib/Repetier-Server/database/klipper -m /opt/klipper/LK5_Pro_ERCF/moonraker -r LK5_Pro_ERCF -i
 ```
+
+If you have multiple Klipper instances installed with for example Kiauh. You can use the `-a` flag to specify the service name. E.g.
+```
+./install-sh -a klipper-two -k <klipper_home_dir> -c <klipper_config_dir>
+```
+
 <br>
 
 > [!IMPORTANT]  

--- a/install.sh
+++ b/install.sh
@@ -1682,8 +1682,9 @@ questionaire() {
 
 usage() {
     echo -e "${EMPHASIZE}"
-    echo "Usage: $0 [-k <klipper_home_dir>] [-c <klipper_config_dir>] [-m <moonraker_home_dir>] [-b <branch>] [-r <Repetier-Server stub>] [-i] [-d] [-z]"
+    echo "Usage: $0 [-a <kiauh-alternate-klipper>] [-k <klipper_home_dir>] [-c <klipper_config_dir>] [-m <moonraker_home_dir>] [-b <branch>] [-r <Repetier-Server stub>] [-i] [-d] [-z]"
     echo
+    echo "-a to specify alternative klipper-service-name when installed with Kiauh."
     echo "-i for interactive install"
     echo "-d for uninstall"
     echo "-b to switch to specified feature branch (sticky)"
@@ -1707,8 +1708,9 @@ INSTALL_KLIPPER_SCREEN_ONLY=0
 PRINTER_CONFIG=printer.cfg
 KLIPPER_SERVICE=klipper.service
 
-while getopts "b:k:c:m:r:idsz" arg; do
+while getopts "a:b:k:c:m:r:idsz" arg; do
     case $arg in
+        a) KLIPPER_SERVICE=${OPTARG}.service;;
         b) N_BRANCH=${OPTARG};;
         k) KLIPPER_HOME=${OPTARG};;
         m) MOONRAKER_HOME=${OPTARG};;


### PR DESCRIPTION
There was a request from an user on Discord to be able to specify an alternative service name for klipper only:

https://discord.com/channels/460117602945990666/909743915475816458/1216405832456212652

While this is somewhat accomplished with the `-r` flag, this depends on the Repetier-Server. 

This added functionality allows setting the `${KLIPPER_SERVICE}` variable to a specific name. This would commonly be used if a user installed multiple klipper services with the commonly used `kiauh` utility.