### PR TITLE
fix link to `MMU_CALIBRATE_TOOLHEAD` documentation

### DIFF
--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -259,7 +259,7 @@ toolhead_homing_max: 40			# Maximum distance to advance in order to attempt to h
 # your nozzle) to control excessive oozing on load. See doc for table of proposed values for common configurations.
 #
 # NOTE: If you have a toolhead sensor you can automate the calculation of these parameters! Read about the
-# `MMU_CALIBRATE_TOOLHEAD` command (https://github.com/moggieuk/Happy-Hare/wiki/Blobing-and-Stringing)
+# `MMU_CALIBRATE_TOOLHEAD` command (https://github.com/moggieuk/Happy-Hare/wiki/Blobbing-and-Stringing#---calibrating-toolhead)
 #
 toolhead_extruder_to_nozzle: 72		# Distance from extruder gears (entrance) to nozzle
 toolhead_sensor_to_nozzle: 62		# Distance from toolhead sensor to nozzle (ignored if not fitted)


### PR DESCRIPTION
Trivial fix:
The link to the `MMU_CALIBRATE_TOOLHEAD` documentation had a typo and redirected to the main wiki page.

I have also taken the liberty of adding the anchor to jump to the relevant section.