### PR TITLE
Fix unicode filament names not matching with automap

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -1230,8 +1230,8 @@ class Mmu:
         a = unicodedata.normalize('NFKC', a)
         b = unicodedata.normalize('NFKC', b)
         if case_insensitive:
-            a = unicodedata.normalize('NFKC', a.casefold())
-            b = unicodedata.normalize('NFKC', b.casefold())
+            a = unicodedata.normalize('NFKC', a.lower())
+            b = unicodedata.normalize('NFKC', b.lower())
         return a == b
 
     # This retuns the hex color format without leading '#' E.g. ff00e0

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -13,7 +13,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 #
 import sys # To detect python2 or python3
-import random, logging, logging.handlers, threading, queue, atexit, time, contextlib, math, os.path, re
+import random, logging, logging.handlers, threading, queue, atexit, time, contextlib, math, os.path, re, unicodedata
 from extras.mmu_toolhead import MmuToolHead, MmuHoming
 from extras.mmu_sensors import MmuRunoutHelper
 from extras.homing import Homing, HomingMove
@@ -1224,6 +1224,15 @@ class Mmu:
                 return int(s)
             except ValueError:
                 return s
+
+    # Compare unicode strings with optional case insensitivity
+    def _compare_unicode(self, a, b, case_insensitive=True):
+        a = unicodedata.normalize('NFKC', a)
+        b = unicodedata.normalize('NFKC', b)
+        if case_insensitive:
+            a = unicodedata.normalize('NFKC', a.casefold())
+            b = unicodedata.normalize('NFKC', b.casefold())
+        return a == b
 
     # This retuns the hex color format without leading '#' E.g. ff00e0
     def _color_to_rgb_hex(self, color):
@@ -7395,7 +7404,12 @@ class Mmu:
             # 'standard' exactly matching fields
             if strategy != self.AUTOMAP_CLOSEST_COLOR:
                 for gn, gate_feature in enumerate(search_in):
-                    if tool_to_remap[tool_field] == gate_feature:
+                    # When matching by name normalize possible unicode characters and match case-insensitive
+                    if strategy == self.AUTOMAP_FILAMENT_NAME:
+                        equal = self._compare_unicode(tool_to_remap[tool_field], gate_feature)
+                    else:
+                        equal = tool_to_remap[tool_field] == gate_feature
+                    if equal:
                         remaps.append("T%s --> G%s (%s)" % (tool, gn, gate_feature))
                         self._wrap_gcode_command("MMU_TTG_MAP TOOL=%d GATE=%d QUIET=1" % (tool, gn))
                 if not len(remaps):

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -1230,8 +1230,8 @@ class Mmu:
         a = unicodedata.normalize('NFKC', a)
         b = unicodedata.normalize('NFKC', b)
         if case_insensitive:
-            a = unicodedata.normalize('NFKC', a.lower())
-            b = unicodedata.normalize('NFKC', b.lower())
+            a = a.lower()
+            b = b.lower()
         return a == b
 
     # This retuns the hex color format without leading '#' E.g. ff00e0


### PR DESCRIPTION
Certain unicode characters wouldn't match properly, e.g. the ™ in  "PolyLite™ ABS Black" (this is how it's defined in [SpoolmanDB](https://donkie.github.io/SpoolmanDB/)) would fail to be auto-mapped. I suspect that the methods to transfer it from spoolman or the slicer use slightly different unicode paths.

Also, although the documentation in `mmu_macro_vars.cfg` states it would match case-insensitive, it didn't. So I fixed that too. (The wiki doesn't mention it though)
```
#   'filament_name'  - exactly match on case insensitive filament name
```
I'm far from proficient with python, so possibly there's a better way? Basically I copied the implementation from here: https://docs.python.org/3/howto/unicode.html#comparing-strings  


