### PR TITLE
Update blobifier_hw.cfg

### DIFF
--- a/config/addons/blobifier_hw.cfg
+++ b/config/addons/blobifier_hw.cfg
@@ -2,13 +2,13 @@
 ##########################################################################################
 # The servo hardware configuration. Change the values to your needs.
 # 
-[servo blobifier]
+[mmu_servo blobifier]
 # Pin for the servo.
 pin: PG14
-# Adjust this value until a 'BLOBIFIER_SERVO POS=in' retracts the tray fully without a 
+# Adjust this value until a 'BLOBIFIER_SERVO POS=out' extends the tray fully without a 
 # buzzing sound
 minimum_pulse_width: 0.00053
-# Adjust this value until a 'BLOBIFIER_SERVO POS=out' extends the tray fully without a 
+# Adjust this value until a 'BLOBIFIER_SERVO POS=in' retracts the tray fully without a 
 # buzzing sound
 maximum_pulse_width: 0.0023
 # Leave this value at 180


### PR DESCRIPTION
These changes were approved and merged before but it seems like these were accidentally reverted when hardware config was separated from the main blobifier file. A short summary of changes.

1. replace servo with mmu_servo
2. minimum_pulse_width actually controls the width for open position so comments are swapped to correct that.