### PR TITLE
Update MMU_SELECT_TOOL to MMU_SELECT

### DIFF
--- a/config/optional/mmu_menu.cfg
+++ b/config/optional/mmu_menu.cfg
@@ -64,7 +64,7 @@ input_max: 8
 input_step: 1
 index: 6
 gcode:
-    MMU_SELECT_TOOL TOOL={menu.input|int}
+    MMU_SELECT TOOL={menu.input|int}
 
 [menu __main __MMU __PRELOAD_TOOL]
 type: input


### PR DESCRIPTION
I noticed, that my menu was not working for this command, and looks like it has been updated some time ago. This should fix the default menu.