### PR TITLE
Allow comments on toolchange commands to accommodate verbose slicer mode

### DIFF
--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -709,7 +709,7 @@ FILAMENT_NAMES_REGEX = r"^;\s*(filament_settings_id)\s*=\s*(.*)$"
 METADATA_FILAMENT_NAMES = "!filament_names!"
 
 # Detection for next pos processing
-T_PATTERN  = r'^T(\d+)$'
+T_PATTERN  = r'^T(\d+)\s*(?:;.*)?$'
 G1_PATTERN = r'^G[01](?=.*\sX(-?[\d.]+))(?=.*\sY(-?[\d.]+)).*$'
 
 def gcode_processed_already(file_path):


### PR DESCRIPTION
I'm using OrcaSlicer and have the Verbose G-code option turned on. That causes T* commands to be emitted with a comment, and Happy Hare's G-code preprocessor no longer recognizes them. This is a simple regex fix to allow (and ignore) comments.