### PR TITLE
fix(addon/respooler): actually use the exponent setting

### DIFF
--- a/config/addons/dc_respooler.cfg
+++ b/config/addons/dc_respooler.cfg
@@ -19,13 +19,13 @@ variable_default_timeout: 60
 
 # The step speed where you want to max out the respooler to run at full speed.
 #
-variable_max_step_speed: 50
+variable_max_step_speed: 200
 
 # Minimum distance of a move required to activate the respooler
 # The lowest valid value for this is 50 because respooler macros
 # will not even be considered if the distance is less than 50.
 #
-variable_min_distance: 100
+variable_min_distance: 200
 
 # Adjusts the speed conversion ratio
 # For the following examples, let's assume max_step_speed = 50.
@@ -46,7 +46,7 @@ variable_min_distance: 100
 # If I am running with a step speed of 25mm/s, the respooler would run at half speed (0.87)
 # Calculated via (25/50)^0.2
 #
-variable_step_speed_exponent: 1
+variable_step_speed_exponent: 0.5
 
 # Internal variable for tracking the gates with respoolers
 variable_respooler_gates: ''
@@ -128,7 +128,7 @@ gcode:
         {% elif step_speed > vars.max_step_speed %}
             {% set speed = 1 %}
         {% else %}
-            {% set speed = step_speed / vars.max_step_speed %}
+            {% set speed = (step_speed / vars.max_step_speed) ** vars.step_speed_exponent %}
         {% endif %}
     {% elif speed < 0 %}
         {% set speed = 1 %}
@@ -141,6 +141,7 @@ gcode:
     {% elif expected_distance >= 0 and expected_distance < vars.min_distance %}
         MMU_LOG DEBUG=1 MSG="Travel distance ({expected_distance}) is shorter than the configured min distance ({vars.min_distance}). Ignoring respooler activation."
     {% else %}
+        MMU_LOG DEBUG=1 MSG="Setting respooler {pin} to {speed}"
         {% set cfg_scale = printer.configfile.settings[pin_cfg].scale|default(1)|float %}
         {% set scale = params.SCALE|default(cfg_scale)|float %}
         {% if en_pin and speed > 0 %}

--- a/config/addons/dc_respooler_hw.cfg
+++ b/config/addons/dc_respooler_hw.cfg
@@ -30,13 +30,13 @@ variable_pin_prefix: '_mmu_dc_respooler'
 
 # The step speed where you want to max out the respooler to run at full speed.
 #
-# variable_max_step_speed: 50
+# variable_max_step_speed: 200
 
 # Minimum distance of a move required to activate the respooler
 # The lowest valid value for this is 50 because respooler macros
 # will not even be considered if the distance is less than 50.
 #
-# variable_min_distance: 100
+# variable_min_distance: 200
 
 # Adjusts the speed conversion ratio
 # For the following examples, let's assume max_step_speed = 50.
@@ -57,7 +57,7 @@ variable_pin_prefix: '_mmu_dc_respooler'
 # If I am running with a step speed of 25mm/s, the respooler would run at half speed (0.87)
 # Calculated via (25/50)^0.2
 #
-# variable_step_speed_exponent: 1
+# variable_step_speed_exponent: 0.5
 gcode: # Leave empty
 
 ##################


### PR DESCRIPTION
Added the exponent setting but forgot to actually add it to the calculation.

Also updated default settings