### PR TITLE
feat(addon-respooler): update respooler to combine main logic into a single macro

### DIFF
--- a/config/addons/README.md
+++ b/config/addons/README.md
@@ -52,7 +52,8 @@ An addon used to control a DC motor based respooler that is active when the MMU 
 
 ### Config
 1. Add `[include mmu/addons/respooler.cfg]` to your `printer.cfg`
-1. Set `variable_user_pre_unload_extension : "_MMU_RESPOOL_START"` in `mmu_macro_vars.cfg` to start respooler movement
-1. Set `variable_user_post_unload_extension : "_MMU_RESPOOL_STOP"` in `mmu_macro_vars.cfg` to stop respooler movement
+1. Set `variable_user_pre_unload_extension : "MMU_RESPOOLER_START"` in `mmu_macro_vars.cfg` to start respooler movement
+1. Set `variable_user_post_unload_extension : "MMU_RESPOOLER_STOP"` in `mmu_macro_vars.cfg` to stop respooler movement
+1. Set `variable_user_mmu_error_extension : "MMU_RESPOOLER_STOP"` in `mmu_macro_vars.cfg` to stop respooler movement on error
 
 <hr>

--- a/config/addons/respooler.cfg
+++ b/config/addons/respooler.cfg
@@ -1,4 +1,29 @@
+###########################################################################
+# Default respooler variables
+#
+# Please do not edit these. To change/override please set them in 
+# your respooler_hw.cfg
+#
+[gcode_macro _MMU_RESPOOLER_VARS]
+# Default max number of seconds for respooler to run
+# Note: Each time any respooler **starts** it will restart the timeout
+variable_default_timeout: 60
+
+# Prefix of name of the `output_pin` for the respooler.
+# The `output_pin` name must follow the pattern {prefix}_rwd_{gate}
+# and {prefix}_en_{gate}.
+variable_pin_prefix: 'mmu_dc_respooler'
+
+# Internal variable for tracking the gates with respoolers
+variable_respooler_gates: ''
+gcode: # Leave empty
+
+###########################################################################
 # Include DC motor pin definitions
+#
+# This should be after the respooler vars macro to ensure the users
+# custom vars override our default ones.
+#
 [include respooler_hw.cfg]
 
 ###########################################################################
@@ -6,40 +31,117 @@
 #
 # Easiest integration is to set this in mmu_macro_vars.cfg:
 #
-#  variable_user_pre_unload_extension    : '_MMU_RESPOOL_START'
+#  variable_user_pre_unload_extension    : 'MMU_RESPOOLER_START'
 #
-[gcode_macro _MMU_RESPOOL_START]
+[gcode_macro MMU_RESPOOLER_START]
 gcode:
-    {% set current_gate = printer['mmu'].gate %}
-    {% set gate = params.GATE|default(current_gate)|int %}
     {% set speed = params.SPEED|default(1)|float %}
-    {% set pin = 'respooler_rwd_%s' % gate %}
+    _MMU_RESPOOLER_CTL {rawparams} SPEED={speed}
 
