### PR TITLE
Mmu server standalone

### DIFF
--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -161,7 +161,7 @@ class MmuServer:
         Initialize mmu gate map if not already done
 
         returns:
-            @return: True if initialized, False otherwise
+            @return: True once initialized
         '''
         if not hasattr(self, 'mmu_backend_present'):
             await self._init_mmu_backend()

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -385,8 +385,7 @@ class MmuServer:
         Rebuilds the local cache of essential spool information
         '''
         async with self.cache_lock:
-            if not await self._initialize_mmu():
-                return False
+            await self._initialize_mmu()
             return await self._build_spool_location_cache(fix=fix, silent=silent)
 
     async def get_filaments(self, gate_ids, silent=False) -> bool:
@@ -404,8 +403,7 @@ class MmuServer:
         Then updates Happy Hare with filament attributes
         '''
         async with self.cache_lock:
-            if not await self._initialize_mmu():
-                return False
+            await self._initialize_mmu()
 
             if not gate_ids:
                 logging.error("Gate spool id mapping not provided or empty")
@@ -466,8 +464,7 @@ class MmuServer:
         Pass back to Happy Hare
         '''
         async with self.cache_lock:
-            if not await self._initialize_mmu():
-                return False
+            await self._initialize_mmu()
 
             gate_ids = [(gate, self._find_first_spool_id(self.printer_hostname, gate)) for gate in range(self.nb_gates)]
             return await self._send_gate_map_update(gate_ids, replace=True, silent=silent)
@@ -477,8 +474,7 @@ class MmuServer:
         Clears all gates for the printer
         '''
         async with self.cache_lock:
-            if not await self._initialize_mmu():
-                return False
+            await self._initialize_mmu()
 
             printer_name = printer or self.printer_hostname
             if not silent:
@@ -518,8 +514,7 @@ class MmuServer:
         Removes the printer + gate allocation in spoolman db for gate (if supplied)
         '''
         async with self.cache_lock:
-            if not await self._initialize_mmu():
-                return False
+            await self._initialize_mmu()
 
             # Sanity checking...
             if gate is not None and gate < 0:
@@ -580,8 +575,7 @@ class MmuServer:
         Removes the printer + gate allocation in spoolman db for gate or spool_id (if supplied)
         '''
         async with self.cache_lock:
-            if not await self._initialize_mmu():
-                return False
+            await self._initialize_mmu()
 
             # Sanity checking...
             if spool_id is None and gate is None:

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -278,7 +278,7 @@ class MmuServer:
 
         if errors:
             if fix:
-                errors += f"\nWill attempt to fix..."
+                errors += "\nWill attempt to fix..."
             await self._log_n_send(f"Warning - Inconsistencies found in spoolman db:{errors}", silent=silent)
 
         if fix:

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -151,6 +151,8 @@ class MmuServer:
         return True
 
     def _mmu_backend_enabled(self):
+        if not hasattr(self, 'mmu_backend_present'):
+            return False
         return self.mmu_backend_present and self.mmu_enabled
 
     async def _initialize_mmu(self):

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -585,7 +585,7 @@ class MmuServer:
 
             # Sanity checking...
             if spool_id is None and gate is None:
-                await self._log_n_send(f"Trying to unset spool but no spool_id or gate provided", error=True, silent=silent)
+                await self._log_n_send("Trying to unset spool but no spool_id or gate provided", error=True, silent=silent)
                 return False
             if spool_id is not None and gate is not None:
                 await self._log_n_send(f"Trying to unset spool but both spool_id {spool_id} and gate {gate} provided. Only one or the other expected", error=True, silent=silent)

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -140,15 +140,14 @@ class MmuServer:
         returns:
             @return: True if initialized, False otherwise
         '''
