### PR TITLE
Fix current spool in spoolman being activated after the load sequence is complete

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -4187,7 +4187,7 @@ class Mmu:
                 self._set_filament_direction(self.DIRECTION_LOAD)
                 self.selector.filament_drive()
 
-                # Record starting position for bowden progress tracking
+                # Record starting position for bowden progress tracking 
                 self.bowden_start_pos = self.get_encoder_distance(dwell=None) - start_pos
 
                 if self.gate_selected > 0 and self.rotation_distances[self.gate_selected] <= 0:


### PR DESCRIPTION
Fixes active spool in spoolman being set after the load sequence is complete. 

The current behaviour triggers the post load macros and then associates the spool from spoolman, meaning that any blobifier purging is not counted against the active filament.

Have moved both the load and unload association from Spoolman for consistency in the code.

Fixes #558

![image](https://github.com/user-attachments/assets/a204ea0e-8922-4927-9828-261f7a6a29bb)
