### PR TITLE
Minor changes to z-hop min floor logic & Prusa style stamping option for tip forming

### DIFF
--- a/config/base/mmu_form_tip.cfg
+++ b/config/base/mmu_form_tip.cfg
@@ -58,6 +58,7 @@ gcode:
     {% set parking_distance = vars['parking_distance']|default(0)|float %}
     {% set orig_temp = printer.extruder.target %}
     {% set next_temp = params.NEXT_TEMP|default(orig_temp)|int %}
+    
     {% set use_stamping = vars['use_stamping']|default(false)|lower == 'true' %}
     {% set stamping_distance = vars['stamping_distance']|float %}
     {% set stamping_insertion_speed = vars['stamping_insertion_speed']|int %}
@@ -71,6 +72,11 @@ gcode:
     G91 # Relative positioning
     M83 # Relative extrusion
     G92 E0
+
+    # undo HH retract for tip forming
+    {% if park_vars.retracted_length > 0 %}
+        _MMU_UNRETRACT
+    {% endif %}
 
     # Step 1 - Ramming
     # This is very generic and unlike slicer does not incorporate moves on the wipetower
@@ -96,12 +102,19 @@ gcode:
 
     # Step 2 - Retraction / Nozzle Separation
     # This is where the tip spear shape comes from. Faster=longer/pointer/higher stringing
-    {% set total_retraction_distance = cooling_tube_position - printer.mmu.extruder_filament_remaining - park_vars.retracted_length + cooling_tube_length - 15 %}
-    G1 E-15 F{1.0 * unloading_speed_start * 60} # Fixed default value from SS
-    {% if total_retraction_distance > 0 %}
-        G1 E-{(0.7 * total_retraction_distance)|round(2)} F{1.0 * unloading_speed * 60}
-        G1 E-{(0.2 * total_retraction_distance)|round(2)} F{0.5 * unloading_speed * 60}
-        G1 E-{(0.1 * total_retraction_distance)|round(2)} F{0.3 * unloading_speed * 60}
+    ;{% set total_retraction_distance = cooling_tube_position - printer.mmu.extruder_filament_remaining - park_vars.retracted_length + cooling_tube_length - 15 %}
+    ;{% set total_retration_distance = cooling_tube_position|float + cooling_tube_length|float / 2 - 15 - park_vars.retracted_length %}
+    {% set retract = cooling_tube_position + cooling_tube_length / 2 - 15 %}
+    {% set adjust = (0 if retract >= 0 else retract|abs) %}
+
+    G1 E-15 F{1.0 * unloading_speed_start * 60} # Fixed default value from SS/Orca
+
+    {% if retract > 0 %}
+        G1 E-{(0.7 * retract)|round(2)} F{1.0 * unloading_speed * 60}
+        G1 E-{(0.2 * retract)|round(2)} F{0.5 * unloading_speed * 60}
+        G1 E-{(0.1 * retract)|round(2)} F{0.3 * unloading_speed * 60}
+    {% else %}
+        { action_respond_info('mmu_form_tip: Top of cooling tube is %.1fmm below min slicer 15mm retraction. Increase to %.1fmm.' % (retract, cooling_tube_position + adjust)) }
     {% endif %}
 
     # Set toolchange temperature just prior to cooling moves (not fast skinnydip mode)
@@ -112,15 +125,18 @@ gcode:
         {% endif %}
     {% endif %}
 
-    # Step 3 - Cooling Moves
+    # Step 3 - Cooling and optional Prusa style stamping moves
     # Solidifies tip shape and helps break strings if formed. Stamping uses separate stamping_insertion_speed and unloading_speed_start to extract
+    # NOTE - Stamping measurement is from the cooling tube position (centre) so needs to be adjusted to top of cooling tube
+
     {% set speed_inc = (final_cooling_speed - initial_cooling_speed) / (2 * cooling_moves - 1) %}
     {% for move in range(cooling_moves) %}
+
         {% if move > 0 and use_stamping == true and stamping_distance > 0 and stamping_insertion_speed > 0 %}
-           G1 E{stamping_distance} F{stamping_insertion_speed * 60}
-           G1 E-{stamping_distance} F{unloading_speed_start * 60}
+           G1 E{stamping_distance + cooling_tube_length / 2 + adjust} F{stamping_insertion_speed * 60}
+           G1 E-{stamping_distance + cooling_tube_length / 2 + adjust} F{stamping_insertion_speed * 60}
         {% endif %}
-        
+
         {% set speed = initial_cooling_speed + speed_inc * move * 2 %}
         G1 E{cooling_tube_length} F{speed * 60}
         G1 E-{cooling_tube_length} F{(speed + speed_inc) * 60}
@@ -134,9 +150,9 @@ gcode:
     # Step 4 - Skinnydip
     # Burns off very fine hairs (Good for PLA)
     {% if use_skinnydip %}
