### PR TITLE
PR - MMU_PRELOAD button always make selector go to gate 0

### DIFF
--- a/config/base/mmu_software.cfg
+++ b/config/base/mmu_software.cfg
@@ -486,7 +486,7 @@ gcode: MMU_RECOVER
 
 [gcode_macro MMU__PRELOAD]
 gcode:
-    {% set gate = params.GATE|default(0)|int %}
+    {% set gate = params.GATE|default(-1)|int %}
     MMU_PRELOAD GATE={gate}
 
 [gcode_macro MMU__CHECK_GATE]

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -7740,12 +7740,11 @@ class Mmu:
     def cmd_MMU_PRELOAD(self, gcmd):
         self._log_to_file(gcmd.get_commandline())
         if self._check_is_disabled(): return
-        if self._check_not_homed(): return
         if self._check_in_bypass(): return
         if self._check_is_loaded(): return
         if self._check_is_calibrated(): return
 
-        gate = gcmd.get_int('GATE', -1, minval=0, maxval=self.mmu_num_gates - 1)
+        gate = gcmd.get_int('GATE', -1, minval=-1, maxval=self.mmu_num_gates - 1)
         self.log_always("Preloading filament in %s" % (("Gate %d" % gate) if gate >= 0 else "current gate"))
         try:
             with self._wrap_action(self.ACTION_CHECKING):


### PR DESCRIPTION
PR - MMU_PRELOAD button always make selector go to gate 0

note, only the button in web interface has this problem.
if type or paste the command and run it in web console input line then it's ok.

**Steps to reproduce**

1 Run MMU_SELECT_TOOL go to gate 1 or 2 or 3 etc  ( any non 0 gate).
2 Press the button in web interface - MMU_PRELOAD

**Expect behaviour:**
 selector doesn't move,  selector work on preload gate 1 or 2 or 3 , the current gate

**Actual behaviour:**
   selector attempt to move to gate 0 and got stuck since filament is inside.

**Impact:**
  most likely filament is inside selector , the selector incorrectly move to gate 0 makes thing messed up, stuck, lose position etc.

**Root cause**
   in mmu_software.cfg it provides a default parameter gate=0
 while the correct value for missing parameter gate should be -1, or anything other than any valid number ( 0 to max-1)
Also in mmu.py preload function should allow -1 as min value. 
So all and all, it made the selector move to gate 0 while pressing the button 

So with the always gate=0 and min value =0, the below lines inside cmd_MMU_PRELOAD() never has a chance to run. (line 7754)
> gate = gcmd.get_int('GATE', -1, minval=-1, maxval=self.mmu_num_gates - 1)
>    if gate == -1:
>          gate = self.gate_selected



One more thing
**remove is_home() check before doing MMU_PRELOAD.**
When selector is not home, software shouldn't restrict user from doing preload and unload the filament.
since filament is already inside selector, there is no way user can do "home".
Forcing home is impossible and defeating the preload action's purpose, which is to unload and clear the selector.

