### PR TITLE
Blobifier V1.5

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -120,7 +120,12 @@ variable_brush_start:           67  # For 300mm build
 #variable_brush_start:          84  # for 350mm build
 
 # width of the brush
-variable_brush_width:          35
+variable_brush_width: 35
+
+# The acceleration to use when using the brush action. If set to 0, it uses the already 
+# set acceleration. However, in some cases this is not desirable for the last motion 
+# could be an 'outer contour' acceleration which is usually lower.
+variable_brush_accel: 0
 
 # Location of where to purge. The tray is 15mm in length, so if you assemble it against 
 # the side of the bed (default), 10mm is a good location
@@ -167,17 +172,16 @@ variable_tray_angle_in: 180
 # |    initial purge (first few mm)     |                            |
 # +-------------------------------------+----------------------------+
 # |  Filament scoots out from under     | Incr. temperature          |
-# |  the nozzle at the first iteration  | Decr. iteration_z_raise    |
-# |                                     | Incr. max_iteration_length |
+# |  the nozzle at the first iteration  | Decr. z_raise              |
+# |                                     | Incr. purge_length_maximum |
 # +-------------------------------------+----------------------------+
 # |  Filament scoots out from under the | Decr. purge_spd            |
-# |  the nozzle at later iterations     | Incr. iteration_z_change   |
+# |  the nozzle at later iterations     | Decr. z_raise_exp          |
+# |                                     | Decr. z_raise              |
+# |                                     | Incr. purge_length_maximum |
 # +-------------------------------------+----------------------------+
-# |  Filament sticks to the nozzle at   | Decr. iteration_z_change   |
-# |         later iterations            |                            |
-# +-------------------------------------+----------------------------+
-# |        I think my blobs can         | Balsy... Increase          |
-# |          be much bigger!            | max_iterations_per_blob    |
+# |  Filament sticks to the nozzle at   | Incr. z_raise_exp          |
+# |         later iterations            |     (Not above 1)          |
 # +-------------------------------------+----------------------------+
 #
 
@@ -185,19 +189,15 @@ variable_tray_angle_in: 180
 # pressure to escape before the purge.
 variable_purge_start: 0.2
 
-# The maximum mm of filament (length) to extrude one iteration. A blob contains multiple 
-# iterations
-variable_max_iteration_length: 50
+# The amount to raise Z
+variable_z_raise: 12
 
-# The amount to raise Z for each iteration
-variable_iteration_z_raise: 5
-
-# As the nozzle gets higher and the blob wider, the Z raise needs to be reduced.
-variable_iteration_z_change: 0.8
-
-# Maximum iterations per blob. 3 Should be sufficient for most flushes. If not, Blobifier 
-# will create multiple blobs for a single purge.
-variable_max_iterations_per_blob: 3
+# As the nozzle gets higher and the blob wider, the Z raise needs to be reduced, this
+# follows the following formula: 
+#            (extruded_amount/max_purge_length)^z_raise_exp * z_raise
+# 1 is linear, below 1 will cause z to raise less quickly over time, above 1 will make it
+# raise quicker over time. 0.85 is a good starting point and you should not have it above 1
+variable_z_raise_exp: 0.85
 
 # Lift the nozzle slightly after creating the blob te release pressure on the tray.
 variable_eject_hop: 1.0
@@ -217,17 +217,21 @@ variable_part_cooling_fan:  1               # Run it at full speed
 # ==================== PURGE LENGTH TUNING ===============================================
 # ========================================================================================
 
-# Default purge length to fall back on when neither the tool map purge_volumes or 
-# parameter PURGE_LENGTH is set.
-variable_purge_length: 150
-
 # The absolute minimum to purge, even if you don't changed tools. This is to prime the 
 # nozzle before printing
 variable_purge_length_minimum: 30
 
