### PR TITLE
Fix parameter name (sync_multiplier_low)

### DIFF
--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -362,7 +362,7 @@ sync_form_tip: 0			# Synchronize during standalone tip formation (initial part o
 #
 sync_feedback_enable: 0			# 0 = Turn off (even with fitted sensor), 1 = Turn on when printing
 sync_multiplier_high: 1.05		# Maximum factor to apply to gear stepper `rotation_distance`
-sync_multipler_low: 0.95		# Minimum factor to apply
+sync_multiplier_low: 0.95		# Minimum factor to apply
 
 
 # Filament Management Options ----------------------------------------------------------------------------------------

--- a/extras/mmu.py
+++ b/extras/mmu.py
@@ -590,7 +590,7 @@ class Mmu:
         self.sync_to_extruder = config.getint('sync_to_extruder', 0, minval=0, maxval=1)
         self.sync_form_tip = config.getint('sync_form_tip', 0, minval=0, maxval=1)
         self.sync_multiplier_high = config.getfloat('sync_multiplier_high', 1.05, minval=1., maxval=2.)
-        self.sync_multiplier_low = config.getfloat('sync_multipler_low', 0.95, minval=0.5, maxval=1.)
+        self.sync_multiplier_low = config.getfloat('sync_multiplier_low', 0.95, minval=0.5, maxval=1.)
         self.sync_feedback_enable = config.getint('sync_feedback_enable', 0, minval=0, maxval=1)
 
         # Servo control


### PR DESCRIPTION
Quick fix for sync_multiplier_low parameter name in the config file.