### PR TITLE
Update mmu_utils.py

### DIFF
--- a/extras/mmu/mmu_utils.py
+++ b/extras/mmu/mmu_utils.py
@@ -89,7 +89,9 @@ class PurgeVolCalculator:
         return purge_volume
 
     def calc_purge_vol_by_hex(self, src_clr, dst_clr):
-        return self.calc_purge_vol_by_rgb(*self.hex_to_rgb(src_clr), *self.hex_to_rgb(dst_clr))
+        src_rgb = self.hex_to_rgb(src_clr)
+        dst_rgb = self.hex_to_rgb(dst_clr)
+        return self.calc_purge_vol_by_rgb(src_rgb[0], src_rgb[1], src_rgb[2], dst_rgb[0], dst_rgb[1], dst_rgb[2])
 
     @staticmethod
     def RGB2HSV(r, g, b):


### PR DESCRIPTION
This produced an error on my machine.
Unhandled exception during connect
Traceback (most recent call last):
  File "/home/pi/klipper/klippy/klippy.py", line 130, in _connect
    self._read_config()
  File "/home/pi/klipper/klippy/klippy.py", line 123, in _read_config
    self.load_object(config, section_config.get_name(), None)
  File "/home/pi/klipper/klippy/klippy.py", line 112, in load_object
    self.objects[section] = init_func(config.getsection(section))
  File "/home/pi/klipper/klippy/extras/mmu_sensors.py", line 248, in load_config
    return MmuSensors(config)
  File "/home/pi/klipper/klippy/extras/mmu_sensors.py", line 147, in __init__
    from extras.mmu import Mmu # For sensor names
  File "/home/pi/klipper/klippy/extras/mmu/__init__.py", line 18, in <module>
    from .mmu import Mmu
  File "/home/pi/klipper/klippy/extras/mmu/mmu.py", line 32, in <module>
    from .mmu_test           import MmuTest
  File "/home/pi/klipper/klippy/extras/mmu/mmu_test.py", line 22, in <module>
    from .mmu_utils import PurgeVolCalculator
  File "/home/pi/klipper/klippy/extras/mmu/mmu_utils.py", line 92
    return self.calc_purge_vol_by_rgb(*self.hex_to_rgb(src_clr), *self.hex_to_rgb(dst_clr))
                                                                 ^
SyntaxError: invalid syntax