### PR TITLE
Update pin_defs for BTT MMB 1.1  board. 

### DIFF
--- a/pin_defs
+++ b/pin_defs
@@ -254,7 +254,7 @@ PIN[MMB10,gear_sensor_7_pin]="";                           PIN[MMB11,gear_sensor
 PIN[MMB10,gear_sensor_8_pin]="";                           PIN[MMB11,gear_sensor_8_pin]="";
 PIN[MMB10,gear_sensor_9_pin]="";                           PIN[MMB11,gear_sensor_9_pin]="";
 PIN[MMB10,gear_sensor_10_pin]="";                          PIN[MMB11,gear_sensor_10_pin]="";
-PIN[MMB10,gear_sensor_11_pin]="";                          PIN[MMB11,gear_sensor_10_pin]="";
+PIN[MMB10,gear_sensor_11_pin]="";                          PIN[MMB11,gear_sensor_11_pin]="";
 #
 # Common Type-B MMU pin utilization
 #


### PR DESCRIPTION
clean up copy paste typo for BTT MMB 1.1 board

- fix for MMB 1.1 board, not properly replaced, causes startup issue. https://github.com/moggieuk/Happy-Hare/issues/578#issuecomment-2577980291