### PR TITLE
Patch _BLOBIFIER_INIT to comment out note for park

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -882,11 +882,11 @@ gcode:
 #          {action_emergency_stop("BLOBIFIER: Both BLOBIFIER_PARK and _MMU_CUT_TIP are enabled, but the tray_top is too low (< 0.2). This will cause the nozzle to run into the bed during cutting")}
 #        {% endif %}
 #      {% endif %}
-    
-    # Blobifier enabled, but Blobifier_park isn't
-    {% elif printer['gcode_macro _MMU_SEQUENCE_VARS'].user_post_load_extension == 'BLOBIFIER' %}
-      {action_respond_info("BLOBIFIER: Consider setting user_pre_unload_extension in mmu_macro_vars.cfg to BLOBIFIER_PARK")}
-    {% endif %}
+#    
+#    # Blobifier enabled, but Blobifier_park isn't
+#    {% elif printer['gcode_macro _MMU_SEQUENCE_VARS'].user_post_load_extension == 'BLOBIFIER' %}
+#      {action_respond_info("BLOBIFIER: Consider setting user_pre_unload_extension in mmu_macro_vars.cfg to BLOBIFIER_PARK")}
+#    {% endif %}
   {% endif %}
 
 


### PR DESCRIPTION
The associated IF/ELIF block was commented because BLOBIFIER_PARK's usage in INIT is broken in 2.7.1. 

Comment out the rest of the block to avoid a config read error.