### PR TITLE
Changes for Creality K1 series

### DIFF
--- a/extras/mmu_toolhead.py
+++ b/extras/mmu_toolhead.py
@@ -36,12 +36,26 @@ class MmuToolHead(toolhead.ToolHead, object):
         self.reactor = self.printer.get_reactor()
         self.all_mcus = [m for n, m in self.printer.lookup_objects(module='mcu')]
         self.mcu = self.all_mcus[0]
+
+        if hasattr(toolhead, 'BUFFER_TIME_HIGH'):
+            time_high = toolhead.BUFFER_TIME_HIGH
+        else:
+            # Backward compatibility for older klipper, like on Sovol or Creality K1 series printers
+            # On Creality K1, these attributes are expected to exist in any Toolhead
+            self.buffer_time_low = config.getfloat('buffer_time_low', 1.000, above=0.)
+            self.buffer_time_high = config.getfloat('buffer_time_high', 2.000, above=self.buffer_time_low)
+            self.buffer_time_start = config.getfloat('buffer_time_start', 0.250, above=0.)
+            self.move_flush_time = config.getfloat('move_flush_time', 0.050, above=0.)
+            self.last_kin_flush_time = self.force_flush_time = self.last_kin_move_time = 0.
+
+            time_high = self.buffer_time_high
+
         if hasattr(toolhead, 'LookAheadQueue'):
             self.lookahead = toolhead.LookAheadQueue(self) # Happy Hare: Use base class LookAheadQueue
-            self.lookahead.set_flush_time(toolhead.BUFFER_TIME_HIGH) # Happy Hare: Use base class
+            self.lookahead.set_flush_time(time_high) # Happy Hare: Use base class
         else:
             self.move_queue = toolhead.MoveQueue(self) # Happy Hare: Use base class MoveQueue (older klipper)
-            self.move_queue.set_flush_time(toolhead.BUFFER_TIME_HIGH) # Happy Hare: Use base class (older klipper)
+            self.move_queue.set_flush_time(time_high) # Happy Hare: Use base class (older klipper)
         self.commanded_pos = [0., 0., 0., 0.]
 
         # MMU velocity and acceleration control
@@ -415,8 +429,10 @@ class MmuKinematics:
             move.limit_speed(self.gear_max_velocity, min(self.gear_max_accel, self.move_accel or self.gear_max_accel))
 
     def get_status(self, eventtime):
+        # Legacy method only used in old Klipper
         return {
             'selector_homed': self.limits[0][0] <= self.limits[0][1],
+            'homed_axes': '' # Required for Creality K1 series printers
         }
 
 


### PR DESCRIPTION
The Creality K1 series of 3d-printers runs on a MIPS CPU, under a heavily trimmed Linux system akin to that on WiFi routers. The current install script will not run on them.
Furthermore, on those printers, there are no users other than root present, the directories for klipper are always different from what you expect on a Pi-based system, the services run as init scripts (with no systemd present).

This PR suggests changes necessary for checking if the srcipt runs on such a system and adjusting the folders accordingly. It addresses the question in #311 and is similar to the script provided in that answer.

Closes #311, closes #189, closes #381