-    {% if gate < 0 %}
-        RESPOND TYPE=error MSG="No active gate. Cannot start respooler."
-    {% elif not printer['output_pin %s' % pin] %}
-        RESPOND TYPE=error MSG="output_pin {pin} does not exist. Cannot start respooler."
-    {% else %}
-        SET_PIN PIN="{pin}" value="{speed}"
-    {% endif %}
+    # Param hints UI
+    {% set dummy = None if True else "
+    {% set d = params.GATE|default(current_gate)|int %}
+    {% set d = params.SCALE|default(cfg_scale)|float %}
+    {% set d = params.TIMEOUT|default(default_timeout)|float %}
+    " %} # End param hints for UI
+
 
 ###########################################################################
 # Macro to stop the DC respooler motor
 #
 # Easiest integration is to set this in mmu_macro_vars.cfg:
 #
-#  variable_user_post_unload_extension    : '_MMU_RESPOOL_STOP'
+#  variable_user_post_unload_extension    : 'MMU_RESPOOLER_STOP'
+#  variable_user_mmu_error_extension      : 'MMU_RESPOOLER_STOP'
 #
-[gcode_macro _MMU_RESPOOL_STOP]
+[gcode_macro MMU_RESPOOLER_STOP]
 gcode:
+    _MMU_RESPOOLER_CTL {rawparams} SPEED={0}
+    
+    # Param hints UI
+    {% set dummy = None if True else "
+    {% set d = params.GATE|default(current_gate)|int %}
+    " %} # End param hints for UI
+
+###########################################################################
+# Macro to control the DC respooler motor
+#
+# Used by both the start and stop respooler macros
+#
+[gcode_macro _MMU_RESPOOLER_CTL]
+gcode:
+    {% set vars = printer["gcode_macro _MMU_RESPOOLER_VARS"] %}
     {% set current_gate = printer['mmu'].gate %}
     {% set gate = params.GATE|default(current_gate)|int %}
-    {% set pin = 'respooler_rwd_%s' % gate %}
+    {% set speed = params.SPEED|default(1)|float %}
+    {% set pin_prefix = vars.pin_prefix %}
+    {% set pin = '%s_rwd_%d' % (pin_prefix, gate) %}
+    {% set en_pin = ('%s_en_%d' % (pin_prefix, gate)) if printer['output_pin %s_en_%d' % (pin_prefix, gate)] else None %}
+    {% set pin_cfg = 'output_pin %s' % pin %}
+    {% set default_timeout = vars.default_timeout %}
+    {% set timeout = params.TIMEOUT|default(default_timeout)|float %}
 
     {% if gate < 0 %}
-        RESPOND TYPE=error MSG="No active gate. Cannot stop respooler."
-    {% elif not printer['output_pin %s' % pin] %}
-        RESPOND TYPE=error MSG="output_pin {pin} does not exist. Cannot stop respooler."
+        RESPOND TYPE=error MSG="No active gate. Cannot start respooler."
+    {% elif not printer[pin_cfg] %}
+        RESPOND TYPE=error MSG="{pin_cfg} does not exist. Cannot start respooler."
     {% else %}
-        SET_PIN PIN="{pin}" value="0"
+        {% set cfg_scale = printer.configfile.settings[pin_cfg].scale|default(1)|float %}
+        {% set scale = params.SCALE|default(cfg_scale)|float %}
+        {% if en_pin and speed > 0 %}
+            SET_PIN PIN="{en_pin}" value="{1}"
+        {% endif %}
+
+        SET_PIN PIN="{pin}" value="{speed * cfg_scale * scale}"
+
+        {% if timeout > 0 and speed > 0 and printer[pin_cfg].value == 0 %}
+            UPDATE_DELAYED_GCODE ID=mmu_respooler_timeout DURATION={timeout}
+        {% elif speed == 0 %}
+            # Cancel delayed gcode...if all are turned off
+            {% set values = [] %}
+            {% for igate in (vars.respooler_gates) %}
+                {% set value = printer['output_pin %s_rwd_%d' % (pin_prefix, igate)].value %}
+                {% set value = 0 if (igate == gate or value == 0) else value %}
+                {% set d = values.append(value) %}
+            {% endfor %}
+            {% if values|sum == 0 %}
+                UPDATE_DELAYED_GCODE ID=mmu_respooler_timeout DURATION=0
+            {% endif %}
+        {% endif %}
+
+        {% if en_pin and speed == 0 %}
+            SET_PIN PIN="{en_pin}" value="{0}"
+        {% endif %}
     {% endif %}
+
+###########################################################################
+# Delayed gcode to run on startup to identify all the respoolers which
+# will be used after respooler timeout to ensure all respoolers have
+# stopped.
+#
+[delayed_gcode mmu_respooler_startup]
+initial_duration: 1.
+gcode:
+    {% set vars = printer["gcode_macro _MMU_RESPOOLER_VARS"] %}
+    {% set pin_prefix = vars.pin_prefix %}
+    {% set pin_cfg_prefix = 'output_pin %s_rwd_' % pin_prefix %}
+    {% set respooler_gates = [] %}
+    {% for key in printer %}
+        {% if key.startswith(pin_cfg_prefix) %}
+            {% set gate = key | replace(pin_cfg_prefix, '') | int %}
+            {% set d = respooler_gates.append(gate | string) %}
+        {% endif %}
+    {% endfor %}
+    SET_GCODE_VARIABLE MACRO=_MMU_RESPOOLER_VARS VARIABLE=respooler_gates VALUE={respooler_gates|join(',')}
+
+###########################################################################
+# Delayed gcode to stop all respooler after timeout. This is used as a 
+# failsafe (unless explicitly disabled by setting a timeout of 0) to ensure
+# the respoolers do not run indefinitely.
+#
+[delayed_gcode mmu_respooler_timeout]
+gcode:
+    {% set vars = printer["gcode_macro _MMU_RESPOOLER_VARS"] %}
+    {% for gate in (vars.respooler_gates) %}
+        MMU_RESPOOLER_STOP GATE={gate}
+    {% endfor %}

--- a/config/addons/respooler_hw.cfg
+++ b/config/addons/respooler_hw.cfg
@@ -1,22 +1,91 @@
-##########################################################################################
-# Define the pins for DC motor based respooler. Create a section for each gate of your MMU
-# 
-[output_pin respooler_rwd_0]
+###########################################################################################
+# Define the pins for DC motor based respooler. Create a section for each gate of your MMU.
+#
+# With pwm enabled, setting the scale parameter (between 0.0 and 1.0) to adjust the top
+# speed of the respooler.
+#
+# Some setups may require an "enable" pin to activate the motor driver. Uncomment those
+# pins as needed for each gate.
+#
+# See https://www.klipper3d.org/Config_Reference.html#output_pin
+#
+
+####################################
+# Variables for the respooler macros
+#
+# Configure these for your setup.
+#
+[gcode_macro _MMU_RESPOOLER_VARS]
+# Default max number of seconds for respooler to run
+# Note: Each time any respooler **starts** it will restart the timeout
+variable_default_timeout: 60
+
+# Prefix of name of the `output_pin` for the respooler.
+# The `output_pin` name must follow the pattern {prefix}_rwd_{gate}
+# and {prefix}_en_{gate}.
+variable_pin_prefix: 'mmu_dc_respooler'
+gcode: # Leave empty
+
+##################
+# Gate 0 respooler
+#
+
+# Rewind pin
+[output_pin mmu_dc_respooler_rwd_0]
 pin: mmu:MMU_DC_MOT_1_A
-pwm: True
 value: 0
+pwm: True
+scale: 1
 
-[output_pin respooler_rwd_1]
+# Enable pin
+# [output_pin mmu_dc_respooler_en_0]
+# pin: mmu:MMU_DC_MOT_1_EN
+# value: 0
+
+##################
+# Gate 1 respooler
+#
+
+# Rewind pin
+[output_pin mmu_dc_respooler_rwd_1]
 pin: mmu:MMU_DC_MOT_2_A
-pwm: True
 value: 0
+pwm: True
+scale: 1
 
-[output_pin respooler_rwd_2]
+# Enable pin
+# [output_pin mmu_dc_respooler_en_1]
+# pin: mmu:MMU_DC_MOT_2_EN
+# value: 0
+
+##################
+# Gate 2 respooler
+#
+
+# Rewind pin
+[output_pin mmu_dc_respooler_rwd_2]
 pin: mmu:MMU_DC_MOT_3_A
-pwm: True
 value: 0
+pwm: True
+scale: 1
 
-[output_pin respooler_rwd_3]
+# Enable pin
+# [output_pin mmu_dc_respooler_en_2]
+# pin: mmu:MMU_DC_MOT_3_EN
+# value: 0
+
+##################
+# Gate 3 respooler
+#
+
+# Rewind pin
+[output_pin mmu_dc_respooler_rwd_3]
 pin: mmu:MMU_DC_MOT_4_A
-pwm: True
 value: 0
+pwm: True
+scale: 1
+
+# Enable pin
+# [output_pin mmu_dc_respooler_en_3]
+# pin: mmu:MMU_DC_MOT_4_EN
+# value: 0


### PR DESCRIPTION
This updates the respooler addon with the following:

* Reduce code duplication by combining start and stop in one "hidden" macro and then exposing start and stop macros
* Add support for an enable pin that is turned on before starting the motor and turned off after turning off a motor. Note: My setup does not currently have this, so I have not tested this yet.
* Added delayed gcode stuff to automatically stop respoolers after a given amount of time. This is just a precaution to prevent the respooler from running indefinitely. The timeout is configureable, but defaults to 60s.