### PR TITLE
Cutting motion for two dimensional cutting action

### DIFF
--- a/config/base/mmu_cut_tip.cfg
+++ b/config/base/mmu_cut_tip.cfg
@@ -176,7 +176,6 @@ gcode:
     {% set evacuate_speed = vars['evacuate_speed']|float %}
     {% set rip_length = vars['rip_length']|float %}
     {% set rip_speed = vars['rip_speed']|float %}
-    {% set cutting_axis = vars['cutting_axis']|string %}
 
     {% set fast_slow_transition_loc_x = (pin_loc_compressed_x - pin_park_x_loc) * cut_fast_move_fraction + pin_park_x_loc|float %}
     {% set fast_slow_transition_loc_y = (pin_loc_compressed_y - pin_park_y_loc) * cut_fast_move_fraction + pin_park_y_loc|float %}

--- a/config/base/mmu_cut_tip.cfg
+++ b/config/base/mmu_cut_tip.cfg
@@ -167,7 +167,8 @@ gcode:
     {% set pin_park_y_loc = params.PIN_PARK_Y_LOC | float %}
     {% set vars = printer['gcode_macro _MMU_CUT_TIP_VARS'] %}
 
-    {% set pin_loc_compressed = vars['pin_loc_compressed']|float %}
+    #{% set pin_loc_compressed = vars['pin_loc_compressed']|float %}
+    {% set pin_loc_compressed_x, pin_loc_compressed_y = vars.pin_loc_compressed_xy|map('float') %}
     {% set cut_fast_move_fraction = vars['cut_fast_move_fraction']|float %}
     {% set cut_fast_move_speed = vars['cut_fast_move_speed']|float %}
     {% set cut_slow_move_speed = vars['cut_slow_move_speed']|float %}
@@ -177,26 +178,17 @@ gcode:
     {% set rip_speed = vars['rip_speed']|float %}
     {% set cutting_axis = vars['cutting_axis']|string %}
 
-    {% if cutting_axis == "x" %}
-        {% set fast_slow_transition_loc = (pin_loc_compressed - pin_park_x_loc) * cut_fast_move_fraction + pin_park_x_loc|float %}
-        G1 X{fast_slow_transition_loc} F{cut_fast_move_speed * 60} # Fast move to initiate contact of the blade with filament
-        G1 X{pin_loc_compressed} F{cut_slow_move_speed * 60} # Do the cut in slow move
-    {% else %}
-        {% set fast_slow_transition_loc = (pin_loc_compressed - pin_park_y_loc) * cut_fast_move_fraction + pin_park_y_loc|float %}
-        G1 Y{fast_slow_transition_loc} F{cut_fast_move_speed * 60} # Fast move to initiate contact of the blade with filament
-        G1 Y{pin_loc_compressed} F{cut_slow_move_speed * 60} # Do the cut in slow move
-    {% endif %}
+    {% set fast_slow_transition_loc_x = (pin_loc_compressed_x - pin_park_x_loc) * cut_fast_move_fraction + pin_park_x_loc|float %}
+    {% set fast_slow_transition_loc_y = (pin_loc_compressed_y - pin_park_y_loc) * cut_fast_move_fraction + pin_park_y_loc|float %}
+    G1 X{fast_slow_transition_loc_x} Y{fast_slow_transition_loc_y} F{cut_fast_move_speed * 60} # Fast move to initiate contact of the blade with filament
+    G1 X{pin_loc_compressed_x} Y{pin_loc_compressed_y} F{cut_slow_move_speed * 60} # Do the cut in slow move
 
     G4 P{cut_dwell_time}
     {% if rip_length > 0 %}
         G1 E-{rip_length} F{rip_speed * 60}
     {% endif %}
 
-    {% if cutting_axis == "x" %}
-        G1 X{pin_park_x_loc} F{evacuate_speed * 60} # Evacuate
-    {% else %}
-        G1 Y{pin_park_y_loc} F{evacuate_speed * 60}
-    {% endif %}
+    G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{evacuate_speed * 60} # Evacuate
 
 
 ###########################################################################

--- a/config/base/mmu_cut_tip.cfg
+++ b/config/base/mmu_cut_tip.cfg
@@ -170,10 +170,10 @@ gcode:
 
     {% if vars['pin_loc_compressed']|float(-9999) != -9999 %}
         {% if cutting_axis == "x" %}
-            {% set pin_loc_compressed_x = vars['pin_loc_compressed']|float}
+            {% set pin_loc_compressed_x = vars['pin_loc_compressed']|float %}
             {% set pin_loc_compressed_y = pin_park_y_loc %}
         {% else %}
-            {% set pin_loc_compressed_y = vars['pin_loc_compressed']|float}
+            {% set pin_loc_compressed_y = vars['pin_loc_compressed']|float %}
             {% set pin_loc_compressed_x = pin_park_x_loc %}   
         {% endif %}
     {% else %}