-        G1 E{skinnydip_distance} F{dip_insertion_speed * 60}
+        G1 E{skinnydip_distance - adjust} F{dip_insertion_speed * 60}
         G4 P{melt_zone_pause}
-        G1 E-{skinnydip_distance} F{dip_extraction_speed * 60}
+        G1 E-{skinnydip_distance - adjust} F{dip_extraction_speed * 60}
         G4 P{cooling_zone_pause}
     {% endif %}
 

--- a/config/base/mmu_form_tip.cfg
+++ b/config/base/mmu_form_tip.cfg
@@ -102,10 +102,8 @@ gcode:
 
     # Step 2 - Retraction / Nozzle Separation
     # This is where the tip spear shape comes from. Faster=longer/pointer/higher stringing
-    ;{% set total_retraction_distance = cooling_tube_position - printer.mmu.extruder_filament_remaining - park_vars.retracted_length + cooling_tube_length - 15 %}
-    ;{% set total_retration_distance = cooling_tube_position|float + cooling_tube_length|float / 2 - 15 - park_vars.retracted_length %}
     {% set retract = cooling_tube_position + cooling_tube_length / 2 - 15 %}
-    {% set adjust = (0 if retract >= 0 else retract|abs) %}
+    {% set adjust = (0 if retract >= 0 else retract|abs) %} ; adjust extrusion distances incase top of cooling zone < minimum slice retract distance
 
     G1 E-15 F{1.0 * unloading_speed_start * 60} # Fixed default value from SS/Orca
 

--- a/config/base/mmu_form_tip.cfg
+++ b/config/base/mmu_form_tip.cfg
@@ -102,9 +102,9 @@ gcode:
     # Step 2 - Retraction / Nozzle Separation
     # This is where the tip spear shape comes from. Faster=longer/pointer/higher stringing
     {% set retract = cooling_tube_position + cooling_tube_length / 2 - 15 %}
-    {% set adjust = (0 if retract >= 0 else retract|abs) %} ; adjust extrusion distances incase top of cooling zone < minimum slice retract distance
+    {% set adjust = (0 if retract >= 0 else retract|abs) %} ; adjust extrusion distances incase top of cooling zone < minimum slicer retract distance
 
-    G1 E-15 F{1.0 * unloading_speed_start * 60} # Fixed default value from SS/Orca
+    G1 E-15 F{1.0 * unloading_speed_start * 60} # Fixed default value from SS/Orca/Prusa
 
     {% if retract > 0 %}
         G1 E-{(0.7 * retract)|round(2)} F{1.0 * unloading_speed * 60}

--- a/config/base/mmu_form_tip.cfg
+++ b/config/base/mmu_form_tip.cfg
@@ -58,6 +58,9 @@ gcode:
     {% set parking_distance = vars['parking_distance']|default(0)|float %}
     {% set orig_temp = printer.extruder.target %}
     {% set next_temp = params.NEXT_TEMP|default(orig_temp)|int %}
+    {% set use_stamping = vars['use_stamping']|default(false)|lower == 'true' %}
+    {% set stamping_distance = vars['stamping_distance']|float %}
+    {% set stamping_insertion_speed = vars['stamping_insertion_speed']|int %}
 
     # Useful state for customizing operations depending on mode
     {% set runout = printer.mmu.runout %}
@@ -110,9 +113,14 @@ gcode:
     {% endif %}
 
     # Step 3 - Cooling Moves
-    # Solidifies tip shape and helps break strings if formed
+    # Solidifies tip shape and helps break strings if formed. Stamping uses separate stamping_insertion_speed and unloading_speed_start to extract
     {% set speed_inc = (final_cooling_speed - initial_cooling_speed) / (2 * cooling_moves - 1) %}
     {% for move in range(cooling_moves) %}
+        {% if move > 0 and use_stamping == true and stamping_distance > 0 and stamping_insertion_speed > 0 %}
+           G1 E{stamping_distance} F{stamping_insertion_speed * 60}
+           G1 E-{stamping_distance} F{unloading_speed_start * 60}
+        {% endif %}
+        
         {% set speed = initial_cooling_speed + speed_inc * move * 2 %}
         G1 E{cooling_tube_length} F{speed * 60}
         G1 E-{cooling_tube_length} F{(speed + speed_inc) * 60}

--- a/config/base/mmu_form_tip.cfg
+++ b/config/base/mmu_form_tip.cfg
@@ -47,8 +47,8 @@ gcode:
     {% set final_cooling_speed = vars['final_cooling_speed']|int %}
     {% set cooling_moves = vars['cooling_moves']|int %}
     {% set toolchange_temp = vars['toolchange_temp']|default(0)|int %}
