### PR TITLE
Move retract to directly after the blob.

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -470,6 +470,9 @@ gcode:
           
         {% endfor %}
 
+        # Retract to match what Happy Hare is expecting
+        G1 E-{park_vars.retracted_length} F{sequence_vars.retract_speed * 60}
+        
         # ==================================================================================
         # ==================== DEPOSIT BLOB ================================================
         # ==================================================================================
@@ -512,9 +515,6 @@ gcode:
     {% endif %}
     
     M220 S{(backup_feedrate * 100)|int}
-
-    # Final retract to match what Happy Hare is expecting
-    G1 E-{park_vars.retracted_length} F{sequence_vars.retract_speed * 60}
   {% endif %}
   
   RESTORE_GCODE_STATE NAME=BLOBIFIER_state 


### PR DESCRIPTION
Moved the final retract to the end of the blob, before the z-lift.  Cuts the blob off cleanly, instead of leaving a string on it. This means the blobs separate cleanly in the bucket instead of all tangling together.

My initial testing shows this works better.

I will do some more testing on this and see how it goes, but also released here so others can review it. Overall it makes sense to me to do it this way.