### PR TITLE
Fix endless spool resume

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -6047,6 +6047,8 @@ class Mmu:
         self._check_runout() # Can throw MmuError
         #self._wrap_gcode_command("RESUME", exception=True)
         self._continue_printing("endless_spool") # Continue printing...
+        self._movequeues_wait_moves(toolhead=True, mmu_toolhead=True)
+        self.pause_resume.send_resume_command()
 
     def _get_next_endless_spool_gate(self, tool, gate):
         group = self.endless_spool_groups[gate]

--- a/extras/mmu_encoder.py
+++ b/extras/mmu_encoder.py
@@ -206,7 +206,7 @@ class MmuEncoder:
         pause_resume = self.printer.lookup_object('pause_resume')
         pause_resume.send_pause_command()
         self.printer.get_reactor().pause(eventtime + self.pause_delay)
-        self._exec_gcode(self.runout_gcode + "\n_MMU_M400")
+        self._exec_gcode(self.runout_gcode)
 
     def _insert_event_handler(self, eventtime):
         self._exec_gcode(self.insert_gcode)

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -71,7 +71,7 @@ class MmuRunoutHelper:
         pause_resume = self.printer.lookup_object('pause_resume')
         pause_resume.send_pause_command()
         self.printer.get_reactor().pause(eventtime + self.pause_delay)
-        self._exec_gcode(self.runout_gcode + " DO_RUNOUT=1\n_MMU_M400")
+        self._exec_gcode(self.runout_gcode + " DO_RUNOUT=1")
 
     def _exec_gcode(self, command):
         try:
@@ -251,4 +251,3 @@ class MmuSensors:
 
 def load_config(config):
     return MmuSensors(config)
-


### PR DESCRIPTION
Basically fixes https://github.com/moggieuk/Happy-Hare/issues/246, in essence `pause_resume.pause` was triggered in sensors or encoder, but there was no resume. 

Also removed `_M400` call and replaced with direct `_movequeues_wait_moves`, otherwise it could be called after resume, which is not okay I guess :)