### PR TITLE
Updated variable_feed_length for EREC Cutter for ERCF V2

### DIFF
--- a/config/addons/mmu_erec_cutter.cfg
+++ b/config/addons/mmu_erec_cutter.cfg
@@ -35,7 +35,7 @@ variable_servo_duration       : 0.4	; Time (s) of PWM pulse to activate servo
 variable_servo_idle_time      : 1.0	; Time (s) to let the servo to reach it's position
 
 # Controls for feed and cut lengths
-variable_feed_length          : 58	; Distance in mm from gate parking position to position of blade
+variable_feed_length          : 48	; Distance in mm from gate parking position to position of blade. ERCF_V1.1:58, V2_and_other:48
 variable_cut_length           : 10	; Amount in mm of filament to cut
 variable_cut_attempts         : 1	; Number of times the cutter tries to cut the filament
 


### PR DESCRIPTION
Updated variable_feed_length for EREC cutter to work with V2 out of the box, which is based on the gate_parking_distance from mmu_parameter.cfg and adjusted the comment to show the values for ERCF V1.1 and V2+ others. This is based on the install.sh gate_parking_distance of 13 (ERCF V2 + others) vs 23(ERCF V1.1).

If not adjusted properly the cut length is not correct. Initial Macro came from me with these Values, since i still had gate_parking_distance of 23 left when upgrading from V1.1 to V2.