### PR TITLE
Fix ‘out of range’ with Blobifier shake

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -96,7 +96,14 @@ variable_wipe_spd_xy:       10000          # Nozzle wipe speed in mm/min.
 # correction is set up. If you have skew correction enabled and get 'move out of range'
 # errors regarding blobifier while skew is enabled, try increasing this value. Keep the 
 # adjustments small though! (0.1mm - 0.5mm) and increase it until it works.
-variable_skew_correction: 0          
+variable_skew_correction_y: 0
+
+# Similarly, Blobifier sends the toolhead to minimum x position when shaking, but this 
+# can cause issues when skew correction is setup. If you have skew correction enabled 
+# and get 'move out of range' when attempting a shake operation, try increasing this 
+# value. Keep the adjustments small though! (0.1mm - 0.5mm) and increase it until it 
+# works.
+variable_skew_correction_x: 0          
 
 # These parameters define the size of the brush. Update as necessary. A visual reference
 # is provided below.
@@ -305,7 +312,7 @@ gcode:
     {% set ignore_safe = safe.print_height < force_safe_descend_height_until %}
     {% set restore_z = [printer['gcode_macro BLOBIFIER_PARK'].restore_z,pos.z]|max %}
     {% set pos_max = printer.toolhead.axis_maximum %}
-    {% set position_y = pos_max.y - skew_correction %}
+    {% set position_y = pos_max.y - skew_correction_y %}
 
     # Get purge volumes from the slicer (if set up right. see 
     # https://github.com/moggieuk/Happy-Hare/wiki/Gcode-Preprocessing)
@@ -552,7 +559,7 @@ gcode:
   {% set pos = printer.gcode_move.gcode_position %}
   {% set safe = printer['gcode_macro _BLOBIFIER_SAFE_DESCEND'] %}
   {% set pos_max = printer.toolhead.axis_maximum %}
-  {% set position_y = pos_max.y - bl.skew_correction %}
+  {% set position_y = pos_max.y - bl.skew_correction_y %}
 
   SET_GCODE_VARIABLE MACRO=BLOBIFIER_PARK VARIABLE=restore_z VALUE={pos.z}
 
@@ -672,7 +679,7 @@ variable_print_layer_height: 0.3
 gcode:
   {% set bl = printer['gcode_macro BLOBIFIER'] %}
   {% set pos_max = printer.toolhead.axis_maximum %}
-  {% set position_y = pos_max.y - bl.skew_correction %}
+  {% set position_y = pos_max.y - bl.skew_correction_y %}
   {% set tray = [bl.purge_x + bl.toolhead_x, position_y - bl.toolhead_y] %}
   {% set brush = [bl.brush_start + bl.brush_width + bl.toolhead_x, position_y - bl.toolhead_y] %}
   {% set shake = [bl.purge_x + bl.toolhead_x, position_y - bl.toolhead_y - 4] %}
@@ -744,6 +751,7 @@ gcode:
   {% set count = printer['gcode_macro _BLOBIFIER_COUNT'] %}
   {% set original_accel = printer.toolhead.max_accel %}
   {% set original_minimum_cruise_ratio = printer.toolhead.minimum_cruise_ratio %}
+  {% set position_x = bl.skew_correction_x %}
   
   {% if "xyz" not in printer.toolhead.homed_axes %}
     {action_raise_error("BLOBIFIER: Not homed. Home xyz first")}
@@ -768,7 +776,7 @@ gcode:
   # move up a bit to prevent oozing on base
   G1 Z2 F{bl.travel_spd_z}
   # slide into the slot
-  G1 X0 F{bl.travel_spd_xy}
+  G1 X{position_x} F{bl.travel_spd_xy}
 
   M400
   M117 (+(+_+)+)

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -92,18 +92,12 @@ variable_travel_spd_z:       1000          # Travel (not cleaning) speed along z
                                            #   in mm/min.
 variable_wipe_spd_xy:       10000          # Nozzle wipe speed in mm/min.
 
