### PR TITLE
feat: Update respooler addon to support variable speed and distance filtering

### DIFF
--- a/config/addons/README.md
+++ b/config/addons/README.md
@@ -52,8 +52,8 @@ An addon used to control a DC motor based respooler that is active when the MMU 
 
 ### Config
 1. Add `[include mmu/addons/dc_respooler.cfg]` to your `printer.cfg`
-1. Set `variable_user_pre_unload_extension : "MMU_RESPOOLER_START"` in `mmu_macro_vars.cfg` to start respooler movement
-1. Set `variable_user_post_unload_extension : "MMU_RESPOOLER_STOP"` in `mmu_macro_vars.cfg` to stop respooler movement
-1. Set `variable_user_mmu_error_extension : "MMU_RESPOOLER_STOP"` in `mmu_macro_vars.cfg` to stop respooler movement on error
+1. Set `respooler_start_macro: MMU_RESPOOLER_START` in `mmu_parameters.cfg` to start respooler movement
+1. Set `respooler_stopt_macro: MMU_RESPOOLER_STOP` in `mmu_parameters.cfg` to stop respooler movement
+1. Update the `mmu/addon/dc_respooler_hw.cfg` for your configuration.
 
 <hr>

--- a/config/addons/dc_respooler.cfg
+++ b/config/addons/dc_respooler.cfg
@@ -29,9 +29,9 @@ gcode: # Leave empty
 ###########################################################################
 # Macro to actuate the correct DC motor for the gate being unloaded
 #
-# Easiest integration is to set this in mmu_macro_vars.cfg:
+# Easiest integration is to set this in mmu_parameters.cfg:
 #
-#  variable_user_pre_unload_extension    : 'MMU_RESPOOLER_START'
+#  respooler_start_macro: MMU_RESPOOLER_START
 #
 [gcode_macro MMU_RESPOOLER_START]
 gcode:
@@ -51,8 +51,7 @@ gcode:
 #
 # Easiest integration is to set this in mmu_macro_vars.cfg:
 #
-#  variable_user_post_unload_extension    : 'MMU_RESPOOLER_STOP'
-#  variable_user_mmu_error_extension      : 'MMU_RESPOOLER_STOP'
+#  respooler_stop_macro: MMU_RESPOOLER_STOP
 #
 [gcode_macro MMU_RESPOOLER_STOP]
 gcode:

--- a/config/addons/dc_respooler.cfg
+++ b/config/addons/dc_respooler.cfg
@@ -12,7 +12,7 @@ variable_default_timeout: 60
 # Prefix of name of the `output_pin` for the respooler.
 # The `output_pin` name must follow the pattern {prefix}_rwd_{gate}
 # and {prefix}_en_{gate}.
-variable_pin_prefix: 'mmu_dc_respooler'
+variable_pin_prefix: '_mmu_dc_respooler'
 
 # Internal variable for tracking the gates with respoolers
 variable_respooler_gates: ''

--- a/config/addons/dc_respooler.cfg
+++ b/config/addons/dc_respooler.cfg
@@ -5,14 +5,48 @@
 # your respooler_hw.cfg
 #
 [gcode_macro _MMU_RESPOOLER_VARS]
-# Default max number of seconds for respooler to run
-# Note: Each time any respooler **starts** it will restart the timeout
-variable_default_timeout: 60
-
 # Prefix of name of the `output_pin` for the respooler.
 # The `output_pin` name must follow the pattern {prefix}_rwd_{gate}
-# and {prefix}_en_{gate}.
+# and {prefix}_en_{gate}. By default we prefix it with an underscore
+# to prevent them from being shown in UI applications (like mainsail).
+#
 variable_pin_prefix: '_mmu_dc_respooler'
