### PR TITLE
fix: do not require all shared stepper configs (development)

### DIFF
--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -112,7 +112,7 @@ class MmuMachine:
             self.multigear = True
 
             for key in SHAREABLE_STEPPER_PARAMS:
-                if not config.fileconfig.has_option(section, key):
+                if not config.fileconfig.has_option(section, key) and config.fileconfig.has_option(GEAR_STEPPER_CONFIG, key):
                     base_value = config.fileconfig.get(GEAR_STEPPER_CONFIG, key)
                     if base_value:
                         config.fileconfig.set(section, key, base_value)


### PR DESCRIPTION
When configuring a stepper, it technically is not required to configure some things such as gear_ratio when you have a rotation distance configured. In my case I had commented out the gear_ratio, but klipper gave a config error. This just updates so that it checks to see if the base stepper has the setting before trying to read it.