### PR TITLE
Reopen "Check filament colour in PrusaSlicer as well"

### DIFF
--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -758,7 +758,7 @@ METADATA_TOOL_DISCOVERY = "!referenced_tools!"
 
 # PS/SS uses "extruder_colour", Orca uses "filament_colour" but extruder_colour can exist with empty or single color
 COLORS_REGEX = {
-    'PrusaSlicer' : r"^;\s*extruder_colour\s*=\s*(#.*;*.*)$",
+    'PrusaSlicer' : r"^;\s*(?:extruder|filament)_colour\s*=\s*(#.*;*.*)$", #if extruder colour is not set, check filament colour
     'SuperSlicer' : r"^;\s*extruder_colour\s*=\s*(#.*;*.*)$",
     'OrcaSlicer'  : r"^;\s*filament_colour\s*=\s*(#.*;*.*)$",
     'BambuStudio' : r"^;\s*filament_colour\s*=\s*(#.*;*.*)$",


### PR DESCRIPTION
Reverts moggieuk/Happy-Hare#631

As I explained in the [discussion on the original PR](https://github.com/moggieuk/Happy-Hare/pull/622#issuecomment-2648306760) after you pointed out that it should take into account the extruder, it looks at the extruder first, as it appears always first in the code file. 

This change makes it so that the filament colours will be checked only if the extruder has no valid colours, which was happening to me as I set my extruders to be the filament colour in PrusaSlicer and they show up as '; extruder_colour = ;;;;;;;'.

As such, I'm reopening this PR.

I want to point out that I should have explained the problem and this solution better in the original PR, sorry.