### PR TITLE
feat: add ability to call `variable_user_park_move_macro` on restore position

### DIFF
--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -271,7 +271,7 @@ variable_unretract_speed        : 30		; Speed of the unretract move in mm/s
 # ADVANCED: Normally x,y moves default to 'G1 X Y' to park position. This allows
 # you to create exotic movements. Macro will be provided the following parameters:
 #    YOUR_MOVE_MACRO X=<x_coord> Y=<y_coord> F=<speed>
-# when restoring the from parked postion the same macro is called but passed a RESTORE=1 paramter, along with co-ordinates to retore to
+# when restoring the from parked postion the same macro is called but passed a RESTORE=1 parameter, along with co-ordinates to restore to
 #    YOUR_MOVE_MACRO RESTORE=1 X=<x_coord> Y=<y_coord> F=<speed>
 variable_user_park_move_macro   : ''		; Executed instead of default 'G1 X Y move' to park position
 

--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -271,6 +271,8 @@ variable_unretract_speed        : 30		; Speed of the unretract move in mm/s
 # ADVANCED: Normally x,y moves default to 'G1 X Y' to park position. This allows
 # you to create exotic movements. Macro will be provided the following parameters:
 #    YOUR_MOVE_MACRO X=<x_coord> Y=<y_coord> F=<speed>
+# when restoring the from parked postion the same macro is called but passed a RESTORE=1 paramter, along with co-ordinates to retore to
+#    YOUR_MOVE_MACRO RESTORE=1 X=<x_coord> Y=<y_coord> F=<speed>
 variable_user_park_move_macro   : ''		; Executed instead of default 'G1 X Y move' to park position
 
 variable_auto_home              : True		; True = automatically home if necessary, False = disable

--- a/config/base/mmu_sequence.cfg
+++ b/config/base/mmu_sequence.cfg
@@ -273,11 +273,21 @@ gcode:
         G1 Z{park_vars.toolchange_z} F{park_lift_speed}	# Ensure at toolchange height for collision avoidance before move
     {% endif %}
     {% if should_restore_nextxy %}
-        MMU_LOG MSG="Restoring toolhead position to next pos: (x:{nx|round(1)}, y:{ny|round(1)}, z:{z|round(1)})"
-        G1 X{nx} Y{ny} F{park_travel_speed}		# Restore X,Y to next print position
+        {% if vars.user_park_move_macro %}
+                MMU_LOG MSG="Restoring toolhead position to next pos using {park_vars.user_park_move_macro} RESTORE=1 (x:{nx|round(1)}, y:{ny|round(1)})"
+                {vars.user_park_move_macro} RESTORE=1 X={nx} Y={ny} F={park_travel_speed}
+        {% else  %}
+                MMU_LOG MSG="Restoring toolhead position to next pos: (x:{nx|round(1)}, y:{ny|round(1)}, z:{z|round(1)})"
+                G1 X{nx} Y{ny} F{park_travel_speed}             # Restore X,Y to next print position
+        {% endif %}
     {% elif should_restore_xy %}
-        MMU_LOG MSG="Restoring toolhead position to last pos: (x:{x|round(1)}, y:{y|round(1)}, z:{z|round(1)})"
-        G1 X{x} Y{y} F{park_travel_speed}		# Restore X,Y to last (starting) position
+        {% if vars.user_park_move_macro %}
+                MMU_LOG MSG="Restoring toolhead position to next pos using {park_vars.user_park_move_macro} RESTORE=1 (x:{x|round(1)}, y:{y|round(1)})"
+                {vars.user_park_move_macro} RESTORE=1 X={x} Y={y} F={park_travel_speed}
+        {% else  %}
+                MMU_LOG MSG="Restoring toolhead position to last pos: (x:{x|round(1)}, y:{y|round(1)}, z:{z|round(1)})"
+                G1 X{x} Y{y} F{park_travel_speed}               # Restore X,Y to last (starting) position
+        {% endif %}
     {% elif park_vars.saved_pos %}
         MMU_LOG MSG="Restoring toolhead position to: (z:{z|round(1)})"
     {% endif %}

--- a/config/base/mmu_sequence.cfg
+++ b/config/base/mmu_sequence.cfg
@@ -274,7 +274,7 @@ gcode:
     {% endif %}
     {% if should_restore_nextxy %}
         {% if vars.user_park_move_macro %}
-                MMU_LOG MSG="Restoring toolhead position to next pos using {park_vars.user_park_move_macro} RESTORE=1 (x:{nx|round(1)}, y:{ny|round(1)})"
+                MMU_LOG MSG="Restoring toolhead position to next pos using {vars.user_park_move_macro} RESTORE=1 (x:{nx|round(1)}, y:{ny|round(1)})"
                 {vars.user_park_move_macro} RESTORE=1 X={nx} Y={ny} F={park_travel_speed}
         {% else  %}
                 MMU_LOG MSG="Restoring toolhead position to next pos: (x:{nx|round(1)}, y:{ny|round(1)}, z:{z|round(1)})"
@@ -282,7 +282,7 @@ gcode:
         {% endif %}
     {% elif should_restore_xy %}
         {% if vars.user_park_move_macro %}
-                MMU_LOG MSG="Restoring toolhead position to next pos using {park_vars.user_park_move_macro} RESTORE=1 (x:{x|round(1)}, y:{y|round(1)})"
+                MMU_LOG MSG="Restoring toolhead position to next pos using {vars.user_park_move_macro} RESTORE=1 (x:{x|round(1)}, y:{y|round(1)})"
                 {vars.user_park_move_macro} RESTORE=1 X={x} Y={y} F={park_travel_speed}
         {% else  %}
                 MMU_LOG MSG="Restoring toolhead position to last pos: (x:{x|round(1)}, y:{y|round(1)}, z:{z|round(1)})"


### PR DESCRIPTION
add ability to call `variable_user_park_move_macro` on restore position. 

when restoring the from parked postion the same macro is called but passed a RESTORE=1 parameter, along with co-ordinates to restore to `YOUR_MOVE_MACRO RESTORE=1 X=<x_coord> Y=<y_coord> F=<speed>`

### example of macro
```
[gcode_macro _MMU_USER_PARK]
description: always move to X74 first to clear brush then move in the Y direction, followed by the X direction
gcode:
  {% if params.RESTORE == 1 %}
    G1 X74 F{params.F}
    G1 Y{params.Y} F{params.F}
    G1 X{params.X} F{params.F}
  {% else %}
    G1 X74 F{params.F}
    G1 Y{params.Y} F{params.F}
    G1 X{params.X} F{params.F}
  {% endif %}
```
