### PR TITLE
Blobifier: Amend display values to better match what is actually purged. Tweak pulsatile flushing.

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -345,7 +345,7 @@ gcode:
       {% endif %}
       {% set purge_len = purge_vol / filament_cross_section %}
 
-      {% set purge_len = purge_len + printer.mmu.extruder_filament_remaining + park_vars.retracted_length + purge_length_addition %}
+      {% set purge_len = purge_len + park_vars.retracted_length + purge_length_addition %}
 
     {% else %} # ========================= USE CONFIG VARIABLE =============================
       {action_respond_info("BLOBIFIER: No toolmap or PURGE_LENGTH. Using default")}

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -325,16 +325,9 @@ gcode:
     # ==================== DETERMINE PURGE LENGTH ==========================================
     # ======================================================================================
 	
-	
     {% if params.PURGE_LENGTH %} # =============== PARAM PURGE LENGTH ======================
       {action_respond_info("BLOBIFIER: param PURGE_LENGTH provided")}
       {% set purge_len = params.PURGE_LENGTH|float %}
-      # APPLY PURGE MINIMUM
-      {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
-      {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
-      # INCREMENT PURGE LENGTH BY THE RETRACTED LENGTH. AS THIS IS NOT PURGE, IT IS NOT DISPLAYED IN THE MESSAGE ABOVE
-      {% set purge_len = purge_len + park_vars.retracted_length %}
-      
     {% elif from_tool == to_tool and to_tool >= 0 %} # ==== TOOL DIDN'T CHANGE =============
       {action_respond_info("BLOBIFIER: Tool didn't change (T%s > T%s), %s" % (from_tool, to_tool, "priming" if purge_length_minimum else "skipping"))}
       {% set purge_len = 0 %}
@@ -350,25 +343,20 @@ gcode:
         {% set purge_vol = pv[from_tool][to_tool]|float * purge_length_modifier %}
         {action_respond_info("BLOBIFIER: Swapped T%s > T%s" % (from_tool, to_tool))}
       {% endif %}
-      {% set purge_len = (purge_vol / filament_cross_section) +  purge_length_addition + printer.mmu.extruder_filament_remaining%}
-
-      # APPLY PURGE MINIMUM
-      {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
-      # DISPLAY THE PURGED AMOUNT
-      {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
-      # INCREMENT PURGE LENGTH BY THE RETRACTED LENGTH. AS THIS IS NOT PURGE, IT IS NOT DISPLAYED IN THE MESSAGE ABOVE
-      {% set purge_len = purge_len + park_vars.retracted_length %}
-
+      {% set purge_len = purge_vol / filament_cross_section %}
+      
+      {% set purge_len = purge_len + printer.mmu.extruder_filament_remaining + purge_length_addition %}
+      
     {% else %} # ========================= USE CONFIG VARIABLE =============================
       {action_respond_info("BLOBIFIER: No toolmap or PURGE_LENGTH. Using default")}
       {% set purge_len = purge_length|float + printer.mmu.extruder_filament_remaining  %}
-      # APPLY PURGE MINIMUM
-      {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
-      {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
-      # INCREMENT PURGE LENGTH BY THE RETRACTED LENGTH. AS THIS IS NOT PURGE, IT IS NOT DISPLAYED IN THE MESSAGE ABOVE
-      {% set purge_len = purge_len + park_vars.retracted_length %}
-      
     {% endif %}
+    
+    # ==================================== APPLY PURGE MINIMUM =============================
+     {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
+     {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
+    # ====================== INCREMENT PURGE LENGTH BY THE RETRACTED LENGTH ================   
+     {% set purge_len = purge_len + park_vars.retracted_length %}
 
     # ======================================================================================
     # ==================== PURGING SEQUENCE ================================================

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -434,7 +434,7 @@ gcode:
       {% set pulses_per_retract = (purge_per_blob / retracts_per_blob / 5)|round(0, 'ceil')|int %}
       {% set pulses_per_blob = (purge_per_blob / 5)|round(0, 'ceil')|int %}
       {% set purge_per_pulse = purge_per_blob / pulses_per_blob %}
-      {% set pulse_time_constant = purge_per_pulse * 0.95 / purge_spd / (purge_per_pulse * 0.95 / purge_spd + purge_per_pulse * 0.05 / 50) %}
+      {% set pulse_time_constant = purge_per_pulse * 0.90 / purge_spd / (purge_per_pulse * 0.90 / purge_spd + purge_per_pulse * 0.10 / 50) %}
       {% set pulse_duration = purge_per_pulse / purge_spd %}
 
       # Repeat the process until purge_len is reached
@@ -462,7 +462,7 @@ gcode:
           # Purge quickly
           G1 Z{z_up * pulse_time_constant} E{purge_per_pulse * 0.90} F{speed}
           # Purge a tiny bit slowly
-          G1 Z{z_up * (1 - pulse_time_constant)} E{purge_per_pulse * 0.10} F50
+          G1 Z{z_up * (1 - pulse_time_constant)} E{purge_per_pulse * 0.10} F{speed}
 
           # retract and unretract filament every now and then for thourough cleaning
           {% if pulse % pulses_per_retract == 0 and pulse > 0 %}

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -350,7 +350,7 @@ gcode:
         {% set purge_vol = pv[from_tool][to_tool]|float * purge_length_modifier %}
         {action_respond_info("BLOBIFIER: Swapped T%s > T%s" % (from_tool, to_tool))}
       {% endif %}
-      {% set purge_len = (purge_vol / filament_cross_section) +  purge_length_addition%}
+      {% set purge_len = (purge_vol / filament_cross_section) +  purge_length_addition + printer.mmu.extruder_filament_remaining%}
 
       # APPLY PURGE MINIMUM
       {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -332,6 +332,8 @@ gcode:
       # APPLY PURGE MINIMUM
       {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
       {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
+      # INCREMENT PURGE LENGTH BY THE RETRACTED LENGTH. AS THIS IS NOT PURGE, IT IS NOT DISPLAYED IN THE MESSAGE ABOVE
+      {% set purge_len = purge_len + park_vars.retracted_length %}
       
     {% elif from_tool == to_tool and to_tool >= 0 %} # ==== TOOL DIDN'T CHANGE =============
       {action_respond_info("BLOBIFIER: Tool didn't change (T%s > T%s), %s" % (from_tool, to_tool, "priming" if purge_length_minimum else "skipping"))}

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -324,7 +324,7 @@ gcode:
     # ======================================================================================
     # ==================== DETERMINE PURGE LENGTH ==========================================
     # ======================================================================================
-	
+
     {% if params.PURGE_LENGTH %} # =============== PARAM PURGE LENGTH ======================
       {action_respond_info("BLOBIFIER: param PURGE_LENGTH provided")}
       {% set purge_len = params.PURGE_LENGTH|float %}
@@ -344,14 +344,14 @@ gcode:
         {action_respond_info("BLOBIFIER: Swapped T%s > T%s" % (from_tool, to_tool))}
       {% endif %}
       {% set purge_len = purge_vol / filament_cross_section %}
-      
+
       {% set purge_len = purge_len + printer.mmu.extruder_filament_remaining + purge_length_addition %}
-      
+
     {% else %} # ========================= USE CONFIG VARIABLE =============================
       {action_respond_info("BLOBIFIER: No toolmap or PURGE_LENGTH. Using default")}
       {% set purge_len = purge_length|float + printer.mmu.extruder_filament_remaining  %}
     {% endif %}
-    
+
     # ==================================== APPLY PURGE MINIMUM =============================
      {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
      {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -324,10 +324,15 @@ gcode:
     # ======================================================================================
     # ==================== DETERMINE PURGE LENGTH ==========================================
     # ======================================================================================
-
+	
+	
     {% if params.PURGE_LENGTH %} # =============== PARAM PURGE LENGTH ======================
       {action_respond_info("BLOBIFIER: param PURGE_LENGTH provided")}
       {% set purge_len = params.PURGE_LENGTH|float %}
+      # APPLY PURGE MINIMUM
+      {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
+      {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
+      
     {% elif from_tool == to_tool and to_tool >= 0 %} # ==== TOOL DIDN'T CHANGE =============
       {action_respond_info("BLOBIFIER: Tool didn't change (T%s > T%s), %s" % (from_tool, to_tool, "priming" if purge_length_minimum else "skipping"))}
       {% set purge_len = 0 %}
@@ -343,18 +348,25 @@ gcode:
         {% set purge_vol = pv[from_tool][to_tool]|float * purge_length_modifier %}
         {action_respond_info("BLOBIFIER: Swapped T%s > T%s" % (from_tool, to_tool))}
       {% endif %}
-      {% set purge_len = purge_vol / filament_cross_section %}
+      {% set purge_len = (purge_vol / filament_cross_section) +  purge_length_addition%}
 
-      {% set purge_len = purge_len + park_vars.retracted_length + purge_length_addition %}
+      # APPLY PURGE MINIMUM
+      {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
+      # DISPLAY THE PURGED AMOUNT
+      {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
+      # INCREMENT PURGE LENGTH BY THE RETRACTED LENGTH. AS THIS IS NOT PURGE, IT IS NOT DISPLAYED IN THE MESSAGE ABOVE
+      {% set purge_len = purge_len + park_vars.retracted_length %}
 
     {% else %} # ========================= USE CONFIG VARIABLE =============================
       {action_respond_info("BLOBIFIER: No toolmap or PURGE_LENGTH. Using default")}
-      {% set purge_len = purge_length|float + printer.mmu.extruder_filament_remaining + park_vars.retracted_length %}
+      {% set purge_len = purge_length|float + printer.mmu.extruder_filament_remaining  %}
+      # APPLY PURGE MINIMUM
+      {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
+      {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
+      # INCREMENT PURGE LENGTH BY THE RETRACTED LENGTH. AS THIS IS NOT PURGE, IT IS NOT DISPLAYED IN THE MESSAGE ABOVE
+      {% set purge_len = purge_len + park_vars.retracted_length %}
+      
     {% endif %}
-
-    # ==================================== APPLY PURGE MINIMUM =============================
-    {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
-    {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
 
     # ======================================================================================
     # ==================== PURGING SEQUENCE ================================================

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -353,8 +353,8 @@ gcode:
     {% endif %}
 
     # ==================================== APPLY PURGE MINIMUM =============================
-     {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
-     {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
+    {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
+    {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
     # ====================== INCREMENT PURGE LENGTH BY THE RETRACTED LENGTH ================   
      {% set purge_len = purge_len + park_vars.retracted_length %}
 

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -472,14 +472,14 @@ gcode:
           {% set speed = z_up / pulse_duration %}
 
           # Purge quickly
-          G1 Z{z_up * pulse_time_constant} E{purge_per_pulse * 0.95} F{speed}
+          G1 Z{z_up * pulse_time_constant} E{purge_per_pulse * 0.90} F{speed}
           # Purge a tiny bit slowly
-          G1 Z{z_up * (1 - pulse_time_constant)} E{purge_per_pulse * 0.05} F{speed}
+          G1 Z{z_up * (1 - pulse_time_constant)} E{purge_per_pulse * 0.10} F50
 
           # retract and unretract filament every now and then for thourough cleaning
           {% if pulse % pulses_per_retract == 0 and pulse > 0 %}
             G1 E-2 F1800
-            G1 E2 F800
+            G1 E2 F300
           {% endif %}
           
         {% endfor %}


### PR DESCRIPTION
**A few proposed changes:**

1. When displaying the BLOBIFIER: Purging %dmm of filament message, dont include de-retraction moves that do not actually do any purge (i.e. park_vars.retracted_length)
2. The slow vs fast pulse volume ratio has been slightly tweaked

### Proposed change 1: When displaying the BLOBIFIER: Purging %dmm of filament message, don't include de-retraction moves that do not actually do any purge (i.e. park_vars.retracted_length)

The way the macro was currently structured, it was considering the park_vars.retracted_length as part of the purge length. However technically this is not a purge but rather a de-retraction move, bringing the filament to the start point, right before extrusion. Hence the display message was incorrect as it was incrementing the true purge value with a de-retraction move that results in no material exiting the nozzle.

In addition the application of the "purge minimum" ceiling, also considered the retracted length as part of the purged amount. Therefore, the produced blob would technically be smaller with a higher retract length vs. with a smaller retract length, even though the user would be expecting a fixed minimum purge amount to be extracted.

The proposed changes in the macro split the purge length calculation into two parts
1. The actual purge value that is incremented by the user requested purge_length_addition and that value is displayed in the UI. 
2. It then adds the residual de-retraction moves and executes the purge move (actual purge amount + deretraction move)


### Proposed change 2: Tweaks to pulsatile flushing
Finally more of a tweak - the slow vs fast pulse volume ratio has been amended from 95-5% (fast - slow) to 90-10% (fast - slow). While this will ever so slightly increase the purge time, it helps a lot with reducing the required purge amount by increasing flushing effectiveness ever so slightly (experimentally).

### Notes:
Raising as draft as currently in testing.
