### PR TITLE
Automatic pull-back of filament after loading long bowden cables

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -4062,6 +4062,15 @@ class Mmu:
             self._set_filament_pos_state(self.FILAMENT_POS_LOADED)
             self._log_debug("Filament should loaded to nozzle")
 
+            # Roll back up to N mm using low torque to pull the filament tight in long bowden tubes with extra space
+            self._log_info("Filament pull after load using low torque")
+            self._adjust_gear_current(percent=30, reason="Pull filament tight")
+            self._set_filament_direction(self.DIRECTION_UNLOAD)
+            
+            _,_,measured,delta = self._trace_filament_move("Loading filament to nozzle", -25, speed=speed, motor="gear", wait=True)
+            self._log_info("Filament pull: rolled back %0.0f mm" % measured) 
+
+
     # Extract filament past extruder gear (to end of bowden). Assume that tip has already been formed
     # and we are parked somewhere in the extruder either by slicer or by stand alone tip creation
     # But be careful:


### PR DESCRIPTION
My Voron is using a long bowden cable, which is also extra wide as 2mm resulted in high friction loads and unloads.

The result is that after a tool swap, the filament was pushed into the extruder head and is slack, resulting in the clog detection triggering right after.

This is not a complete pull request as the amount of rollback and torque should probably be adjustable from the configuration files. Also, I still have trouble getting reliable swaps, with or without this change - so either I am missing something or I need to configure my printer better.

Anyway, comments welcome.

**What does this do?**
At each tool load, the filament is pushed down the tube, picked up by the extruder and then put into the parking position inside the extruder (both the ERCF feeder motor and extruder motor run in parallel for this).
This new code then reverses the feeder motor on the ERCF (after reducing the pulling torque) to pull the filament tight from the ERCF side before disengaging the servo (letting go of the filament).

At this point, the filament should be tight and as soon as the extuder pulls it in further, the encoder wheel should move, thereby accurately showing that the filament is indeed loaded and fed through.

