### PR TITLE
Advance to next gcode position (impovement over not restoring xy)

### DIFF
--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -192,10 +192,10 @@ def copy_next_position_to_toolhange_param(file_path, tmp_file):
     with open(file_path, 'r') as in_file:
         in_content = in_file.read()
         # Look for tool changes (Tx) and the next move command (G0/1) and fetch the XYZ locations. Then place a new command
-        # above the toolchange (_MMU_POS_AFTER_NEXT_TOOLCHANGE POS="xx.xx,yy.yy,zz.zz")
+        # above the toolchange (MMU_CHANGE_TOOL TOOL=x NEXT_POS="xx.xx,yy.yy")
         out_content = re.sub(
-            r'(?P<tool>^T\d{1,3})(?P<other>[\s\S]+?)(?P<cmd>G[01](?:\s+X(?P<X>[\d.]*)|\s+Y(?P<Y>[\d.]*)|\s+Z(?P<Z>[\d.]*))+.*)', 
-            r'_MMU_POS_AFTER_NEXT_TOOLCHANGE POS="\g<X>,\g<Y>,\g<Z>"\n\g<tool>\g<other>\g<cmd>', 
+            r'^T(?P<tool>\d{1,3})(?P<other>[\s\S]+?)(?P<cmd>G[01](?:\s+X(?P<X>[\d.]*)|\s+Y(?P<Y>[\d.]*)|\s+F(?P<F>[\d]*))+.*)', 
+            r'MMU_CHANGE_TOOL TOOL=\g<tool> NEXT_POS="\g<X>,\g<Y>" ; T\g<tool>\n\g<other>\g<cmd>', 
             in_content, 
             flags=re.MULTILINE
         )

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -432,7 +432,7 @@ gcode:
         BLOBIFIER_SERVO POS=in
         # Move the toolhead down to purge_start height lowering the blob below the tray
         G90 # absolute positioning
-        G1 Z{tray_top}
+        G1 Z{tray_top} F{travel_spd_z}
         # Extend the tray to 'cut off' the blob and prepare for the next blob
         BLOBIFIER_SERVO POS=out
         BLOBIFIER_SERVO POS=in
@@ -442,6 +442,7 @@ gcode:
       {% endif %}
     {% endfor %}
   {% endif %}
+  G1 Z{tray_top + 1} F{travel_spd_z}
   G4 P{pressure_release_time}
   BLOBIFIER_CLEAN
 

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -701,8 +701,8 @@ gcode:
   {% endif %}  
 
   {% if printer.mmu %}
-    {% if printer['gcode_macro _MMU_SEQUENCE_VARS'].restore_xy_pos %}
-      {action_respond_info("BLOBIFIER: If not using a wipe tower, consider disabling restore_xy_pos in mmu_macro_vars.cfg")}
+    {% if printer['gcode_macro _MMU_SEQUENCE_VARS'].restore_xy_pos != 'next' %}
+      {action_respond_info("BLOBIFIER: If not using a wipe tower, consider setting restore_xy_pos: 'next' in mmu_macro_vars.cfg")}
     {% endif %}
 
     # Blobifier park enabled

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -290,9 +290,8 @@ gcode:
   {% if params.PURGE_LENGTH %} # ======= PARAM PURGE LENGTH ==============================
     {action_respond_info("BLOBIFIER: param PURGE_LENGTH provided")}
     {% set purge_len = params.PURGE_LENGTH|float %}
-  {% elif from_tool == to_tool %} # ==== TOOL DIDN'T CHANGE ==============================
-    {action_respond_info("BLOBIFIER: Tool didn't change (T%s > T%s), " ~ 
-      "priming" if purge_length_minimum else "skipping"  % (from_tool, to_tool))}
+  {% elif from_tool == to_tool and to_tool >= 0 %} # ==== TOOL DIDN'T CHANGE =============
+    {action_respond_info("BLOBIFIER: Tool didn't change (T%s > T%s), %s" % (from_tool, to_tool, "priming" if purge_length_minimum else "skipping"))}
     {% set purge_len = 0 %}
   {% elif pv %} # ====================== FECTH FROM SLICER ===============================
     {% if from_tool < 0 and to_tool >= 0%}

