### PR TITLE
fix: return the selected gate from select_gate

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -5431,11 +5431,12 @@ class Mmu:
 
     def select_gate(self, gate):
         #self.log_error("PAUL TEMP: select_gate(%s)%s" % (gate, " - NO-OP" if gate == self.gate_selected else ""))
-        if gate == self.gate_selected: return
+        if gate == self.gate_selected: return gate
         try:
             self._next_gate = gate # Valid only during the gate selection process
             self.selector.select_gate(gate)
             self._set_gate_selected(gate)
+            return gate
         except MmuError as ee:
             self.unselect_gate()
             raise ee


### PR DESCRIPTION
Looks like [recent changes](https://github.com/moggieuk/Happy-Hare/commit/7e608f49848be5cc7cf24a301b18c0517e60fa54#diff-47f1fc0c56dacae8e98e2ec82af6b3a5996edf5c9560d6078e4291eb1cf0ddefR3815) to the preload (and eject) code expects this to return the gate number. Without this, we get crashes because gate ends up becoming `None`