-        if not hasattr(self, 'mmu_backend_present'):
-            self.mmu_backend_present = 'mmu' in await self.klippy_apis.get_object_list()
-            logging.info(f"MMU backend present: {self.mmu_backend_present}")
-            if self.mmu_backend_present:
-                self.mmu_backend_config = await self.klippy_apis.query_objects({"mmu": None})
-                self.mmu_enabled = self.mmu_backend_config.get('mmu', {}).get('enabled', False)
-            else:
-                self.mmu_enabled = False
-            logging.info(f"MMU backend enabled: {self.mmu_enabled}")
+        self.mmu_backend_present = 'mmu' in await self.klippy_apis.get_object_list()
+        if self.mmu_backend_present:
+            self.mmu_backend_config = await self.klippy_apis.query_objects({"mmu": None})
+            self.mmu_enabled = self.mmu_backend_config.get('mmu', {}).get('enabled', False)
+        else:
+            self.mmu_enabled = False
+        logging.info(f"MMU backend present: {self.mmu_backend_present}")
+        logging.info(f"MMU backend enabled: {self.mmu_enabled}")
         return True
 
     def _mmu_backend_enabled(self):

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -521,7 +521,7 @@ class MmuServer:
             if gate is not None and gate < 0:
                 await self._log_n_send("Trying to set spool {spool_id} for printer {self.printer_hostname} but gate {gate} is invalid.", error=True, silent=silent)
                 return False
-            if gate is not None and gate > self.nb_gates:
+            if gate is not None and gate > self.nb_gates -1:
                 await self._log_n_send(f"Trying to set spool {spool_id} for printer {self.printer_hostname} @ gate {gate} but only {self.nb_gates} gates are available. Please check the spoolman or moonraker [spoolman] setup.", error=True, silent=silent)
                 return False
             if gate is None:

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -162,13 +162,13 @@ class MmuServer:
         returns:
             @return: True if initialized, False otherwise
         '''
-        self.nb_gates = 0
         if not hasattr(self, 'mmu_backend_present'):
             await self._init_mmu_backend()
-        if self._mmu_backend_enabled():
-            if len(self.mmu_backend_config.get('mmu', {}).get('ttg_map', [])) == 0:
-                return False
-            self.nb_gates = len(self.mmu_backend_config.get('mmu', {}).get('ttg_map', []))
+            if self._mmu_backend_enabled():
+                self.nb_gates = self.mmu_backend_config.get('mmu', {}).get('nb_gates', 0)
+            else:
+                self.nb_gates = 1 # for standalone usage (no mmu backend considering standard printer setup)
+            logging.info(f"MMU nb_gates: {self.nb_gates}")
         return True
 
     async def _get_extra_fields(self, entity_type) -> bool:

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -103,7 +103,7 @@ class MmuServer:
                 fields = await self._get_extra_fields("spool")
                 if MMU_NAME_FIELD not in fields:
                     extras = extras and await self._add_extra_field("spool", field_name="Printer Name", field_key=MMU_NAME_FIELD, field_type="text", default_value="")
-                if MMU_GATE_FIELD not in await self._get_extra_fields("spool"):
+                if MMU_GATE_FIELD not in fields:
                     extras = extras and await self._add_extra_field("spool", field_name="MMU Gate", field_key=MMU_GATE_FIELD, field_type="integer", default_value=None)
             else:
                 logging.error(f"Could not initialize Spoolman db for Happy Hare. Spoolman db version too old (found {self.spoolman_version} < {MIN_SM_VER})")
@@ -185,7 +185,7 @@ class MmuServer:
             return False
         else:
             logging.info(f"Extra fields for {entity_type} found")
-            return [r['name'] for r in response.json()]
+            return [r['key'] for r in response.json()]
 
     async def _add_extra_field(self, entity_type, field_key, field_name, field_type, default_value) -> bool:
         '''

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -129,7 +129,8 @@ class MmuServer:
                 msg = msg.replace("\n", "\\n") # Get through klipper filtering
                 await self.klippy_apis.run_gcode(f"MMU_LOG MSG='{msg}' {error_flag}")
             else:
-                await self.klippy_apis.run_gcode(f"RESPOND MSG='{msg}'")
+                for msg in msg.split("\n"):
+                    await self.klippy_apis.run_gcode(f"M118 {msg}")
                 if error :
                     await self.klippy_apis.pause_print()
 

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -78,7 +78,7 @@ class MmuServer:
         # Options
         self.update_location = self.config.getboolean("update_spoolman_location", True)
 
