### PR TITLE
Remove duplicate section in espooler

### DIFF
--- a/config/addons/dc_espooler.cfg
+++ b/config/addons/dc_espooler.cfg
@@ -1,8 +1,7 @@
-###########################################################################
-# Default eSpooler variables
+####################################
+# Variables for the eSpooler macros
 #
-# Please do not edit these. To change/override please set them in 
-# your espooler_hw.cfg
+# Configure these for your setup.
 #
 [gcode_macro _MMU_ESPOOLER_VARS]
 # Prefix of name of the `output_pin` for the eSpooler.

--- a/config/addons/dc_espooler_hw.cfg
+++ b/config/addons/dc_espooler_hw.cfg
@@ -10,56 +10,6 @@
 # See https://www.klipper3d.org/Config_Reference.html#output_pin
 #
 
-####################################
-# Variables for the eSpooler macros
-#
-# Configure these for your setup.
-#
-[gcode_macro _MMU_ESPOOLER_VARS]
-# Prefix of name of the `output_pin` for the eSpooler.
-# The `output_pin` name must follow the pattern {prefix}_rwd_{gate}
-# and {prefix}_en_{gate}. By default we prefix it with an underscore
-# to prevent them from being shown in UI applications (like mainsail).
-#
-variable_pin_prefix: '_mmu_dc_espooler'
-
-# Default max number of seconds for eSpooler to run
-# Note: Each time any eSpooler **starts** it will restart the timeout
-#
-# variable_default_timeout: 60
-
-# The step speed where you want to max out the eSpooler to run at full speed.
-#
-# variable_max_step_speed: 200
-
-# Minimum distance of a move required to activate the eSpooler
-# The lowest valid value for this is 50 because eSpooler macros
-# will not even be considered if the distance is less than 50.
-#
-# variable_min_distance: 200
-
-# Adjusts the speed conversion ratio
-# For the following examples, let's assume max_step_speed = 50.
-# And remember actual eSpooler speed values are between 0.0 (off) and 1.0 (full speed) (inclusive)
-#
-# The forumula looks like this:
-# ({step_speed} / {max_step_speed}) ^ {step_speed_exponent}
-#
-# With step_speed_exponent of 1 would have a linear ratio:
-# If I am running with a step speed of 50mm/s, the eSpooler would run at full speed (1.0)
-# Calculated via (50/50)^1
-# If I am running with a step speed of 25mm/s, the eSpooler would run at half speed (0.5)
-# Calculated via (25/50)^1
-#
-# With step_speed_exponent of 0.2 would have a linear ratio:
-# If I am running with a step speed of 50mm/s, the eSpooler would run at full speed (1.0)
-# Calculated via (50/50)^0.2
-# If I am running with a step speed of 25mm/s, the eSpooler would run at half speed (0.87)
-# Calculated via (25/50)^0.2
-#
-# variable_step_speed_exponent: 0.5
-gcode: # Leave empty
-
 ##################
 # Gate 0 eSpooler
 #


### PR DESCRIPTION
The section `[gcode_macro _MMU_ESPOOLER_VARS]` was defined in both `dc_espooler.cfg` and `dc_espooler_hw.cfg` 
I presume it was some leftover from a refactor. I removed the redundant section in `dc_espooler_hw.cfg`