+
+# Default max number of seconds for respooler to run
+# Note: Each time any respooler **starts** it will restart the timeout
+#
+variable_default_timeout: 60
+
+# The step speed where you want to max out the respooler to run at full speed.
+#
+variable_max_step_speed: 50
+
+# Minimum distance of a move required to activate the respooler
+# The lowest valid value for this is 50 because respooler macros
+# will not even be considered if the distance is less than 50.
+#
+variable_min_distance: 100
+
+# Adjusts the speed conversion ratio
+# For the following examples, let's assume max_step_speed = 50.
+# And remember actual respooler speed values are between 0.0 (off) and 1.0 (full speed) (inclusive)
+#
+# The forumula looks like this:
+# ({step_speed} / {max_step_speed}) ^ {step_speed_exponent}
+#
+# With step_speed_exponent of 1 would have a linear ratio:
+# If I am running with a step speed of 50mm/s, the respooler would run at full speed (1.0)
+# Calculated via (50/50)^1
+# If I am running with a step speed of 25mm/s, the respooler would run at half speed (0.5)
+# Calculated via (25/50)^1
+#
+# With step_speed_exponent of 0.2 would have a linear ratio:
+# If I am running with a step speed of 50mm/s, the respooler would run at full speed (1.0)
+# Calculated via (50/50)^0.2
+# If I am running with a step speed of 25mm/s, the respooler would run at half speed (0.87)
+# Calculated via (25/50)^0.2
+#
+variable_step_speed_exponent: 1
 
 # Internal variable for tracking the gates with respoolers
 variable_respooler_gates: ''
@@ -35,8 +69,7 @@ gcode: # Leave empty
 #
 [gcode_macro MMU_RESPOOLER_START]
 gcode:
