### PR TITLE
fix(installer): Default the _hw_selector_type when reading previous m…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -470,6 +470,16 @@ read_previous_mmu_type() {
             HAS_ENCODER="no"
         fi
     fi
+    # set the selector type
+    if [ "$HAS_SELECTOR" == "no" -a "$HAS_SERVO" == "no" ]; then
+        _hw_selector_type='VirtualSelector'
+    elif [ "$HAS_SELECTOR" == "no" -a "$HAS_SERVO" == "yes" ]; then
+        _hw_selector_type='ServoSelector'
+    elif [ "$HAS_SELECTOR" == "yes" -a "$HAS_SERVO" == "no" ]; then
+        _hw_selector_type='RotarySelector'
+    else
+        _hw_selector_type='LinearSelector'
+    fi
 }
 
 # Set default parameters from the distribution (reference) config files


### PR DESCRIPTION
…mu type to match previous config

At one point I think it was required for the mmu_hardware.cfg to contain a `selector_type` property. _If_ that propery was present, then during the read_previous_config, it would have picked up the correct selector type, but by default the selector_type is not explicitly set. Instead it is implied by the mmu_vendor in the python code. This code attempts to effectively restore a valid default value. If the user has selector_type set when reading previous config, it would override what we are setting here.

After fixing this, I was able to re-run the installer and it successfully removed the properties that had gotten added with blank values after first installing the multi_mmu branch.

```
Parameter: 'gate_load_retries: ''' is not required or deprecated and has been removed
Parameter: 'preload_attempts: ''' is not required or deprecated and has been removed
Parameter: 'selector_homing_speed: ''' is not required or deprecated and has been removed
Parameter: 'selector_max_accel: ''' is not required or deprecated and has been removed
Parameter: 'selector_max_velocity: ''' is not required or deprecated and has been removed
Parameter: 'selector_move_speed: ''' is not required or deprecated and has been removed
Parameter: 'selector_touch_enable: ''' is not required or deprecated and has been removed
Parameter: 'selector_touch_speed: ''' is not required or deprecated and has been removed
Parameter: 'sync_form_tip: ''' is not required or deprecated and has been removed
Parameter: 'sync_to_extruder: ''' is not required or deprecated and has been removed
```