### PR TITLE
Add Help URLs to Installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1490,6 +1490,8 @@ questionaire() {
             HAS_ENCODER=no
             HAS_SELECTOR=no
             HAS_SERVO=no
+            HELP_URL="https://github.com/moggieuk/Happy-Hare/wiki/Quick-Start-3MS"
+            HELP_URL_B="https://3dcoded.github.io/3MS/instructions/"
             _hw_mmu_vendor="3MS"
             _hw_mmu_version="1.0"
             _hw_selector_type=VirtualSelector
@@ -2103,6 +2105,13 @@ questionaire() {
     echo 
     echo "    Good luck! MMU is complex to setup. Remember Discord is your friend.."
     echo -e "    Join the dedicated Happy Hare forum here: ${EMPHASIZE}https://discord.gg/98TYYUf6f2${INFO}"
+    if [ -n "${HELP_URL}" ]; then
+        echo -e "    Make sure to follow these instructions while setting up your MMU:"
+        echo -e "    ${EMPHASIZE}${HELP_URL}"
+        if [ -n "${HELP_URL_B}" ]; then
+            echo -e "    ${EMPHASIZE}${HELP_URL_B}"
+        fi
+    fi
     echo
     echo "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
     echo


### PR DESCRIPTION
Hello,

I noticed that many help requests for MMUs are related to not reading documentation. While we can't exactly *make* people read docs, we can at least show them links as frequently as possible. This PR allows two help URLs per MMU to be added to the installer script. Currently, only the 3MS has help URLs, but it should be easy for other MMUs to add help URLs.

Example with the 3MS:

<img width="516" alt="Screenshot 2025-02-01 at 1 12 57 PM" src="https://github.com/user-attachments/assets/153c24eb-5b77-49cc-9a24-48db1afb36bd" />

This should hopefully help direct new users to the relevant docs for MMUs and keep MMU help forums focused on things that actually require help, and aren't just a result of not reading the docs.

---

**To add new help URLs**

1. Locate `"$_<YOUR MMU NAME>")` in `install.sh`
2. Add `HELP_URL` below `HAS_SERVO`
3. Optionally, add `HELP_URL_B` below `HELP_URL`

<img width="653" alt="Screenshot 2025-02-01 at 1 18 22 PM" src="https://github.com/user-attachments/assets/d51f416d-97d7-4f2d-a98c-f3527de3a34e" />
