### PR TITLE
Move park_operation variable update

### DIFF
--- a/config/base/mmu_sequence.cfg
+++ b/config/base/mmu_sequence.cfg
@@ -200,9 +200,9 @@ gcode:
             {% elif x < 0 and y >= 0 %}
                 G1 Y{y} F{park_travel_speed}						# Y move only
             {% endif %}
-        {% endif %}
-        {% if not force_park %}
-            SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=park_operation VALUE=\"{operation}\"
+            {% if not force_park %}
+                SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=park_operation VALUE=\"{operation}\"
+            {% endif %}
         {% endif %}
     {% endif %}
 


### PR DESCRIPTION
I would argue that setting this variable should only be done once an actual park operation has been performed.