### PR TITLE
Warn if user defined accels exceed max_accels defined for the printer.

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -867,7 +867,15 @@ gcode:
     {action_respond_info("BLOBIFIER: variable_z_raise_exp has value: %f. This value is out of spec (0.5 ... 1.0)." % (bl.z_raise))}
   {% endif %}
 
-
+  # cap user defined accels at printer max_accel if greater
+  {% if bl.shake_accel >  printer.configfile.config.printer.max_accel|int %}
+     {action_respond_info("BLOBIFIER: variable_shake_accel has value: %d which is higher than your printer limit of %d. Reseting to match your printer limit." % (bl.shake_accel,printer.configfile.config.printer.max_accel|int))}
+     SET_GCODE_VARIABLE MACRO=BLOBIFIER VARIABLE=shake_accel VALUE={printer.configfile.config.printer.max_accel} 
+  {% endif %}
+  {% if bl.brush_accel >  printer.configfile.config.printer.max_accel|int %}
+     {action_respond_info("BLOBIFIER: variable_brush_accel has value: %d which is higher than your printer limit of %d. Reseting to match your printer limit." % (bl.brush_accel,printer.configfile.config.printer.max_accel|int))}
+     SET_GCODE_VARIABLE MACRO=BLOBIFIER VARIABLE=brush_accel VALUE={printer.configfile.config.printer.max_accel} 
+  {% endif %}
 
 [delayed_gcode BLOBIFIER_LOAD_STATE]
 initial_duration: 2.0 # Give it some time to boot up

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -869,12 +869,10 @@ gcode:
 
   # cap user defined accels at printer max_accel if greater
   {% if bl.shake_accel >  printer.configfile.config.printer.max_accel|int %}
-     {action_respond_info("BLOBIFIER: variable_shake_accel has value: %d which is higher than your printer limit of %d. Resetting to match your printer limit." % (bl.shake_accel,printer.configfile.config.printer.max_accel|int))}
-     SET_GCODE_VARIABLE MACRO=BLOBIFIER VARIABLE=shake_accel VALUE={printer.configfile.config.printer.max_accel} 
+     {action_respond_info("BLOBIFIER: variable_shake_accel has value: %d which is higher than your printer limit of %d. Reduce this if your printer skips steps." % (bl.shake_accel,printer.configfile.config.printer.max_accel|int))}
   {% endif %}
   {% if bl.brush_accel >  printer.configfile.config.printer.max_accel|int %}
-     {action_respond_info("BLOBIFIER: variable_brush_accel has value: %d which is higher than your printer limit of %d. Resetting to match your printer limit." % (bl.brush_accel,printer.configfile.config.printer.max_accel|int))}
-     SET_GCODE_VARIABLE MACRO=BLOBIFIER VARIABLE=brush_accel VALUE={printer.configfile.config.printer.max_accel} 
+     {action_respond_info("BLOBIFIER: variable_brush_accel has value: %d which is higher than your printer limit of %d. Reduce this if your printer skips steps." % (bl.brush_accel,printer.configfile.config.printer.max_accel|int))}
   {% endif %}
 
 [delayed_gcode BLOBIFIER_LOAD_STATE]

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -869,11 +869,11 @@ gcode:
 
   # cap user defined accels at printer max_accel if greater
   {% if bl.shake_accel >  printer.configfile.config.printer.max_accel|int %}
-     {action_respond_info("BLOBIFIER: variable_shake_accel has value: %d which is higher than your printer limit of %d. Reseting to match your printer limit." % (bl.shake_accel,printer.configfile.config.printer.max_accel|int))}
+     {action_respond_info("BLOBIFIER: variable_shake_accel has value: %d which is higher than your printer limit of %d. Resetting to match your printer limit." % (bl.shake_accel,printer.configfile.config.printer.max_accel|int))}
      SET_GCODE_VARIABLE MACRO=BLOBIFIER VARIABLE=shake_accel VALUE={printer.configfile.config.printer.max_accel} 
   {% endif %}
   {% if bl.brush_accel >  printer.configfile.config.printer.max_accel|int %}
-     {action_respond_info("BLOBIFIER: variable_brush_accel has value: %d which is higher than your printer limit of %d. Reseting to match your printer limit." % (bl.brush_accel,printer.configfile.config.printer.max_accel|int))}
+     {action_respond_info("BLOBIFIER: variable_brush_accel has value: %d which is higher than your printer limit of %d. Resetting to match your printer limit." % (bl.brush_accel,printer.configfile.config.printer.max_accel|int))}
      SET_GCODE_VARIABLE MACRO=BLOBIFIER VARIABLE=brush_accel VALUE={printer.configfile.config.printer.max_accel} 
   {% endif %}
 


### PR DESCRIPTION
Apply sane limits to prevent users from defining brush and shake accel's that exceed max_accel settings of the printer to minimise potential for missed steps.  Checks added to delayed_gcode blobifier init block