-    async def _get_spoolman_version(self) -> (int, int, int) | None:
+    async def _get_spoolman_version(self) -> tuple[int, int, int] | None:
         response = await self.http_client.get(url=f'{self.spoolman.spoolman_url}/v1/info')
         if response.status_code == 404:
             logging.info(f"'{self.spoolman.spoolman_url}/v1/info' not found")

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -119,21 +119,19 @@ class MmuServer:
         '''
         logs and sends msg to the klipper console
         '''
-        async with self.cache_lock:
-            if not await self._initialize_mmu():
-                if error:
-                    logging.error(msg)
-                else:
-                    logging.info(msg)
-                if not silent:
-                    if self._mmu_backend_enabled():
-                        error_flag = "ERROR=1" if error else ""
-                        msg = msg.replace("\n", "\\n") # Get through klipper filtering
-                        await self.klippy_apis.run_gcode(f"MMU_LOG MSG='{msg}' {error_flag}")
-                    else:
-                        await self.klippy_apis.run_gcode(f"RESPOND MSG='{msg}'")
-                        if error :
-                            await self.klippy_apis.pause_print()
+        if error:
+            logging.error(msg)
+        else:
+            logging.info(msg)
+        if not silent:
+            if self._mmu_backend_enabled():
+                error_flag = "ERROR=1" if error else ""
+                msg = msg.replace("\n", "\\n") # Get through klipper filtering
+                await self.klippy_apis.run_gcode(f"MMU_LOG MSG='{msg}' {error_flag}")
+            else:
+                await self.klippy_apis.run_gcode(f"RESPOND MSG='{msg}'")
+                if error :
+                    await self.klippy_apis.pause_print()
 
     async def _init_mmu_backend(self):
         '''

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -204,7 +204,7 @@ class MmuServer:
             logging.error(f"Attempt add field {field_name} failed: {err_msg}")
             return False
         logging.info(f"Field {field_name} added to spoolman db for entity type {entity_type}")
-        logging.info(f"  -fields: %s", response.json())
+        logging.info("  -fields: %s", response.json())
         return True
 
     async def _fetch_spool_info(self, spool_id) -> dict | None:

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -187,7 +187,6 @@ class MmuServer:
         else:
             logging.info(f"Extra fields for {entity_type} found")
             return [r['name'] for r in response.json()]
-        return True
 
     async def _add_extra_field(self, entity_type, field_key, field_name, field_type, default_value) -> bool:
         '''

--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -166,10 +166,10 @@ class MmuServer:
         if not hasattr(self, 'mmu_backend_present'):
             await self._init_mmu_backend()
             if self._mmu_backend_enabled():
-                self.nb_gates = self.mmu_backend_config.get('mmu', {}).get('nb_gates', 0)
+                self.nb_gates = self.mmu_backend_config.get('mmu', {}).get('num_gates', 0)
             else:
                 self.nb_gates = 1 # for standalone usage (no mmu backend considering standard printer setup)
