### PR TITLE
fix: add handle_disconnect to virtual selector

### DIFF
--- a/extras/mmu/mmu_selector.py
+++ b/extras/mmu/mmu_selector.py
@@ -60,6 +60,9 @@ class VirtualSelector:
     def handle_ready(self):
         pass
 
+    def handle_disconnect(self):
+        pass
+
     def home(self, tool = None, force_unload = None):
         pass
 


### PR DESCRIPTION
I noticed when shutting down, this triggers an error because it's not defined.