--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -98,8 +98,7 @@ gcode: # Leave empty
 variable_enable_park            : True		; True = Enable parking move when printing (not runout), False = disable
 variable_enable_park_runout     : True		; True = Enable parking move during runout handling, False = disable
 variable_enable_park_standalone : True		; True = Enable parking move when not printing, False = disable
-variable_advance_xy_pos         : True		; True = Advance toolhead x,y position to the next location in the file, False = Let restore_xy_pos handle the logic
-variable_restore_xy_pos         : True		; True = Restore toolhead x,y position, False = Let slicer perform travel move. Ignored if advance_xy_pos = True
+variable_restore_xy_pos         : 'last'    ; [last|next|none] What x,y position the toolhead should travel to after a toolchange
 variable_park_xy                : 50, 50	; Coordinates of park position for toolchange
 variable_park_z_hop             : 1.0		; Additional Z_hop (mm) when toolchanging (works in and out of print)
 variable_travel_speed           : 200		; XY travel speed in mm/s

--- a/config/base/mmu_sequence.cfg
+++ b/config/base/mmu_sequence.cfg
@@ -125,18 +125,17 @@ gcode:
     {% set nx,ny = park_vars.next_xy|map('float') %}
     {% set travel_speed = vars.travel_speed|default(200)|float * 60 %}
     {% set lift_speed = vars.lift_speed|default(15)|float * 60 %}
-    {% set advance_xy_pos = vars.advance_xy_pos|default(true)|lower == 'true' %}
-    {% set restore_xy_pos = vars.restore_xy_pos|default(true)|lower == 'true' %}
+    {% set restore_xy_pos = vars.restore_xy_pos|default('last') %}
     {% set printing = printer.mmu.print_state == 'printing' %}
 
     G90 #Absolute
-    {% if advance_xy_pos and park_vars.next_pos %}
+    {% if restore_xy_pos == 'next' and park_vars.next_pos %}
         G1 X{nx} Y{ny} F{travel_speed}	# Restore X,Y position
         {% if 'z' in printer.toolhead.homed_axes %}
             G1 Z{z} F{lift_speed}		# Restore Z position as last step
         {% endif %}
     {% elif park_vars.saved_pos %}
-        {% if restore_xy_pos or not printing %}	# Are we or slicer restoring position
+        {% if restore_xy_pos == 'last' or not printing %}	# Are we or slicer restoring position
             G1 X{x} Y{y} F{travel_speed}	# Restore X,Y position
         {% endif %}
         {% if 'z' in printer.toolhead.homed_axes %}

--- a/config/base/mmu_sequence.cfg
+++ b/config/base/mmu_sequence.cfg
@@ -122,8 +122,7 @@ gcode:
     {% set vars = printer['gcode_macro _MMU_SEQUENCE_VARS'] %}
     {% set park_vars = printer['gcode_macro _MMU_PARK'] %}
     {% set x,y,z = park_vars.saved_xyz|map('float') %}
-    {% set nx,ny,nz = park_vars.next_xyz|map('float') %}
-    {% set nz = nz if nz >= 0 else z %}
+    {% set nx,ny = park_vars.next_xyz|map('float') %}
     {% set travel_speed = vars.travel_speed|default(200)|float * 60 %}
     {% set lift_speed = vars.lift_speed|default(15)|float * 60 %}
     {% set advance_xy_pos = vars.advance_xy_pos|default(true)|lower == 'true' %}
@@ -134,7 +133,7 @@ gcode:
     {% if advance_xy_pos and park_vars.next_pos %}
         G1 X{nx} Y{ny} F{travel_speed}	# Restore X,Y position
         {% if 'z' in printer.toolhead.homed_axes %}
-            G1 Z{nz} F{lift_speed}		# Restore Z position as last step
+            G1 Z{z} F{lift_speed}		# Restore Z position as last step
         {% endif %}
     {% elif park_vars.saved_pos %}
         {% if restore_xy_pos or not printing %}	# Are we or slicer restoring position