-            logging.info(f"MMU nb_gates: {self.nb_gates}")
+            logging.info(f"MMU num_gates: {self.nb_gates}")
         return True
 
     async def _get_extra_fields(self, entity_type) -> bool:

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -1396,7 +1396,7 @@ class Mmu:
     def get_status(self, eventtime):
         return {
                 'enabled': self.is_enabled,
-                'nb_gates': self.mmu_num_gates,
+                'num_gates': self.mmu_num_gates,
                 'is_paused': self._is_mmu_paused(),
                 'is_locked': self._is_mmu_paused(), # Alias for is_paused
                 'is_homed': self.is_homed,

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -1396,6 +1396,7 @@ class Mmu:
     def get_status(self, eventtime):
         return {
                 'enabled': self.is_enabled,
+                'nb_gates': self.mmu_num_gates,
                 'is_paused': self._is_mmu_paused(),
                 'is_locked': self._is_mmu_paused(), # Alias for is_paused
                 'is_homed': self.is_homed,
@@ -5733,7 +5734,7 @@ class Mmu:
         try:
             webhooks = self.printer.lookup_object('webhooks')
             self._log_debug("Storing gate map in spoolman db...")
-            webhooks.call_remote_method("spoolman_push_gate_map", nb_gates=self.mmu_num_gates, gate_ids=gate_ids, silent=quiet)
+            webhooks.call_remote_method("spoolman_push_gate_map", gate_ids=gate_ids, silent=quiet)
         except Exception as e:
             self._log_error("Error while calling _spoolman_push_gate_map: %s" % str(e))
 
@@ -5743,7 +5744,7 @@ class Mmu:
         self._log_debug("Requesting the gate map from Spoolman")
         try:
             webhooks = self.printer.lookup_object('webhooks')
-            webhooks.call_remote_method("spoolman_pull_gate_map", nb_gates=self.mmu_num_gates, silent=quiet)
+            webhooks.call_remote_method("spoolman_pull_gate_map", silent=quiet)
         except Exception as e:
             self._log_error("Error while retrieving spoolman gate mapping info (see mmu.log for more info): %s" % str(e))
 
@@ -5753,7 +5754,7 @@ class Mmu:
         self._log_debug("Requesting to clear the gate map in Spoolman")
         try:
             webhooks = self.printer.lookup_object('webhooks')
-            webhooks.call_remote_method("spoolman_clear_spools_for_printer", nb_gates=self.mmu_num_gates, sync=sync, silent=quiet)
+            webhooks.call_remote_method("spoolman_clear_spools_for_printer", sync=sync, silent=quiet)
         except Exception as e:
             self._log_error("Error while clearing spoolman gate mapping: %s" % str(e))
 
@@ -5763,7 +5764,7 @@ class Mmu:
         self._log_debug("Requesting to refresh the spoolman gate cache")
         try:
             webhooks = self.printer.lookup_object('webhooks')
-            webhooks.call_remote_method("spoolman_refresh", nb_gates=self.mmu_num_gates, fix=fix, silent=quiet)
+            webhooks.call_remote_method("spoolman_refresh", fix=fix, silent=quiet)
         except Exception as e:
             self._log_error("Error while refreshing spoolman gate cache: %s" % str(e))
 
@@ -5773,7 +5774,7 @@ class Mmu:
         self._log_debug("Setting spool %d to gate %d directly in spoolman db" % (spool_id, gate))
         try:
             webhooks = self.printer.lookup_object('webhooks')
-            webhooks.call_remote_method("spoolman_set_spool_gate", spool_id=spool_id, gate=gate, nb_gates=self.mmu_num_gates, sync=sync, silent=quiet)
+            webhooks.call_remote_method("spoolman_set_spool_gate", spool_id=spool_id, gate=gate, sync=sync, silent=quiet)
         except Exception as e:
             self._log_error("Error while setting spoolman gate association: %s" % str(e))
 
@@ -5782,7 +5783,7 @@ class Mmu:
         self._log_debug("Unsetting spool %s or gate %s in spoolman db" % (spool_id, gate))
         try:
             webhooks = self.printer.lookup_object('webhooks')
-            webhooks.call_remote_method("spoolman_unset_spool_gate", spool_id=spool_id, gate=gate, nb_gates=self.mmu_num_gates, sync=sync, silent=quiet)
+            webhooks.call_remote_method("spoolman_unset_spool_gate", spool_id=spool_id, gate=gate, sync=sync, silent=quiet)
         except Exception as e:
             self._log_error("Error while unsetting spoolman gate association: %s" % str(e))
 
@@ -5800,7 +5801,7 @@ class Mmu:
         if self.spoolman_support == self.SPOOLMAN_OFF: return
         try:
             webhooks = self.printer.lookup_object('webhooks')
-            webhooks.call_remote_method("spoolman_display_spool_location", printer=printer, nb_gates=self.mmu_num_gates)
+            webhooks.call_remote_method("spoolman_display_spool_location", printer=printer)
         except Exception as e:
             self._log_error("Error while displaying spool location map: %s" % str(e))
 
@@ -6514,7 +6515,7 @@ class Mmu:
             msg += "\nselector_homing_speed = %.1f" % self.selector_homing_speed
             msg += "\nselector_touch_speed = %.1f" % self.selector_touch_speed
             msg += "\nselector_touch_enable = %d" % self.selector_touch_enable
-    
+
             msg += "\n\nTMC & MOTOR SYNC CONTROL:"
             msg += "\nsync_to_extruder = %d" % self.sync_to_extruder
             msg += "\nsync_form_tip = %d" % self.sync_form_tip
@@ -6524,7 +6525,7 @@ class Mmu:
             msg += "\nsync_gear_current = %d" % self.sync_gear_current
             msg += "\nextruder_collision_homing_current = %d" % self.extruder_collision_homing_current
             msg += "\nextruder_form_tip_current = %d" % self.extruder_form_tip_current
-    
+
             msg += "\n\nLOADING/UNLOADING:"
             msg += "\ngate_homing_endstop = %s" % self.gate_homing_endstop
             if self.gate_homing_endstop == self.ENDSTOP_GATE and self._has_encoder():
@@ -6547,12 +6548,12 @@ class Mmu:
             msg += "\ntoolhead_post_load_tighten = %d" % self.toolhead_post_load_tighten
             msg += "\ngcode_load_sequence = %d" % self.gcode_load_sequence
             msg += "\ngcode_unload_sequence = %d" % self.gcode_unload_sequence
-    
+
             msg += "\n\nTIP FORMING:"
             msg += "\nform_tip_macro = %s" % self.form_tip_macro
             msg += "\nslicer_tip_park_pos = %.1f" % self.slicer_tip_park_pos
             msg += "\nforce_form_tip_standalone = %d" % self.force_form_tip_standalone
-    
+
             msg += "\n\nBLOB/STRINGING:"
             msg += "\nz_hop_height_toolchange = %.1f" % self.z_hop_height_toolchange
             msg += "\nz_hop_height_error = %.1f" % self.z_hop_height_error
@@ -6562,7 +6563,7 @@ class Mmu:
             msg += "\ntoolchange_retract = %.1f" % self.toolchange_retract
             msg += "\ntoolchange_retract_speed = %.1f" % self.toolchange_retract_speed
             msg += "\ntoolchange_unretract_speed = %.1f" % self.toolchange_unretract_speed
-    
+
             msg += "\n\nLOGGING:"
             msg += "\nlog_level = %d" % self.log_level
             msg += "\nlog_visual = %d" % self.log_visual
@@ -6570,7 +6571,7 @@ class Mmu:
                 msg += "\nlog_file_level = %d" % self.log_file_level
             msg += "\nlog_statistics = %d" % self.log_statistics
             msg += "\nconsole_gate_stat = %s" % self.console_gate_stat
-    
+
             msg += "\n\nOTHER:"
             msg += "\nextruder_temp_variance = %.1f" % self.extruder_temp_variance
             if self._has_encoder():
@@ -6588,7 +6589,7 @@ class Mmu:
             msg += "\nretry_tool_change_on_error = %d" % self.retry_tool_change_on_error
             msg += "\nprint_start_detection = %d" % self.print_start_detection
             msg += "\nshow_error_dialog = %d" % self.show_error_dialog
-    
+
             msg += "\n\nCALIBRATION:"
             msg += "\nmmu_calibration_bowden_length = %.1f" % self.calibrated_bowden_length
             if self._has_encoder():


### PR DESCRIPTION
Add the possibility to include only mmu_server into moonraker in order to expose spoolman methods for storing, setting, retrieving spools for printers.

## This PR mainly consists in:
- add the standalone operation to mmu_server
- switch to query object for mmu_server initialization to avoid passing arguments 
- minor fixes :
   - gate assignment overflow check fixed
   - minor linting issues

## Limitations:
- Active spool setting has to be done manually

## Interrogations:
- is is possible no mmu module is present in klipper but mmu_server is enabled ?
- if klipper is down, mmu_server will default to nb_gates = 1 (standalone mode)


### example file
Below is a simple example cfg file to interface with this ecosystem 
```yml

[gcode_macro SET_ACTIVE_SPOOL]
description: Sets active spool to spool with given id.
  Usage: SET_ACTIVE_SPOOL [ID=<int>]
gcode:
    {% if params.ID %}
        {% set id = params.ID|int %}
        {action_call_remote_method(
        "spoolman_set_active_spool",
        spool_id=id
        )}
    {% else %}
        {action_respond_info("Parameter 'ID' is required")}
    {% endif %}

[gcode_macro SPOOLMAN_REFRESH]
description: Rebuilds the local cache of essential spool information
gcode:
    {% set fix = False %}
    {% if params.FIX %}
        {% set fix = params.FIX %}
    {% endif %}
    {action_call_remote_method("spoolman_refresh", fix=fix)}

[gcode_macro SPOOLMAN_PUSH_GATE_MAP]
description: Store the gate map for the printer for a list of (gate, spool_id) tuples.
        This attempts to reduce the number of necessary tasks and then run them in parallel
  Usage: SPOOLMAN_PUSH_GATE_MAP
gcode:
    {% if not "ID" in params %}
        {action_raise_error("Parameter 'ID' is required")}
    {% endif %}
    {% set id = params.ID|int %}
    {action_call_remote_method("spoolman_push_gate_map", gate_ids=[(0,id)])}

[gcode_macro SPOOLMAN_PULL_GATE_MAP]
description: Get all spools assigned to the current printer from spoolman db and map them to gates
  Usage: SPOOLMAN_PULL_GATE_MAP
gcode:
    {action_call_remote_method("spoolman_pull_gate_map", nb_gates=1)}

[gcode_macro SPOOLMAN_GET_SPOOL_INFO]
description: Gets information for active spool if no id given else information of spool with given id. If no id given, active spool is used.
  Usage: GET_SPOOL_INFO [ID=<int>]
gcode:
    {% set id = None %}
    {% if params.ID %}
        {% set id = params.ID|int %}
    {% endif %}
    {action_call_remote_method("spoolman_get_spool_info",spool_id=id)}

[gcode_macro SPOOLMAN_SET_SPOOL_GATE]
description: Assigns spool id=ID to current machine. If MMU is enabled GATE number must be specified with GATE=<int>.
  Usage: SET_SPOOL_GATE [ID=<int>]
                        [GATE=<int>]
gcode:
    {% set id = None %}
    {% set gate = None %}
    {% if params.ID %}
        {% set id = params.ID|int %}
    {% endif %}
    {% if params.GATE %}
        {% set gate = params.GATE|int %}
    {% endif %}
    {action_call_remote_method("spoolman_set_spool_gate", spool_id=id, gate=gate)}

[gcode_macro SPOOLMAN_UNSET_SPOOL_GATE]
description: Unassigns spool from current machine.
  Usage: UNSET_SPOOL_GATE [GATE=<int>]
gcode:
    {% set id = None %}
    {% set gate = None %}
    {% if params.ID %}
        {% set id = params.ID|int %}
    {% endif %}
    {% if params.GATE %}
        {% set gate = params.GATE|int %}
    {% endif %}
    {action_call_remote_method("spoolman_unset_spool_gate", spool_id=id, gate=gate)}

[gcode_macro SPOOLMAN_GET_SPOOLS]
description: Gets all spools assigned to current machine.
  Usage: GET_SPOOLS
gcode:
    {action_call_remote_method("spoolman_display_spool_location")}

[gcode_macro CLEAR_SPOOLS_FOR_MACHINE]
description: Clears all spool GATEs.
  Usage: CLEAR_SPOOLS_FOR_MACHINE
gcode:
    {action_call_remote_method("spoolman_clear_spools_for_machine")}

[gcode_macro _SYNC_SPOOLS]
description: Syncs spools with or from spoolman db.
   Usage: _SYNC_SPOOLS MODE=[push|pull]
gcode:
    {% if not "MODE" in params %}
        {action_raise_error("Parameter 'MODE' is required")}
    {% endif %}
    {% set mode = params.MODE %}
    {% if mode == "push" %}
        SPOOLMAN_PUSH_GATE_MAP
    {% elif mode == "pull" %}
        SPOOLMAN_PULL_GATE_MAP
    {% else %}
        {action_raise_error("Invalid mode (can either be 'push' or 'pull')")}
    {% endif %}

[delayed_gcode _INIT_SPOOLMAN]
gcode:
    ### Change the sync mode here for startup syncing
    _SYNC_SPOOLS MODE=pull
```