### PR TITLE
Check Extruder Entry sensor during filament position recovery

### DIFF
--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -5284,7 +5284,7 @@ class Mmu:
                     else:
                         es = self._check_sensor(self.ENDSTOP_EXTRUDER_ENTRY)
                         if es is not None and es: # Installed and triggered
-                            self._set_filament_pos_state(self.FILAMENT_POS_EXTRUDER_ENTRY, silent=silent)
+                            self._set_filament_pos_state(self.FILAMENT_POS_HOMED_ENTRY, silent=silent)
                         else:
                             self._set_filament_pos_state(self.FILAMENT_POS_IN_BOWDEN, silent=silent) # This prevents fast unload move
                 else:
@@ -5299,14 +5299,14 @@ class Mmu:
                         else:
                             es = self._check_sensor(self.ENDSTOP_EXTRUDER_ENTRY)
                             if es is not None and es: # Installed and triggered
-                                self._set_filament_pos_state(self.FILAMENT_POS_EXTRUDER_ENTRY, silent=silent)
+                                self._set_filament_pos_state(self.FILAMENT_POS_HOMED_ENTRY, silent=silent)
                             else:
                                 self._set_filament_pos_state(self.FILAMENT_POS_IN_BOWDEN, silent=silent) # Slight risk of it still being gripped by extruder
                                 
                     else:
                         es = self._check_sensor(self.ENDSTOP_EXTRUDER_ENTRY)
                         if es is not None and es: # Installed and triggered
-                            self._set_filament_pos_state(self.FILAMENT_POS_EXTRUDER_ENTRY, silent=silent)
+                            self._set_filament_pos_state(self.FILAMENT_POS_HOMED_ENTRY, silent=silent)
                         else:
                             self._set_filament_pos_state(self.FILAMENT_POS_IN_BOWDEN, silent=silent) # Slight risk of it still being gripped by extruder
                 else:

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -5282,7 +5282,11 @@ class Mmu:
                     if can_heat and self._check_filament_still_in_extruder():
                         self._set_filament_pos_state(self.FILAMENT_POS_IN_EXTRUDER, silent=silent)
                     else:
-                        self._set_filament_pos_state(self.FILAMENT_POS_IN_BOWDEN, silent=silent) # This prevents fast unload move
+                        es = self._check_sensor(self.ENDSTOP_EXTRUDER_ENTRY)
+                        if es is not None and es: # Installed and triggered
+                            self._set_filament_pos_state(self.FILAMENT_POS_EXTRUDER_ENTRY, silent=silent)
+                        else:
+                            self._set_filament_pos_state(self.FILAMENT_POS_IN_BOWDEN, silent=silent) # This prevents fast unload move
                 else:
                     self._set_filament_pos_state(self.FILAMENT_POS_UNLOADED, silent=silent)
             elif ts: # Filament detected in toolhead
@@ -5293,9 +5297,18 @@ class Mmu:
                         if can_heat and self._check_filament_still_in_extruder():
                             self._set_filament_pos_state(self.FILAMENT_POS_EXTRUDER_ENTRY, silent=silent)
                         else:
-                            self._set_filament_pos_state(self.FILAMENT_POS_IN_BOWDEN, silent=silent)
+                            es = self._check_sensor(self.ENDSTOP_EXTRUDER_ENTRY)
+                            if es is not None and es: # Installed and triggered
+                                self._set_filament_pos_state(self.FILAMENT_POS_EXTRUDER_ENTRY, silent=silent)
+                            else:
+                                self._set_filament_pos_state(self.FILAMENT_POS_IN_BOWDEN, silent=silent) # Slight risk of it still being gripped by extruder
+                                
                     else:
-                        self._set_filament_pos_state(self.FILAMENT_POS_IN_BOWDEN, silent=silent) # Slight risk of it still being gripped by extruder
+                        es = self._check_sensor(self.ENDSTOP_EXTRUDER_ENTRY)
+                        if es is not None and es: # Installed and triggered
+                            self._set_filament_pos_state(self.FILAMENT_POS_EXTRUDER_ENTRY, silent=silent)
+                        else:
+                            self._set_filament_pos_state(self.FILAMENT_POS_IN_BOWDEN, silent=silent) # Slight risk of it still being gripped by extruder
                 else:
                     self._set_filament_pos_state(self.FILAMENT_POS_UNLOADED, silent=silent)
 


### PR DESCRIPTION
Update the logic in `_recover_filament_pos` to include a check for the extruder entry endstop. This should help catch cases where a restart left filament past the entry sensor but not yet engaged with the extruder. May also help for devices without a toolhead sensor.

For conditions that would set the position to `FILAMENT_POS_IN_BOWDEN`, now perform a check on the extruder entry endstop and if it is installed and triggered, set the position to `FILAMENT_POS_EXTRUDER_ENTRY` instead of `FILAMENT_POS_IN_BOWDEN`.

Addresses issue #468.