-# Blobifier sends the toolhead to maximum y position, but this can cause issues when skew 
-# correction is set up. If you have skew correction enabled and get 'move out of range'
-# errors regarding blobifier while skew is enabled, try increasing this value. Keep the 
+# Blobifier sends the toolhead to the maximum y position during purge oeprations and
+# minimum x position during shake operations. This can cause issues when skew correction 
+# is set up. If you have skew correction enabled and get 'move out of range' errors 
+# regarding blobifier while skew is enabled, try increasing this value. Keep the 
 # adjustments small though! (0.1mm - 0.5mm) and increase it until it works.
-variable_skew_correction_y: 0
-
-# Similarly, Blobifier sends the toolhead to minimum x position when shaking, but this 
-# can cause issues when skew correction is setup. If you have skew correction enabled 
-# and get 'move out of range' when attempting a shake operation, try increasing this 
-# value. Keep the adjustments small though! (0.1mm - 0.5mm) and increase it until it 
-# works.
-variable_skew_correction_x: 0          
+variable_skew_correction: 0
 
 # These parameters define the size of the brush. Update as necessary. A visual reference
 # is provided below.
@@ -312,7 +306,7 @@ gcode:
     {% set ignore_safe = safe.print_height < force_safe_descend_height_until %}
     {% set restore_z = [printer['gcode_macro BLOBIFIER_PARK'].restore_z,pos.z]|max %}
     {% set pos_max = printer.toolhead.axis_maximum %}
-    {% set position_y = pos_max.y - skew_correction_y %}
+    {% set position_y = pos_max.y - skew_correction %}
 
     # Get purge volumes from the slicer (if set up right. see 
     # https://github.com/moggieuk/Happy-Hare/wiki/Gcode-Preprocessing)
@@ -559,7 +553,7 @@ gcode:
   {% set pos = printer.gcode_move.gcode_position %}
   {% set safe = printer['gcode_macro _BLOBIFIER_SAFE_DESCEND'] %}
   {% set pos_max = printer.toolhead.axis_maximum %}
-  {% set position_y = pos_max.y - bl.skew_correction_y %}
+  {% set position_y = pos_max.y - bl.skew_correction %}
 
   SET_GCODE_VARIABLE MACRO=BLOBIFIER_PARK VARIABLE=restore_z VALUE={pos.z}
 
@@ -679,7 +673,7 @@ variable_print_layer_height: 0.3
 gcode:
   {% set bl = printer['gcode_macro BLOBIFIER'] %}
   {% set pos_max = printer.toolhead.axis_maximum %}
-  {% set position_y = pos_max.y - bl.skew_correction_y %}
+  {% set position_y = pos_max.y - bl.skew_correction %}
   {% set tray = [bl.purge_x + bl.toolhead_x, position_y - bl.toolhead_y] %}
   {% set brush = [bl.brush_start + bl.brush_width + bl.toolhead_x, position_y - bl.toolhead_y] %}
   {% set shake = [bl.purge_x + bl.toolhead_x, position_y - bl.toolhead_y - 4] %}
@@ -751,8 +745,8 @@ gcode:
   {% set count = printer['gcode_macro _BLOBIFIER_COUNT'] %}
   {% set original_accel = printer.toolhead.max_accel %}
   {% set original_minimum_cruise_ratio = printer.toolhead.minimum_cruise_ratio %}
-  {% set position_x = bl.skew_correction_x %}
-  
+  {% set position_x = bl.skew_correction %}
+
   {% if "xyz" not in printer.toolhead.homed_axes %}
     {action_raise_error("BLOBIFIER: Not homed. Home xyz first")}
   {% endif %}


### PR DESCRIPTION
When using skew correction, a Blobifier shake operation can trigger an ‘out of range’ error.  This fix allows the user to apply a skew correction to both x and y axes.

cc: @Dendrowen 

Thank you for your consideration.