-# The slicer values often are a bit too wastefull. Tune it here to get optimal values. 0.6
-# is a good starting point.
-variable_purge_length_modifier: 0.5
+# The maximum amount of filament (in mm¹) to purge in a single blob. Blobifier will 
+# automatically purge multiple blobs if the purge amount exeeds this.
+variable_purge_length_maximum: 150
+
+# Default purge length to fall back on when neither the tool map purge_volumes or 
+# parameter PURGE_LENGTH is set.
+variable_purge_length: 150
+
+# The slicer values often are a bit too wastefull. Tune it here to get optimal values. 
+# 0.6 (60%) is a good starting point.
+variable_purge_length_modifier: 0.6
 
 # Fixed length of filament to add after the purge volume calculation. Happy Hare already
 # shares info on the extra amount of filament to purge based on known residual filament,
@@ -259,6 +263,9 @@ variable_shake_accel: 10000
 # is never, and 1 is every time. This way the shaking occurs more often as the bucket 
 # fills up. Sensible values range from 0.75 to 0.95
 variable_bucket_shake_frequency: 0.95
+
+# Height of the shaker arm. If your hotend hits your tray during shaking, increase.
+variable_shaker_arm_z: 2
 
 gcode:
 
@@ -346,8 +353,8 @@ gcode:
     {% endif %}
 
     # ==================================== APPLY PURGE MINIMUM =============================