--- a/config/base/mmu_sequence.cfg
+++ b/config/base/mmu_sequence.cfg
@@ -56,7 +56,7 @@ description: Park toolhead safely away from print
 # -------------------------- Internal Don't Touch -------------------------
 variable_saved_xyz: 0, 0, 0
 variable_saved_pos: False
-variable_next_xyz: 0, 0, 0
+variable_next_xy: 0, 0
 variable_next_pos: False
 variable_initial_park_z: 9999
 
@@ -122,7 +122,7 @@ gcode:
     {% set vars = printer['gcode_macro _MMU_SEQUENCE_VARS'] %}
     {% set park_vars = printer['gcode_macro _MMU_PARK'] %}
     {% set x,y,z = park_vars.saved_xyz|map('float') %}
-    {% set nx,ny = park_vars.next_xyz|map('float') %}
+    {% set nx,ny = park_vars.next_xy|map('float') %}
     {% set travel_speed = vars.travel_speed|default(200)|float * 60 %}
     {% set lift_speed = vars.lift_speed|default(15)|float * 60 %}
     {% set advance_xy_pos = vars.advance_xy_pos|default(true)|lower == 'true' %}

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -678,6 +678,8 @@ class Mmu:
         self.gcode.register_command('MMU_TOOL_OVERRIDES', self.cmd_MMU_TOOL_OVERRIDES, desc = self.cmd_MMU_TOOL_OVERRIDES_help)
         self.gcode.register_command('MMU_SLICER_TOOL_MAP', self.cmd_MMU_SLICER_TOOL_MAP, desc = self.cmd_MMU_SLICER_TOOL_MAP_help)
 
+        self.gcode.register_command('_MMU_POS_AFTER_NEXT_TOOLCHANGE', self.cmd_MMU_POS_AFTER_NEXT_TOOLCHANGE, desc = self.cmd_MMU_POS_AFTER_NEXT_TOOLCHANGE_help)
+
         # For use in user controlled load and unload macros
         self.gcode.register_command('_MMU_STEP_LOAD_GATE', self.cmd_MMU_STEP_LOAD_GATE, desc = self.cmd_MMU_STEP_LOAD_GATE_help)
         self.gcode.register_command('_MMU_STEP_UNLOAD_GATE', self.cmd_MMU_STEP_UNLOAD_GATE, desc = self.cmd_MMU_STEP_UNLOAD_GATE_help)
@@ -5075,7 +5077,7 @@ class Mmu:
         self._wrap_track_time('post_unload', self._wrap_gcode_command(self.post_unload_macro, exception=True))
 
     # This is the main function for initiating a tool change, it will handle unload if necessary
-    def _change_tool(self, tool, skip_tip=True, next_pos=''):
+    def _change_tool(self, tool, skip_tip=True):
         self._log_debug("Tool change initiated %s" % ("with slicer tip forming" if skip_tip else "with standalone MMU tip forming"))
         self._track_time_start('total')
         skip_unload = False
@@ -5116,17 +5118,6 @@ class Mmu:
 
         if not skip_unload:
             self._unload_tool(skip_tip=skip_tip)
-
-        # Save the next position for the _MMU_RESTORE_POSITION to pick them up
-        if next_pos:
-            match = re.match(r"G[01](?:\s+X(?P<x>[\d.]*)|\s+Y(?P<y>[\d.]*)|\s+Z(?P<z>[\d.]*))+", next_pos)
-            pos = match.groupdict()
-            if pos['x'] and pos['y']:
-                self._wrap_gcode_command(f"SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=next_xyz VALUE=\"{pos['x']}, {pos['y']}, {pos['z'] or -1}\"")
-                self._wrap_gcode_command(f"SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=next_pos VALUE={True}")
-            else:
-                self._wrap_gcode_command(f"SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=next_pos VALUE={False}")
-
 
         self._select_and_load_tool(tool)
         self._track_swap_completed()