-    {% set speed = params.SPEED|default(1)|float %}
-    _MMU_RESPOOLER_CTL {rawparams} SPEED={speed}
+    _MMU_RESPOOLER_CTL {rawparams}
 
     # Param hints UI
     {% set dummy = None if True else "
@@ -72,18 +105,41 @@ gcode:
     {% set vars = printer["gcode_macro _MMU_RESPOOLER_VARS"] %}
     {% set current_gate = printer['mmu'].gate %}
     {% set gate = params.GATE|default(current_gate)|int %}
-    {% set speed = params.SPEED|default(1)|float %}
+    {% set step_speed = params.STEP_SPEED|default(-1)|float %}
+    {% set expected_distance = params.MAX_DISTANCE|default(-1)|float %}
+    {% set homing_move = params.HOMING_MOVE|default(0)|int %}
+    {% set speed = params.SPEED|default(-1)|float %}
     {% set pin_prefix = vars.pin_prefix %}
-    {% set pin = '%s_rwd_%d' % (pin_prefix, gate) %}
+    {% set pin = ('%s_rwd_%d' % (pin_prefix, gate)) if printer['output_pin %s_rwd_%d' % (pin_prefix, gate)] else None %}
     {% set en_pin = ('%s_en_%d' % (pin_prefix, gate)) if printer['output_pin %s_en_%d' % (pin_prefix, gate)] else None %}
-    {% set pin_cfg = 'output_pin %s' % pin %}
+    {% set pin_cfg = ('output_pin %s' % pin) if pin else None %}
+    {% set pwm = (printer.configfile.settings[pin_cfg].scale) if pin_cfg else False %}
     {% set default_timeout = vars.default_timeout %}
     {% set timeout = params.TIMEOUT|default(default_timeout)|float %}
 
+    # Convert speed
+    {% if speed < 0 and step_speed >= 0 %}
+        # determine speed from step speed
+        {% if not pwm %}
+            # TODO: something special for long slow (tbd) moves? 
+            #       delayed start so it runs after the stepper has run for a little bit?
+            #       or just don't run on long slow moves?
+            {% set speed = 1 %}
+        {% elif step_speed > vars.max_step_speed %}
+            {% set speed = 1 %}
+        {% else %}
+            {% set speed = step_speed / vars.max_step_speed %}
+        {% endif %}
+    {% elif speed < 0 %}
+        {% set speed = 1 %}
+    {% endif %}
+
     {% if gate < 0 %}
         RESPOND TYPE=error MSG="No active gate. Cannot start respooler."
-    {% elif not printer[pin_cfg] %}
+    {% elif not pin %}
         RESPOND TYPE=error MSG="{pin_cfg} does not exist. Cannot start respooler."
+    {% elif expected_distance >= 0 and expected_distance < vars.min_distance %}
+        MMU_LOG DEBUG=1 MSG="Travel distance ({expected_distance}) is shorter than the configured min distance ({vars.min_distance}). Ignoring respooler activation."
     {% else %}
         {% set cfg_scale = printer.configfile.settings[pin_cfg].scale|default(1)|float %}
         {% set scale = params.SCALE|default(cfg_scale)|float %}

--- a/config/addons/dc_respooler_hw.cfg
+++ b/config/addons/dc_respooler_hw.cfg
@@ -22,8 +22,9 @@ variable_default_timeout: 60
 
 # Prefix of name of the `output_pin` for the respooler.
 # The `output_pin` name must follow the pattern {prefix}_rwd_{gate}
-# and {prefix}_en_{gate}.
-variable_pin_prefix: 'mmu_dc_respooler'
+# and {prefix}_en_{gate}. By default we prefix it with an underscore
+# to prevent them from being shown in UI applications (like mainsail).
+variable_pin_prefix: '_mmu_dc_respooler'
 gcode: # Leave empty
 
 ##################
@@ -31,14 +32,14 @@ gcode: # Leave empty
 #
 
 # Rewind pin
-[output_pin mmu_dc_respooler_rwd_0]
+[output_pin _mmu_dc_respooler_rwd_0]
 pin: mmu:MMU_DC_MOT_1_A
 value: 0
 pwm: True
 scale: 1
 
 # Enable pin
-# [output_pin mmu_dc_respooler_en_0]
+# [output_pin _mmu_dc_respooler_en_0]
 # pin: mmu:MMU_DC_MOT_1_EN
 # value: 0
 
@@ -47,14 +48,14 @@ scale: 1
 #
 
 # Rewind pin
-[output_pin mmu_dc_respooler_rwd_1]
+[output_pin _mmu_dc_respooler_rwd_1]
 pin: mmu:MMU_DC_MOT_2_A
 value: 0
 pwm: True
 scale: 1
 
 # Enable pin
-# [output_pin mmu_dc_respooler_en_1]
+# [output_pin _mmu_dc_respooler_en_1]
 # pin: mmu:MMU_DC_MOT_2_EN
 # value: 0
 
@@ -63,14 +64,14 @@ scale: 1
 #
 
 # Rewind pin
-[output_pin mmu_dc_respooler_rwd_2]
+[output_pin _mmu_dc_respooler_rwd_2]
 pin: mmu:MMU_DC_MOT_3_A
 value: 0
 pwm: True
 scale: 1
 
 # Enable pin
-# [output_pin mmu_dc_respooler_en_2]
+# [output_pin _mmu_dc_respooler_en_2]
 # pin: mmu:MMU_DC_MOT_3_EN
 # value: 0
 
@@ -79,13 +80,13 @@ scale: 1
 #
 
 # Rewind pin
-[output_pin mmu_dc_respooler_rwd_3]
+[output_pin _mmu_dc_respooler_rwd_3]
 pin: mmu:MMU_DC_MOT_4_A
 value: 0
 pwm: True
 scale: 1
 
 # Enable pin
-# [output_pin mmu_dc_respooler_en_3]
+# [output_pin _mmu_dc_respooler_en_3]
 # pin: mmu:MMU_DC_MOT_4_EN
 # value: 0

--- a/config/addons/dc_respooler_hw.cfg
+++ b/config/addons/dc_respooler_hw.cfg
@@ -16,15 +16,48 @@
 # Configure these for your setup.
 #
 [gcode_macro _MMU_RESPOOLER_VARS]
-# Default max number of seconds for respooler to run
-# Note: Each time any respooler **starts** it will restart the timeout
-variable_default_timeout: 60
-
 # Prefix of name of the `output_pin` for the respooler.
 # The `output_pin` name must follow the pattern {prefix}_rwd_{gate}
 # and {prefix}_en_{gate}. By default we prefix it with an underscore
 # to prevent them from being shown in UI applications (like mainsail).
+#
 variable_pin_prefix: '_mmu_dc_respooler'
+
+# Default max number of seconds for respooler to run
+# Note: Each time any respooler **starts** it will restart the timeout
+#
+# variable_default_timeout: 60
+
+# The step speed where you want to max out the respooler to run at full speed.
+#
+# variable_max_step_speed: 50
+
+# Minimum distance of a move required to activate the respooler
+# The lowest valid value for this is 50 because respooler macros
+# will not even be considered if the distance is less than 50.
+#
+# variable_min_distance: 100
+
+# Adjusts the speed conversion ratio
+# For the following examples, let's assume max_step_speed = 50.
+# And remember actual respooler speed values are between 0.0 (off) and 1.0 (full speed) (inclusive)
+#
+# The forumula looks like this:
+# ({step_speed} / {max_step_speed}) ^ {step_speed_exponent}
+#
+# With step_speed_exponent of 1 would have a linear ratio:
+# If I am running with a step speed of 50mm/s, the respooler would run at full speed (1.0)
+# Calculated via (50/50)^1
+# If I am running with a step speed of 25mm/s, the respooler would run at half speed (0.5)
+# Calculated via (25/50)^1
+#
+# With step_speed_exponent of 0.2 would have a linear ratio:
+# If I am running with a step speed of 50mm/s, the respooler would run at full speed (1.0)
+# Calculated via (50/50)^0.2
+# If I am running with a step speed of 25mm/s, the respooler would run at half speed (0.87)
+# Calculated via (25/50)^0.2
+#
+# variable_step_speed_exponent: 1
 gcode: # Leave empty
 
 ##################

--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -541,7 +541,7 @@ pre_load_macro: _MMU_PRE_LOAD				# Called before starting the load
 post_load_macro: _MMU_POST_LOAD				# Called after the load is complete
 unload_sequence_macro: _MMU_UNLOAD_SEQUENCE		# VERY ADVANCED: Optionally called based on 'gcode_unload_sequence'
 load_sequence_macro: _MMU_LOAD_SEQUENCE			# VERY ADVANCED: Optionally called based on 'gcode_load_sequence'
-respooler_start_macro: ''				# Called to start respooled if fitted (GATE, SPEED, MAX_DISTANCE, HOMING)
+respooler_start_macro: ''				# Called to start respooler if fitted (GATE, STEP_SPEED, MAX_DISTANCE, HOMING)
 respooler_stop_macro: ''				# Called to stop respooler if fitted (GATE, DISTANCE)
 
 

--- a/config/base/mmu_parameters.cfg.vs
+++ b/config/base/mmu_parameters.cfg.vs
@@ -496,7 +496,7 @@ pre_load_macro: _MMU_PRE_LOAD				# Called before starting the load
 post_load_macro: _MMU_POST_LOAD				# Called after the load is complete
 unload_sequence_macro: _MMU_UNLOAD_SEQUENCE		# VERY ADVANCED: Optionally called based on 'gcode_unload_sequence'
 load_sequence_macro: _MMU_LOAD_SEQUENCE			# VERY ADVANCED: Optionally called based on 'gcode_load_sequence'
-respooler_start_macro: ''				# Called to start respooled if fitted (GATE, SPEED, MAX_DISTANCE, HOMING)
+respooler_start_macro: ''				# Called to start respooler if fitted (GATE, STEP_SPEED, MAX_DISTANCE, HOMING)
 respooler_stop_macro: ''				# Called to stop respooler if fitted (GATE, DISTANCE)
 
 

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -5111,7 +5111,7 @@ class Mmu:
     def _wrap_respooler(self, motor, dist, speed, homing_move):
         if motor == "gear" and dist < -50 and self.respooler_start_macro and self.respooler_start_macro != "''":
             active = True
-            self._wrap_gcode_command("%s GATE=%d MAX_DISTANCE=%d SPEED=%d HOMING_MOVE=%d" % (self.respooler_start_macro, self.gate_selected, abs(dist), speed, abs(homing_move)))
+            self._wrap_gcode_command("%s GATE=%d MAX_DISTANCE=%d STEP_SPEED=%d HOMING_MOVE=%d" % (self.respooler_start_macro, self.gate_selected, abs(dist), speed, abs(homing_move)))
             self._wait_for_respooler = True if not homing_move else False
             initial_pos = self.mmu_toolhead.get_position()[1]
         else:


### PR DESCRIPTION
This updates the respooler to convert the stepper speed to a value between `0.0` and `1.0` for the respooler speed (if the pin is configured for pwm). There is a step speed exponent value that can be configured as well to give allow scaling the speed exponentially rather than linearly. The default speed configurations favor full speed currently. I will play need to play with these settings a bit to see what might work best as default values (will open a separate PR to adjust them if needed).

It also allows configuring the minimum distance of a move to activate a respooler.