### PR TITLE
Check filament colour in PrusaSlicer as well

### DIFF
--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -758,7 +758,7 @@ METADATA_TOOL_DISCOVERY = "!referenced_tools!"
 
 # PS/SS uses "extruder_colour", Orca uses "filament_colour" but extruder_colour can exist with empty or single color
 COLORS_REGEX = {
-    'PrusaSlicer' : r"^;\s*extruder_colour\s*=\s*(#.*;*.*)$",
+    'PrusaSlicer' : r"^;\s*(?:extruder|filament)_colour\s*=\s*(#.*;*.*)$", #if extruder colour is not set, check filament colour
     'SuperSlicer' : r"^;\s*extruder_colour\s*=\s*(#.*;*.*)$",
     'OrcaSlicer'  : r"^;\s*filament_colour\s*=\s*(#.*;*.*)$",
     'BambuStudio' : r"^;\s*filament_colour\s*=\s*(#.*;*.*)$",


### PR DESCRIPTION
My files were not detecting the colours when pre-processed by Happy-Hare, found out, while looking at the gcode file that the line it was looking for was set as '; extruder_colour = ;;;;;;;' as my extruders are set to have the colour of the filament. This solves the problem by also looking at the filament colour (if the extruder colour is not set)