### PR TITLE
add new feature - auto sync filament rotation dist adjustment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 my_*.cfg
+.idea

--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -352,6 +352,18 @@ sync_multiplier_high: 1.05		# Maximum factor to apply to gear stepper `rotation_
 sync_multipler_low: 0.95		# Minimum factor to apply
 
 
+
+# advance feature, automatically adjust rotation_distance base on two tension sensors feedback.
+# must have two tension sensors for expanded and compressed, otherwise it's impossible to work, and 
+# this feature is disbled.
+# gate ratio calibration values are not needed and disregarded. 
+# sync_multiplier_high and sync_multiplier_low values are not needed and disregarded.
+# It allows bad gear stepper rotation_distance value +-50% or even more off,
+# ie if the perfect rotation_dist is 20, set it anything between 10 and 30, it will be automatically 
+# adjusted to the correct value.
+sync_auto_adjust_rotation_dist: 1 
+
+
 # Filament Management Options ----------------------------------------------------------------------------------------
 # ███████╗██╗██╗            ███╗   ███╗ ██████╗ ███╗   ███╗████████╗
 # ██╔════╝██║██║            ████╗ ████║██╔════╝ ████╗ ████║╚══██╔══╝


### PR DESCRIPTION
**add a new feature auto sync filament rotation dist adjustment with support of two tension sensors compressed and expanded.**

- Automatically adjust the rotation_dist. using binary search algorithm to quickly find the correct perfect rotation dist value. 
- It shall also make the gate ratio calibration steps fully optional or obsolete ( a few less setup steps required).
- It can adjust 50% out of range bad rotation distance value, that means, if the perfect rotation_dist is 20,  allow any value from 10 to 30 in the config, it can be fixed and printing won't be impacted at all.  The algorithm can automatically adjust it using the help of two tension sensors's feedback in printing time. after a few automatic adjustment the filament and sensor shall stay in neutral state for long time.
- added a 2nd level of safety measure, to check tension state if stays in the state for too long, adjust the rotation_dist value even more to ensure get out of the tension state quickly.
-  Added an option in the mmu_parameter.cfg file to enable / disable this feature.
- the feature enable flag will be disabled by itself if no two tension sensors installed
- put the majority of the new code in mmu_sensors.py to avoid making the main file mmu.py too large and potentially reduce the chance of annoying file conflict

-  Tested multiple times with real printing.  log file attached from an actual 3.5 hour print. log shows the algorithm found the "perfect" rotation_dist at 11:57 and it lasted for 1hour and finally finished the print.

 
[review_log.txt](https://github.com/user-attachments/files/16791122/review_log.txt)