--- a/config/base/mmu_cut_tip.cfg
+++ b/config/base/mmu_cut_tip.cfg
@@ -166,9 +166,20 @@ gcode:
     {% set pin_park_x_loc = params.PIN_PARK_X_LOC | float %}
     {% set pin_park_y_loc = params.PIN_PARK_Y_LOC | float %}
     {% set vars = printer['gcode_macro _MMU_CUT_TIP_VARS'] %}
+    {% set cutting_axis = vars['cutting_axis'] %}
 
-    #{% set pin_loc_compressed = vars['pin_loc_compressed']|float %}
-    {% set pin_loc_compressed_x, pin_loc_compressed_y = vars.pin_loc_compressed_xy|map('float') %}
+    {% if vars['pin_loc_compressed']|float(-9999) != -9999 %}
+        {% if cutting_axis == "x" %}
+            {% set pin_loc_compressed_x = vars['pin_loc_compressed']|float}
+            {% set pin_loc_compressed_y = pin_park_y_loc %}
+        {% else %}
+            {% set pin_loc_compressed_y = vars['pin_loc_compressed']|float}
+            {% set pin_loc_compressed_x = pin_park_x_loc %}   
+        {% endif %}
+    {% else %}
+        {% set pin_loc_compressed_x, pin_loc_compressed_y = vars.pin_loc_compressed|map('float') %}
+    {% endif %}
+        
     {% set cut_fast_move_fraction = vars['cut_fast_move_fraction']|float %}
     {% set cut_fast_move_speed = vars['cut_fast_move_speed']|float %}
     {% set cut_slow_move_speed = vars['cut_slow_move_speed']|float %}
@@ -176,6 +187,7 @@ gcode:
     {% set evacuate_speed = vars['evacuate_speed']|float %}
     {% set rip_length = vars['rip_length']|float %}
     {% set rip_speed = vars['rip_speed']|float %}
+
 
     {% set fast_slow_transition_loc_x = (pin_loc_compressed_x - pin_park_x_loc) * cut_fast_move_fraction + pin_park_x_loc|float %}
     {% set fast_slow_transition_loc_y = (pin_loc_compressed_y - pin_park_y_loc) * cut_fast_move_fraction + pin_park_y_loc|float %}

--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -331,7 +331,7 @@ variable_pin_park_dist          : 5.0		; Distance in mm
 # Position of the toolhead when the cutter is fully compressed. This value is on the x or y axis depending on the value of
 # 'cutting_axis'. Should leave a small headroom (should be a bit larger than 0, or whatever xmin is) to
 # avoid banging the toolhead or gantry
-variable_pin_loc_compressed     : 0.5, 250		; x,y coordinates of fully depressed location
+variable_pin_loc_compressed     : 0.5, 250		; x,y coordinates of fully depressed location, assumes y is equal to pin_loc y position if omitted
 
 # Retract length and speed after the cut so that the cutter blade doesn't
 # get stuck on return to origin position

--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -320,7 +320,7 @@ variable_simple_tip_forming     : True		; True = Perform simple tip forming, Fal
 
 # This should be the position of the toolhead where the cutter arm just
 # lightly touches the depressor pin
-variable_cutting_axis		: "x"		; "x" or "y". Determines cut direction (axis) during cut motion
+variable_cutting_axis		: "x"		; "x" or "y". Determines cut direction (axis) during cut motion, used for park distance
 variable_pin_loc_xy             : 14, 250	; x,y coordinates of depressor pin
 
 # This distance is added to "pin_loc_x" or "pin_loc_y" depending on the 'cutting_axis'
@@ -331,7 +331,7 @@ variable_pin_park_dist          : 5.0		; Distance in mm
 # Position of the toolhead when the cutter is fully compressed. This value is on the x or y axis depending on the value of
 # 'cutting_axis'. Should leave a small headroom (should be a bit larger than 0, or whatever xmin is) to
 # avoid banging the toolhead or gantry
-variable_pin_loc_compressed     : 0.5		; Distance. Coordinate in x or y direction depending on 'cutting_axis'
+variable_pin_loc_compressed     : 0.5, 250		; x,y coordinates of fully depressed location
 
 # Retract length and speed after the cut so that the cutter blade doesn't
 # get stuck on return to origin position


### PR DESCRIPTION
- Added additional movement axis to cutter action to support non-linear cutter such as [this cutter](https://www.printables.com/model/1142687-filament-cutter-for-reaper-toolhead-and-orbiter-pa) to allow for smoother operation and provide more leverage
- Update mmu_macros_vars.cfg defaults to include a y-axis dimension to the compressed position
- Added some logic to _FILAMETRIX_DO_CUT_MOTION macro to allow backwards compatibility for existing configurations with single dimensional compressed location
	- It assumes that the omitted second dimension is the same as the park location coordinate
- Tested with and without y-axis dimension provided and operation works as before
- Tested switching to y-axis cutting direction as the primary direction and it also works
- Attached video shows exaggerated cutter motion in which x and y position are changing

https://github.com/user-attachments/assets/cde72a52-4829-4b21-8944-a9077e806191

