### PR TITLE
Set servo to down during MMU_TEST_TRACKING

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -6696,6 +6696,7 @@ class Mmu:
                 self._load_sequence(bowden_move=100. if direction == self.DIRECTION_LOAD else 200., skip_extruder=True)
             with self._require_encoder():
                 self._initialize_filament_position()
+                self._servo_down()
                 for i in range(1, int(100 / step)):
                     self._trace_filament_move(None, direction * step, encoder_dwell=None)
                     measured = self._get_encoder_distance()


### PR DESCRIPTION
Just a simple fix to ensure the servo is down when starting MMU_TEST_TRACKING

Fixes issue #238 