### PR TITLE
Fix load initial tool in case of using bypass

### DIFF
--- a/config/base/mmu_software.cfg
+++ b/config/base/mmu_software.cfg
@@ -206,7 +206,7 @@ gcode:
         {% set slicer_tool_map = printer.mmu.slicer_tool_map %}
         {% set initial_tool = slicer_tool_map.initial_tool %}
         {% set tools = slicer_tool_map.referenced_tools %}
-        {% if not using_bypass or tools|length >= 1 %}
+        {% if not using_bypass and tools|length > 0 %}
             {% if load_initial_tool and (initial_tool is not none and initial_tool >= 0) %}
                 RESPOND MSG="Loading initial tool T{initial_tool}..."
                 MMU_CHANGE_TOOL STANDALONE=1 TOOL={initial_tool}


### PR DESCRIPTION
Related to #272. MMU shouldn't try to load initial tool in case of using bypass.