@@ -5321,14 +5312,13 @@ class Mmu:
         quiet = gcmd.get_int('QUIET', 0, minval=0, maxval=1)
         standalone = bool(gcmd.get_int('STANDALONE', 0, minval=0, maxval=1))
         cmd = gcmd.get_command().strip()
-        match = re.match(r'[Tt](\d{1,3}).*$', cmd)
+        match = re.match(r'[Tt](\d{1,3})$', cmd)
         if match:
             tool = int(match.group(1))
             if tool < 0 or tool > self.mmu_num_gates - 1:
                 raise gcmd.error("Invalid tool")
         else:
             tool = gcmd.get_int('TOOL', minval=0, maxval=self.mmu_num_gates - 1)
-        next_pos = gcmd.get('NEXT', '')
         skip_tip = self._is_printing() and not (standalone or self.force_form_tip_standalone)
         if self.filament_pos == self.FILAMENT_POS_UNKNOWN and self.is_homed: # Will be done later if not homed
             self._recover_filament_pos(message=True)
@@ -5344,7 +5334,7 @@ class Mmu:
             try:
                 for i in range(attempts):
                     try:
-                        if self._change_tool(tool, skip_tip, next_pos):
+                        if self._change_tool(tool, skip_tip):
                             self._dump_statistics(job=not quiet, gate=not quiet)
                         continue
                     except MmuError as ee:
@@ -6445,6 +6435,18 @@ class Mmu:
             elif have_purge_map:
                 msg += "\nDETAIL=1 to see purge volumes"
             self._log_always(msg)
+
+    cmd_MMU_POS_AFTER_NEXT_TOOLCHANGE_help = "Set the next location after the next toolchange. The toolhead can then travel to that location instead of the old one"
+    def cmd_MMU_POS_AFTER_NEXT_TOOLCHANGE(self, gcmd):
+        pos = gcmd.get('POS', '').split(',')
+        if pos[0] and pos[1]:
+            x = pos[0]
+            y = pos[1]
+            z = pos[2] or -1
+            self._wrap_gcode_command(f"SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=next_xyz VALUE=\"{x}, {y}, {z}\"")
+            self._wrap_gcode_command(f"SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=next_pos VALUE={True}")
+        else:
+            self._wrap_gcode_command(f"SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=next_pos VALUE={False}")
 
     # TODO default to current gate; MMU_CHECK_GATES default to all gates. Add ALL=1 flag
     cmd_MMU_CHECK_GATE_help = "Automatically inspects gate(s), parks filament and marks availability"

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -6443,7 +6443,7 @@ class Mmu:
         if pos[0] and pos[1]:
             x = pos[0]
             y = pos[1]
-            self._wrap_gcode_command(f"SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=next_xyz VALUE=\"{x}, {y}\"")
+            self._wrap_gcode_command(f"SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=next_xy VALUE=\"{x}, {y}\"")
             self._wrap_gcode_command(f"SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=next_pos VALUE={True}")
         else:
             self._wrap_gcode_command(f"SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=next_pos VALUE={False}")

--- a/install.sh
+++ b/install.sh
@@ -976,7 +976,7 @@ copy_config_files() {
             for (( i=0; i<=$(expr $mmu_num_gates - 1); i++ ))
             do
                 tx_macros+="[gcode_macro T${i}]\n"
-                tx_macros+="gcode: MMU_CHANGE_TOOL TOOL=${i} {rawparams}\n"
+                tx_macros+="gcode: MMU_CHANGE_TOOL TOOL=${i}\n"
             done
 
             if [ "${INSTALL}" -eq 1 ]; then


### PR DESCRIPTION
When not restoring x and y, z gets dropped before returning to the print, which causes tiny oozes to contaminate the print walls.

advance_xy_pos causes the toolhead to return to the print and then dropping to the correct z height.

To achieve this, the next G1/0 gcode command is passed as a parameter on the toolchange. This requires file preprocessing. I haven't been able to make that step optional. Don't know if that is necessary though. 