### PR TITLE
fix: make safe travel move dependent on cutting axis

### DIFF
--- a/config/base/mmu_cut_tip.cfg
+++ b/config/base/mmu_cut_tip.cfg
@@ -148,11 +148,17 @@ gcode:
 
     {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
     {% set travel_speed = vars['travel_speed']|float %}
+    {% set cutting_axis = vars['cutting_axis'] %}
 
     {% if ((printer.gcode_move.gcode_position.x - pin_park_x_loc)|abs < safe_margin_x) or ((printer.gcode_move.gcode_position.y - pin_park_y_loc)|abs < safe_margin_y) %}
         # Make a safe but slower travel move
-        G1 X{pin_park_x_loc} F{travel_speed * 60}
-        G1 Y{pin_park_y_loc} F{travel_speed * 60}
+        {% if cutting_axis == "x" %}
+            G1 X{pin_park_x_loc} F{travel_speed * 60}
+            G1 Y{pin_park_y_loc} F{travel_speed * 60}
+        {% else %}
+            G1 Y{pin_park_y_loc} F{travel_speed * 60}
+            G1 X{pin_park_x_loc} F{travel_speed * 60}
+        {% endif %}
     {% else %}
         G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed * 60}
     {% endif %}


### PR DESCRIPTION
If we need to do a safe travel move, first the cutting axis should be moved and then the other one. I have my cutter on the y axis and moving x first would cause the lever to crash into the pin.