### PR TITLE
fix: set default to None when looking up print_stats module

### DIFF
--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -107,8 +107,8 @@ class MmuRunoutHelper:
 
     def _process_state_change(self, eventtime, is_filament_present):
         # Determine "printing" status
-        print_stats = self.printer.lookup_object("print_stats")
-        if print_stats:
+        print_stats = self.printer.lookup_object("print_stats", None)
+        if print_stats is not None:
             is_printing = print_stats.get_status(eventtime)["state"] == "printing"
         else:
             is_printing = self.printer.lookup_object("idle_timeout").get_status(eventtime)["state"] == "Printing"


### PR DESCRIPTION
This means printing status will fall back to idle_timeout, which reports "Printing" anytime the printer performs any action until the idle timeout occurs. So it really has a different meaning, but I guess octoprint conflicts with using virtual_sdcard (which is what auto loads the print_stats module and updates it's stats).

This was an issue raised [here](https://discord.com/channels/1305204275315474452/1305204561186914376/1337239962827096120)