### PR TITLE
Added functionality to include `toolhead_ooze_reduction` into tip forming macro

### DIFF
--- a/config/base/mmu_cut_tip.cfg
+++ b/config/base/mmu_cut_tip.cfg
@@ -46,6 +46,9 @@ gcode:
     {% set pin_park_x_loc = pin_loc_x + pin_park_x_dist %}
     {% set pin_park_y_loc = pin_loc_y %}
 
+    #Grab toolhead_ooze_reduction from mmu_parameters.cfg
+    {% set toolhead_ooze_reduction = printer['mmu_parameters']['toolhead_ooze_reduction']|float %}
+
     # Useful state for customizing operations depending on mode
     {% set runout = printer.mmu.runout %}
     {% set printing = printer.mmu.print_state == 'printing' %}
@@ -62,10 +65,10 @@ gcode:
     G92 E0
     {% if retract_length > 0 %}
         # Retract to save filament waste, repeat to allow some cooling
-        G1 E-{retract_length} F{extruder_move_speed * 60}
+        G1 E-{retract_length - toolhead_ooze_reduction} F{extruder_move_speed * 60}
         {% if simple_tip_forming %}
-            G1 E{retract_length / 2} F{extruder_move_speed * 60}
-            G1 E-{retract_length / 2} F{extruder_move_speed * 60}
+            G1 E{(retract_length - toolhead_ooze_reduction) / 2} F{extruder_move_speed * 60}
+            G1 E-{(retract_length - toolhead_ooze_reduction) / 2} F{extruder_move_speed * 60}
         {% endif %}
     {% endif %}
 

--- a/config/base/mmu_form_tip.cfg
+++ b/config/base/mmu_form_tip.cfg
@@ -33,7 +33,6 @@ gcode:
     {% set ramming_volume_standalone = vars['ramming_volume']|float %}
     {% set cooling_tube_length = vars['cooling_tube_length']|float %}
     {% set cooling_tube_position = vars['cooling_tube_position']|float %}
-    {% set toolhead_ooze_reduction = vars['toolhead_ooze_reduction']|float %}
     {% set initial_cooling_speed = vars['initial_cooling_speed'] %}
     {% set final_cooling_speed = vars['final_cooling_speed'] %}
     {% set cooling_moves = vars['cooling_moves']|int %}
@@ -49,6 +48,9 @@ gcode:
     {% set parking_distance = vars['parking_distance']|default(0)|float %}
     {% set orig_temp = printer.extruder.target %}
     {% set next_temp = params.NEXT_TEMP|default(orig_temp)|int %}
+
+    #Grab toolhead_ooze_reduction from mmu_parameters.cfg
+    {% set toolhead_ooze_reduction = printer['mmu_parameters']['toolhead_ooze_reduction']|float %}
 
     # Useful state for customizing operations depending on mode
     {% set runout = printer.mmu.runout %}

--- a/config/base/mmu_form_tip.cfg
+++ b/config/base/mmu_form_tip.cfg
@@ -85,7 +85,7 @@ gcode:
 
     # Step 2 - Retraction / Nozzle Separation
     # This is where the tip spear shape comes from. Faster=longer/pointer/higher stringing
-    {% set total_retraction_distance = (cooling_tube_position - toolhead_ooze_reduction) + cooling_tube_length / 2 - 15 %}
+    {% set total_retraction_distance = (cooling_tube_position - toolhead_ooze_reduction) + cooling_tube_length - 15 %}
     G1 E-15 F{1.0 * unloading_speed_start * 60} # Fixed default value from SS
     G1 E-{0.7 * total_retraction_distance} F{1.0 * unloading_speed * 60}
     G1 E-{0.2 * total_retraction_distance} F{0.5 * unloading_speed * 60}

--- a/config/base/mmu_form_tip.cfg
+++ b/config/base/mmu_form_tip.cfg
@@ -33,6 +33,7 @@ gcode:
     {% set ramming_volume_standalone = vars['ramming_volume']|float %}
     {% set cooling_tube_length = vars['cooling_tube_length']|float %}
     {% set cooling_tube_position = vars['cooling_tube_position']|float %}
+    {% set toolhead_ooze_reduction = vars['toolhead_ooze_reduction']|float %}
     {% set initial_cooling_speed = vars['initial_cooling_speed'] %}
     {% set final_cooling_speed = vars['final_cooling_speed'] %}
     {% set cooling_moves = vars['cooling_moves']|int %}
@@ -84,7 +85,7 @@ gcode:
 
     # Step 2 - Retraction / Nozzle Separation
     # This is where the tip spear shape comes from. Faster=longer/pointer/higher stringing
-    {% set total_retraction_distance = cooling_tube_position + cooling_tube_length / 2 - 15 %}
+    {% set total_retraction_distance = (cooling_tube_position - toolhead_ooze_reduction) + cooling_tube_length / 2 - 15 %}
     G1 E-15 F{1.0 * unloading_speed_start * 60} # Fixed default value from SS
     G1 E-{0.7 * total_retraction_distance} F{1.0 * unloading_speed * 60}
     G1 E-{0.2 * total_retraction_distance} F{0.5 * unloading_speed * 60}

--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -241,6 +241,7 @@ variable_cooling_tube_length    : 10		; Movement length. DragonST:15, DragonHF:1
 variable_initial_cooling_speed  : 10		; Inital slow movement (mm/s) to solidify tip and cool string if formed
 variable_final_cooling_speed    : 50		; Fast movement (mm/s) Too fast: tip deformation on eject, Too Slow: long string/no seperation
 variable_cooling_moves          : 4		; Number of back and forth cooling moves to make (2-4 is a good start)
+variable_toolhead_ooze_reduction : 25
 
 # Step 4 - Skinnydip
 # Skinnydip is an advanced final move that may have benefit with some

--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -241,7 +241,6 @@ variable_cooling_tube_length    : 10		; Movement length. DragonST:15, DragonHF:1
 variable_initial_cooling_speed  : 10		; Inital slow movement (mm/s) to solidify tip and cool string if formed
 variable_final_cooling_speed    : 50		; Fast movement (mm/s) Too fast: tip deformation on eject, Too Slow: long string/no seperation
 variable_cooling_moves          : 4		; Number of back and forth cooling moves to make (2-4 is a good start)
-variable_toolhead_ooze_reduction : 25
 
 # Step 4 - Skinnydip
 # Skinnydip is an advanced final move that may have benefit with some


### PR DESCRIPTION
I still need to pass the `toolhead_ooze_reduction` value through from the `mmu_parameters.cfg` file but this is a start/ proof of concept adding the variable to the `mmu_macro_vars.cfg` file.

NEED TO UPDATE