-    {% set use_skinnydip = vars['use_skinnydip']|default(false)|lower == 'true' %}
-    {% set use_fast_skinnydip = vars['use_fast_skinnydip']|default(false)|lower == 'true' %}
+    {% set use_skinnydip = vars['use_skinnydip']|default(false)|lower %}
+    {% set use_fast_skinnydip = vars['use_fast_skinnydip']|default(false)|lower %}
     {% set skinnydip_distance = vars['skinnydip_distance']|float %}
     {% set dip_insertion_speed = vars['dip_insertion_speed']|int %}
     {% set dip_extraction_speed = vars['dip_extraction_speed']|int %}
@@ -58,8 +58,7 @@ gcode:
     {% set parking_distance = vars['parking_distance']|default(0)|float %}
     {% set orig_temp = printer.extruder.target %}
     {% set next_temp = params.NEXT_TEMP|default(orig_temp)|int %}
-    
-    {% set use_stamping = vars['use_stamping']|default(false)|lower == 'true' %}
+    {% set use_stamping = vars['use_stamping']|default(false)|lower %}
     {% set stamping_distance = vars['stamping_distance']|float %}
     {% set stamping_insertion_speed = vars['stamping_insertion_speed']|int %}
 

--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -424,7 +424,10 @@ variable_cooling_tube_position  : 35		; Start of cooling tube. DragonST:35, Drag
 variable_cooling_tube_length    : 10		; Movement length. DragonST:15, DragonHF:10, Mosquito:20, Revo:10, RapidoHF:10
 variable_initial_cooling_speed  : 10		; Inital slow movement (mm/s) to solidify tip and cool string if formed
 variable_final_cooling_speed    : 50		; Fast movement (mm/s) Too fast: tip deformation on eject, Too Slow: long string/no seperation
-variable_cooling_moves          : 4		; Number of back and forth cooling moves to make (2-4 is a good start)
+variable_cooling_moves          : 4		  ; Number of back and forth cooling moves to make (2-4 is a good start)
+variable_use_stamping           : False ; Incorporate Prusa stamping moves into the cooling process
+variable_stamping_distance      : 0     ; Distance to reinsert filament into the hotend from the top of the cooling tube
+variable_stamping_insertion_speed : 0   ; Speed mm/s for stamping move. Filament extracted using unloading_speed_start
 
 # Step 4 - Skinnydip
 # Skinnydip is an advanced final move that may have benefit with some

--- a/config/base/mmu_sequence.cfg
+++ b/config/base/mmu_sequence.cfg
@@ -121,10 +121,10 @@ gcode:
     {% endif %}
     {% set park_z_hop = park_z_hop|abs %}
     {% set z_hop_ramp = z_hop_ramp|abs %}
-    {% if x == -1 and y == -1 and park_z_hop == 0 %} ; if not parking/moving, dont set z-hop floor 
+    {% if x == -1 and y == -1 and park_z_hop == 0 %} ; if not parking/moving, dont set min z-hop floor 
         {% set min_toolchange_z = 0 %}
     {% else %}
-      {% set min_toolchange_z = vars.min_toolchange_z|default(1)|float|abs %}
+        {% set min_toolchange_z = vars.min_toolchange_z|default(0)|float|abs %}
     {% endif %}                                       
     {% set park_travel_speed = vars.park_travel_speed|default(200)|float * 60 %}
     {% set lift_speed = vars.lift_speed|default(15)|float * 60 %}

--- a/config/base/mmu_sequence.cfg
+++ b/config/base/mmu_sequence.cfg
@@ -121,7 +121,11 @@ gcode:
     {% endif %}
     {% set park_z_hop = park_z_hop|abs %}
     {% set z_hop_ramp = z_hop_ramp|abs %}
-    {% set min_toolchange_z = vars.min_toolchange_z|default(1)|float|abs %}
+    {% if x == -1 and y == -1 and park_z_hop == 0 %} ; if not parking/moving, dont set z-hop floor 
+        {% set min_toolchange_z = 0 %}
+    {% else %}
+      {% set min_toolchange_z = vars.min_toolchange_z|default(1)|float|abs %}
+    {% endif %}                                       
     {% set park_travel_speed = vars.park_travel_speed|default(200)|float * 60 %}
     {% set lift_speed = vars.lift_speed|default(15)|float * 60 %}
     {% set pos = printer.gcode_move.gcode_position %}


### PR DESCRIPTION
Suppressed z-hop min floor when park moves aren't defined for the mmu sequence to keep nozzle on purge block during toolchange.  e.g. when the user has used ``variable_park_toolchange : -1,-1, 0, 0, 2`` 

Also incorporated Prusa style stamping moves as part of tip form macro in cooling move loop (only stamps on even moves). Controlled using 3 variables: ``use_stamping`` (``true`` | ``false``), ``stamping_insertion_distance`` mm & ``stamping_insertion_speed``.  Currently using ``unloading_speed_start`` value for the retraction rather than creating another parameter.  Need to check and review move offsets as ``stamping_insertion_distance`` "should" technically be from the middle of the cooling tube according to Prusa slicer  

Still testing so not ready to merge.

Fixes #486 