-    {% set purge_len = [purge_len,purge_length_minimum]|max %}
-    {action_respond_info("BLOBIFIER: Purging %.2fmm of filament" % (purge_len|float))}
+    {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
+    {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
 
     # ======================================================================================
     # ==================== PURGING SEQUENCE ================================================
@@ -418,68 +425,68 @@ gcode:
       
       # Calculate total number of iterations based on the purge length and the max_iteration 
       # length.
-      {% set iterations = (purge_len / max_iteration_length)|round(0, 'ceil')|int %}
+      {% set blobs = (purge_len / purge_length_maximum)|round(0, 'ceil')|int %}
+      {% set purge_per_blob = purge_len|float / blobs %}
+      {% set retracts_per_blob = (purge_per_blob / 40)|round(0, 'ceil')|int %}
+      {% set purge_per_retract = (purge_per_blob / retracts_per_blob)|int %}
+      {% set pulses_per_retract = (purge_per_blob / retracts_per_blob / 5)|round(0, 'ceil')|int %}
+      {% set pulses_per_blob = (purge_per_blob / 5)|round(0, 'ceil')|int %}
+      {% set purge_per_pulse = purge_per_blob / pulses_per_blob %}
+      {% set pulse_time_constant = purge_per_pulse * 0.95 / purge_spd / (purge_per_pulse * 0.95 / purge_spd + purge_per_pulse * 0.05 / 50) %}
+      {% set pulse_duration = purge_per_pulse / purge_spd %}
 
       # Repeat the process until purge_len is reached
-      {% for n in range(iterations) %}
-      
-        # Calculate current iteration in current blob
-        {% set step = n % max_iterations_per_blob %}
+      {% for blob in range(blobs) %}
+        RESPOND MSG={"'BLOBIFIER: Blob %d of %d (%.1fmm)'" % (blob + 1, blobs, purge_per_blob)}
 
-        {% if step == 0 and (safe.tray or ignore_safe) %}
+        {% if safe.tray or ignore_safe %}
           G1 Z{tray_top + purge_start} F{travel_spd_z}
         {% endif %}
 
-        # Determine the amount to extrude. Either the remaining purge_len or 
-        # max_iteration_length.
-        {% set purge_amount_left = purge_len - (max_iteration_length * n) %}
-        {% set extrude_amount = [purge_amount_left,max_iteration_length]|min %}
-        {% set extrude_ratio = extrude_amount / max_iteration_length %}
-
         # relative positioning
         G91 
+        # relative extrusion
         M83
 
-        # Calculate the amount z has to be raised
-        # If step equals 0, the start position of the nozzle is already a little higher.
-        {% set step_triangular = step * (step + 1) / 2 %}
-        {% set z_raise_substract = purge_start if step == 0 else 
-          step_triangular * iteration_z_change %}
-        {% set raise_z = (iteration_z_raise - z_raise_substract) * extrude_ratio %}
+        # Purge filament in a pulsating motion to purge the filament quicker and better
+        {% for pulse in range(pulses_per_blob) %}
+          # Calculations to determine z-speed
+          {% set purged_this_blob = pulse * purge_per_pulse %}
+          {% set z_last_pos = purge_start + ((purged_this_blob)/purge_length_maximum)**z_raise_exp * z_raise %}
+          {% set z_pos = purge_start + ((purged_this_blob + purge_per_pulse)/purge_length_maximum)**z_raise_exp * z_raise %}
+          {% set z_up = z_pos - z_last_pos %}
+          {% set speed = z_up / pulse_duration %}
 
-        # make sure raise_z never goes negative, dropping the nozzle while purging.
-        {% set raise_z = [raise_z,0]|max %}
+          # Purge quickly
+          G1 Z{z_up * pulse_time_constant} E{purge_per_pulse * 0.95} F{speed}
+          # Purge a tiny bit slowly
+          G1 Z{z_up * (1 - pulse_time_constant)} E{purge_per_pulse * 0.05} F{speed}
 
-        # Calculate the raise speed based on the purge speed.
-        {% set duration = extrude_amount / purge_spd %} 
-        {% set speed = raise_z / duration %}
-      
-        # Purge one iteration
-        {% if safe.tray or ignore_safe %}
-          G1 Z{raise_z} E{extrude_amount} F{speed}
-        {% endif %}
+          # retract and unretract filament every now and then for thourough cleaning
+          {% if pulse % pulses_per_retract == 0 and pulse > 0 %}
+            G1 E-2 F1800
+            G1 E2 F800
+          {% endif %}
+          
+        {% endfor %}
 
         # ==================================================================================
         # ==================== DEPOSIT BLOB ================================================
         # ==================================================================================
         {% if safe.tray or ignore_safe %}
-          {% set max_iterations_reached = step == max_iterations_per_blob - 1 %}
-          {% set purge_length_reached = purge_len - max_iteration_length * (n+1) <= 0 %}
-          {% if max_iterations_reached or purge_length_reached %}
-            # Raise z a bit to relieve pressure on the blob preventing it to go sideways
-            G1 Z{eject_hop} F{travel_spd_z}
-            # Retract the tray
-            BLOBIFIER_SERVO POS=in
-            # Move the toolhead down to purge_start height lowering the blob below the tray
-            G90 # absolute positioning
-            G1 Z{tray_top} F{travel_spd_z}
-            # Extend the tray to 'cut off' the blob and prepare for the next blob
-            BLOBIFIER_SERVO POS=out
-            BLOBIFIER_SERVO POS=in
-            BLOBIFIER_SERVO POS=out
-            # Keep track of the # of blobs
-            _BLOBIFIER_COUNT
-          {% endif %}
+          # Raise z a bit to relieve pressure on the blob preventing it to go sideways
+          G1 Z{eject_hop} F{travel_spd_z}
+          # Retract the tray
+          BLOBIFIER_SERVO POS=in
+          # Move the toolhead down to purge_start height lowering the blob below the tray
+          G90 # absolute positioning
+          G1 Z{tray_top} F{travel_spd_z}
+          # Extend the tray to 'cut off' the blob and prepare for the next blob
+          BLOBIFIER_SERVO POS=out
+          BLOBIFIER_SERVO POS=in
+          BLOBIFIER_SERVO POS=out
+          # Keep track of the # of blobs
+          _BLOBIFIER_COUNT
         {% endif %}
       {% endfor %}
     {% endif %}
@@ -520,12 +527,16 @@ gcode:
 gcode:
   {% set bb = printer['gcode_macro BLOBIFIER'] %}
   {% set position_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
-  # Position for wipe. Either left or right of brush based off bucket_pos to avoid 
-  # unnecessary travel.
+  {% set original_accel = printer.toolhead.max_accel %}
+  {% set original_minimum_cruise_ratio = printer.toolhead.minimum_cruise_ratio %}
   
   SAVE_GCODE_STATE NAME=BLOBIFIER_CLEAN_state
 
   G90
+  
+  {% if bb.brush_accel > 0 %}
+    SET_VELOCITY_LIMIT ACCEL={bb.brush_accel} MINIMUM_CRUISE_RATIO=0.1
+  {% endif %}
 
   G1 Z{bb.brush_top + bb.clearance_z} F{bb.travel_spd_z}
   G1 X{bb.brush_start} F{bb.travel_spd_xy}
@@ -533,7 +544,9 @@ gcode:
 
   # Move nozzle down into brush.
   G1 Z{bb.brush_top} F{bb.travel_spd_z}
-   
+
+  SET_VELOCITY_LIMIT ACCEL={original_accel} MINIMUM_CRUISE_RATIO={original_minimum_cruise_ratio}
+  
   # Perform wipe. Wipe direction based off bucket_pos for cool random scrubby routine.
   {% for wipes in range(1, (bb.wipe_qty + 1)) %}
      G1 X{bb.brush_start + bb.brush_width} F{bb.wipe_spd_xy}
@@ -683,13 +696,6 @@ gcode:
   {% set objects = printer.exclude_object.objects | map(attribute='polygon') %}
 
   {% for polygon in objects %}
-    # {% for i in range(polygon|length) %}
-    #   {% set p = polygon[i] %}
-    #   {% set n = polygon[(i + 1) % (polygon|length)] %}
-    #   {% set d = ((n[0] - p[0])|pow(2) + (n[1] - p[1])|pow(2))|root|abs|round %}
-    #   {% for j in range(d) %}
-    # {% endfor %}
-
     {% for point in polygon %}
       {% if point[0] < tray[0] and point[1] > tray[1] %}
         SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=tray VALUE=False
@@ -771,7 +777,7 @@ gcode:
   {% endif %}
 
   # move up a bit to prevent oozing on base
-  G1 Z2 F{bl.travel_spd_z}
+  G1 Z{bl.shaker_arm_z} F{bl.travel_spd_z}
   # slide into the slot
   G1 X{position_x} F{bl.travel_spd_xy}
 
@@ -834,12 +840,6 @@ gcode:
 [gcode_macro _BLOBIFIER_INIT]
 gcode:
   {% set bl = printer['gcode_macro BLOBIFIER'] %}
-  {% set raise_z_min = (bl.iteration_z_raise - ((bl.max_iterations_per_blob - 1) * (bl.max_iterations_per_blob) / 2) * bl.iteration_z_change) %}
-  
-  # No drop on purging
-  {% if raise_z_min < 0 %} 
-    {action_emergency_stop("BLOBIFIER: Your current blob settings cause the nozzle to drop on the final iteration(s). increase iteration_z_raise or decrease either iteration_z_change or max_iterations_per_blob.")}
-  {% endif %}
 
   # Valid part cooling fan setting
   {% if bl.part_cooling_fan != -1 and (bl.part_cooling_fan < 0 or bl.part_cooling_fan > 1) %}
@@ -851,44 +851,23 @@ gcode:
     {action_emergency_stop("BLOBIFIER: Value %f is invalid for variable bucket_shake_frequency. Change it to a value between 0 .. 1" % (bl.bucket_shake_frequency))}
   {% endif %}  
 
+  # Check if position is on 'next'
   {% if printer.mmu %}
     {% if printer['gcode_macro _MMU_SEQUENCE_VARS'].restore_xy_pos != 'next' %}
       {action_respond_info("BLOBIFIER: If not using a wipe tower, consider setting restore_xy_pos: 'next' in mmu_macro_vars.cfg")}
     {% endif %}
-
-# TODO: These checks are no longer compatible with v2.7.1. Need to rethink
-#    # Blobifier park enabled
-#    {% if printer['gcode_macro _MMU_SEQUENCE_VARS'].user_pre_unload_extension == "BLOBIFIER_PARK" %}
-#
-#      # MMU park is enabled
-#      {% if printer['gcode_macro _MMU_SEQUENCE_VARS'].enable_park %}
-#        {action_respond_info("BLOBIFIER: MMU park is enabled in mmu_macro_vars.cfg. This could interfere with BLOBIFIER_PARK")}
-#
-#        # MMU Park after form tip is enabled
-#        {% if printer['gcode_macro _MMU_SEQUENCE_VARS'].park_after_form_tip %}
-#          {action_respond_info("BLOBIFIER: MMU park_after_form_tip in mmu_macro_vars.cfg is enabled and could interfere with BLOBIFIER_PARK")}
-#        {% endif %}
-#      {% endif %}
-#
-#      # Filametrix installed?
-#      {% if printer.configfile.config.mmu.form_tip_macro == '_MMU_CUT_TIP' %}
-#
-#        # Restore position after CUT disabled
-#        {% if not printer['gcode_macro _MMU_CUT_TIP_VARS'].restore_position %}
-#          {action_respond_info("BLOBIFIER: _MMU_CUT_TIP restore_position in mmu_macro_vars.cfg is disabled, this disables BLOBIFIER_PARK's use")}
-#        {% endif %}
-#
-#        # Tray_top too low
-#        {% if bl.tray_top < 0.2 %}
-#          {action_emergency_stop("BLOBIFIER: Both BLOBIFIER_PARK and _MMU_CUT_TIP are enabled, but the tray_top is too low (< 0.2). This will cause the nozzle to run into the bed during cutting")}
-#        {% endif %}
-#      {% endif %}
-#    
-#    # Blobifier enabled, but Blobifier_park isn't
-#    {% elif printer['gcode_macro _MMU_SEQUENCE_VARS'].user_post_load_extension == 'BLOBIFIER' %}
-#      {action_respond_info("BLOBIFIER: Consider setting user_pre_unload_extension in mmu_macro_vars.cfg to BLOBIFIER_PARK")}
-#    {% endif %}
   {% endif %}
+
+  # Check the z_raise variable for normal values
+  {% if bl.z_raise < 3 %}
+    {action_respond_info("BLOBIFIER: variable_z_raise: %f is very low. This is the value z raises in total on a single blob. Make sure the value is correct before continuing." % (bl.z_raise))}
+  {% endif %}
+
+  # Z raise exponent
+  {% if bl.z_raise_exp > 1 or bl.z_raise_exp < 0.5 %}
+    {action_respond_info("BLOBIFIER: variable_z_raise_exp has value: %f. This value is out of spec (0.5 ... 1.0)." % (bl.z_raise))}
+  {% endif %}
+
 
 
 [delayed_gcode BLOBIFIER_LOAD_STATE]

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -90,7 +90,12 @@ variable_travel_spd_xy:     10000          # Travel (not cleaning) speed along x
                                            #   y-axis in mm/min.
 variable_travel_spd_z:       1000          # Travel (not cleaning) speed along z axis
                                            #   in mm/min.
-variable_wipe_spd_xy:       10000          # Nozzle wipe speed in mm/min.
+variable_wipe_spd_xy: 10000          # Nozzle wipe speed in mm/min.
+
+# The acceleration to use when using the brush action. If set to 0, it uses the already 
+# set acceleration. However, in some cases this is not desirable for the last motion 
+# could be an 'outer contour' acceleration which is usually lower.
+variable_brush_accel: 0
 
 # Blobifier sends the toolhead to the maximum y position during purge oeprations and
 # minimum x position during shake operations. This can cause issues when skew correction 
@@ -121,11 +126,6 @@ variable_brush_start:           67  # For 300mm build
 
 # width of the brush
 variable_brush_width: 35
-
-# The acceleration to use when using the brush action. If set to 0, it uses the already 
-# set acceleration. However, in some cases this is not desirable for the last motion 
-# could be an 'outer contour' acceleration which is usually lower.
-variable_brush_accel: 0
 
 # Location of where to purge. The tray is 15mm in length, so if you assemble it against 
 # the side of the bed (default), 10mm is a good location
@@ -529,6 +529,7 @@ gcode:
   {% set position_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
   {% set original_accel = printer.toolhead.max_accel %}
   {% set original_minimum_cruise_ratio = printer.toolhead.minimum_cruise_ratio %}
+  {% set pos = printer.gcode_move.gcode_position %}
   
   SAVE_GCODE_STATE NAME=BLOBIFIER_CLEAN_state
 
@@ -538,9 +539,12 @@ gcode:
     SET_VELOCITY_LIMIT ACCEL={bb.brush_accel} MINIMUM_CRUISE_RATIO=0.1
   {% endif %}
 
+  {% if pos.z < bb.brush_top + bb.clearance_z %}
   G1 Z{bb.brush_top + bb.clearance_z} F{bb.travel_spd_z}
+  {% endif %}
   G1 X{bb.brush_start} F{bb.travel_spd_xy}
   G1 Y{position_y}
+  G1 Z{bb.brush_top + bb.clearance_z} F{bb.travel_spd_z}
 
   # Move nozzle down into brush.
   G1 Z{bb.brush_top} F{bb.travel_spd_z}

--- a/install.sh
+++ b/install.sh
@@ -794,8 +794,8 @@ read_previous_config() {
     # Blobifer update - Oct 13th 20204
     if [ ! "${variable_iteration_z_raise}" == "" ]; then
         echo -e "${INFO}Setting Blobifier variable_z_raise and variable_purge_length_maximum from previous settings"
-        variable_z_raise=$((variable_iteration_z_raise * variable_max_iterations_per_blob - $(triangular $variable_iteration) * variable_iteration_z_change))
-        variable_purge_length_maximum=$((variable_iteration_z_raise * max_iterations_per_blob))
+        variable_z_raise=$(python -c "print(${variable_iteration_z_raise} * ${variable_max_iterations_per_blob} - $(triangular $((variable_max_iterations_per_blob - 1))) * ${variable_iteration_z_change})")
+        variable_purge_length_maximum=$(python -c "print(${variable_max_iteration_length} * ${variable_max_iterations_per_blob})")
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -791,6 +791,18 @@ read_previous_config() {
         _param_toolhead_residual_filament=$_param_toolhead_ooze_reduction
         _param_toolhead_ooze_reduction=0
     fi
+    # Blobifer update - Oct 13th 20204
+    if [ ! "${variable_iteration_z_raise}" == "" ]; then
+        echo -e "${INFO}Setting Blobifier variable_z_raise and variable_purge_length_maximum from previous settings"
+        variable_z_raise=$((variable_iteration_z_raise * variable_max_iterations_per_blob - $(triangular $variable_iteration) * variable_iteration_z_change))
+        variable_purge_length_maximum=$((variable_iteration_z_raise * max_iterations_per_blob))
+    fi
+}
+
+
+triangular() {
+  local n=$1
+  echo $((n * (n + 1) / 2))
 }
 
 convert_to_boolean_string() {

--- a/install.sh
+++ b/install.sh
@@ -801,8 +801,7 @@ read_previous_config() {
 
 
 triangular() {
-  local n=$1
-  echo $((n * (n + 1) / 2))
+    awk "BEGIN {print ($1 * ($1 + 1)) / 2}"
 }
 
 convert_to_boolean_string() {


### PR DESCRIPTION
## version 1.5
- Purge with a pulsating (and occasionally, retracting) motion. This will prevent laminar flow from occuring and purge the old filament more quicly. (Up to 30% EXTRA filament saved!)
- Changed the blob calculation mode. The blob will now split into equal parts if it is too large (e.g. 2x85mm instead of 150mm + 20mm). This will eliminate/reduce the small blobs scattering over the buildplate.
- Due to the above changes, certain variables have been added and removed:
  - new:
    - `z_raise`: The total amount the nozzle should be raised during a blob. The value should be somewhere around `iteration_z_raise * max_iterations_per_blob - triangular(iteration) * iteration_z_change`
    - `z_raise_exp`: The rate at which the hotend reduces raising speed during a blob. `0.85` seems to be a good starting value.
    - `purge_length_maximum`: The maximum length of the entire purge. Use `max_iterations_per_blob * max_iteration_length`.
  - removed:
    - `iteration_z_raise`
    - `max_iterations_per_blob`
    - `iteration_z_change`
    - `max_iteration_length`
- Revised some parameter checks to work with the new Happy Hare version 2.7
- Add settings:
  - `shaker_arm_z` to allow for different bed/shaker arm heights.
  - `brush_accell` to be able to change the acceleration of the brush movement.
- Keep in mind I do not maintain the `SW Only Blobifier.cfg`