### PR TITLE
Sync mechanism fixing and/or enhancing 

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -2793,6 +2793,8 @@ class Mmu:
             self.sync_feedback_last_state = float(state)
             if self.sync_feedback_enable and self.sync_feedback_operational:
                 self._update_sync_multiplier()
+        else :
+            self.log_error("Invalid sync feedback state: %s" % state)
 
     def _handle_mmu_synced(self):
         if not self.is_enabled: return

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -2834,20 +2834,12 @@ class Mmu:
             pos = extruder.find_past_position(estimated_print_time)
             past_pos = extruder.find_past_position(max(0., estimated_print_time - self.SYNC_POSITION_TIMERANGE))
             if abs(pos - past_pos) >= self.SYNC_POSITION_MIN_DELTA:
-                # change in direction
                 prev_direction = self.sync_feedback_last_direction
                 self.sync_feedback_last_direction = self.DIRECTION_LOAD if pos > past_pos else self.DIRECTION_UNLOAD if pos < past_pos else 0
                 if self.sync_feedback_last_direction != prev_direction:
                     d = self.sync_feedback_last_direction
                     self.log_trace("New sync direction: %s" % ('extrude' if d == self.DIRECTION_LOAD else 'retract' if d == self.DIRECTION_UNLOAD else 'static'))
                     self._update_sync_multiplier()
-                # change in state
-                prev_state = self.sync_feedback_last_state
-                self.sync_feedback_last_state = self._get_current_sync_state()
-                if self.sync_feedback_last_state != prev_state:
-                    self.log_trace("New sync state: %s" % self._get_sync_feedback_string())
-                    self._update_sync_multiplier()
-
         return eventtime + self.SYNC_FEEDBACK_INTERVAL
 
     def _update_sync_multiplier(self):
@@ -4206,7 +4198,7 @@ class Mmu:
                 self._set_filament_direction(self.DIRECTION_LOAD)
                 self.selector.filament_drive()
 
-                # Record starting position for bowden progress tracking 
+                # Record starting position for bowden progress tracking
                 self.bowden_start_pos = self.get_encoder_distance(dwell=None) - start_pos
 
                 if self.gate_selected > 0 and self.rotation_distances[self.gate_selected] <= 0:
@@ -4240,7 +4232,7 @@ class Mmu:
                             self.log_info("Warning: Excess slippage was detected in bowden tube load afer correction moves. Gear moved %.1fmm, Encoder measured %.1fmm. See mmu.log for more details"% (length, length - delta))
                     else:
                         self.log_info("Warning: Excess slippage was detected in bowden tube load but 'bowden_apply_correction' is disabled. Gear moved %.1fmm, Encoder measured %.1fmm. See mmu.log for more details" % (length, length - delta))
-    
+
                     if delta >= self.bowden_allowable_load_delta:
                         self.log_debug("Possible causes of slippage:\nCalibration ref length too long (hitting extruder gear before homing)\nCalibration ratio for gate is not accurate\nMMU gears are not properly gripping filament\nEncoder reading is inaccurate\nFaulty servo")
 
@@ -4277,7 +4269,7 @@ class Mmu:
                 self._set_filament_direction(self.DIRECTION_UNLOAD)
                 self.selector.filament_drive()
 
-                # Record starting position for bowden progress tracking 
+                # Record starting position for bowden progress tracking
                 self.bowden_start_pos = self.get_encoder_distance(dwell=None)
 
                 # Optional pre-unload safety step
@@ -4736,7 +4728,7 @@ class Mmu:
 
             # Activate loaded spool in Spoolman
             self._spoolman_activate_spool(self.gate_spool_id[self.gate_selected])
-            
+
             # POST_LOAD user defined macro
             if macros_and_track:
                 with self._wrap_track_time('post_load'):
@@ -4890,7 +4882,7 @@ class Mmu:
 
             # Deactivate spool in Spoolman as it is now unloaded.
             self._spoolman_activate_spool(0)
-            
+
             # POST_UNLOAD user defined macro
             if macros_and_track:
                 with self._wrap_track_time('post_unload'):

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -2795,6 +2795,7 @@ class Mmu:
                 self._update_sync_multiplier()
         else :
             self.log_error("Invalid sync feedback state: %s" % state)
+        self.printer.send_event("mmu:sync_feedback_finished", state)
 
     def _handle_mmu_synced(self):
         if not self.is_enabled: return

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -2820,7 +2820,7 @@ class Mmu:
             # Disable sync feedback
             self.reactor.update_timer(self.sync_feedback_timer, self.reactor.NEVER)
             self.sync_feedback_operational = False
-            self.sync_feedback_last_direction = self.SYNC_STATE_NEUTRAL
+            self.sync_feedback_last_state = self.SYNC_STATE_NEUTRAL
             self.log_trace("Reset sync multiplier")
             self._set_rotation_distance(self._get_rotation_distance(self.gate_selected))
 

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -2841,7 +2841,7 @@ class Mmu:
 
     def _update_sync_multiplier(self):
         if not self.sync_feedback_enable or not self.sync_feedback_operational: return
-        if self.sync_feedback_last_direction == self.SYNC_STATE_NEUTRAL:
+        if self.sync_feedback_last_state == self.SYNC_STATE_NEUTRAL:
             multiplier = 1.
         else:
             go_slower = lambda s, d: abs(s - d) < abs(s + d)

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -519,6 +519,8 @@ class Mmu:
         self.tool_extrusion_multipliers.extend([1.] * self.num_gates)
         self.tool_speed_multipliers.extend([1.] * self.num_gates)
 
+        # Soak Testing
+        self._is_running_test = False
         # Register GCODE commands ---------------------------------------------------------------------------
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode_move = self.printer.load_object(config, 'gcode_move')
@@ -2802,7 +2804,8 @@ class Mmu:
                 self._update_sync_multiplier()
         else :
             self.log_error("Invalid sync feedback state: %s" % state)
-        self.printer.send_event("mmu:sync_feedback_finished", state)
+        if self._is_running_test:
+            self.printer.send_event("mmu:sync_feedback_finished", state)
 
     def _handle_mmu_synced(self):
         if not self.is_enabled: return

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -55,7 +55,7 @@ class MmuTest:
             compression_sensor = self.mmu.printer.lookup_object("filament_switch_sensor %s_sensor" % self.mmu.SENSOR_COMPRESSION, None)
             tension_sensor = self.mmu.printer.lookup_object("filament_switch_sensor %s_sensor" % self.mmu.SENSOR_TENSION, None)
             if sync_state == 'loop':
-                nb_iterations = gcmd.get_int('LOOP', 1000, minval=1, maxval=1000000)
+                nb_iterations = gcmd.get_int('LOOP', 1000, minval=1, maxval=10000000)
                 gathered_states = []
                 tests = []
                 def test_2_string(test):
@@ -136,6 +136,9 @@ class MmuTest:
                     compression_sensor.runout_helper.note_filament_present(compression_sensor_filament_present)
                 if tension_sensor is not None:
                     tension_sensor.runout_helper.note_filament_present(tension_sensor_filament_present)
+            # remove event handlers
+            self.mmu.printer.event_handlers.pop("mmu:sync_feedback_finished", None)
+            self.mmu.printer.event_handlers.pop("mmu:state_gathering_finished", None)
             return
 
 

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -78,7 +78,7 @@ class MmuTest:
                         # sort by most mismatches.values (highest first)
                         mismatches = dict(sorted(mismatches.items(), key=lambda item: item[1], reverse=True))
                         for test, count in mismatches.items():
-                            self.mmu.log_trace("MISMATCH: %s -> %s" % (test_2_string(test), count))
+                            self.mmu.log_debug("MISMATCH: %s -> %s" % (test_2_string(test), count))
 
                 self.mmu.printer.register_event_handler("mmu:sync_feedback_finished", gather_state)
                 self.mmu.printer.register_event_handler("mmu:state_gathering_finished", display_mimatches)

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -28,6 +28,7 @@ class MmuTest:
 
     cmd_MMU_TEST_help = "Internal Happy Hare development tests"
     def cmd_MMU_TEST(self, gcmd):
+        self.mmu._is_running_test = True
         self.mmu.log_to_file(gcmd.get_commandline())
         if self.mmu.check_if_disabled(): return
 
@@ -542,3 +543,5 @@ class MmuTest:
         fil_pos = gcmd.get_int('FILAMENT_POS', -2, minval=-1, maxval=10)
         if fil_pos != -2:
             self.mmu._set_filament_pos_state(fil_pos)
+        # Restore non testing context
+        self.mmu._is_running_test = False

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -86,7 +86,7 @@ class MmuTest:
                     self.mmu.log_info("NB Gathered states: %s" % len(gathered_states))
                     self.mmu.log_info("NB Tests: %s" % len(tests))
                     # for each configuration print the number of times it was run
-                    self.mmu.log_info("Configuration repartition")
+                    self.mmu.log_debug("Configuration repartition")
                     nb_hits = {}
                     for comp in [None, True, False]:
                         for tens in [None, True, False]:
@@ -100,7 +100,7 @@ class MmuTest:
                         self.mmu.log_debug("   compression : %s - tension : %s -> %s" % (key[0], key[1], value))
 
                     # group by expected result and print how many tests should result in that state
-                    self.mmu.log_info("Expected state repartition")
+                    self.mmu.log_debug("Expected state repartition")
                     for expected in [1.,0.,-1.]:
                         count = len([1 for __, sync_state_float in tests if sync_state_float == expected])
                         self.mmu.log_debug("   Expected state %s -> %s" % (expected, count))
@@ -145,7 +145,7 @@ class MmuTest:
 
                 self.mmu.printer.register_event_handler("mmu:sync_feedback_finished", gather_state)
                 self.mmu.printer.register_event_handler("mmu:test_gen_finished", wait_for_results)
-                for __ in range(nb_iterations):
+                while len(tests) < nb_iterations:
                     compression_sensor_filament_present = None
                     tension_sensor_filament_present = None
                     toggle_compression = "no change"
@@ -165,6 +165,8 @@ class MmuTest:
                                 toggle_tension = "rising edge" if tension_sensor_filament_present else "falling edge"
                                 tension_sensor.runout_helper.note_filament_present(tension_sensor_filament_present)
                                 tests.append([(compression_sensor_filament_present, tension_sensor_filament_present, toggle_compression, toggle_tension), sync_state_float])
+                        if len(tests) >= nb_iterations:
+                            break
                     else :
                         if tension_sensor is not None:
                             tension_sensor_filament_present = random.choice([True, False])

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -67,9 +67,9 @@ class MmuTest:
                 def display_mimatches():
                     mismatches = {}
                     for i, (test, sync_state_float) in enumerate(tests):
+                        if test not in mismatches :
+                            mismatches.update({test: 0})
                         if sync_state_float != gathered_states[i]:
-                            if test not in mismatches :
-                                mismatches.update({test: 0})
                             mismatches[test] += 1
                     # display mismatches
                     self.mmu.log_info("Total Mismatches: "+str(sum(mismatches.values())) + '/' + str(nb_iterations) + ' (' + str(sum(mismatches.values()) / nb_iterations * 100) +' %)')

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -87,7 +87,6 @@ class MmuTest:
                     compression_sensor_filament_present = random.choice([True, False])
                     tension_sensor_filament_present = random.choice([True, False])
                     order = random.choice([0,1])
-                    # self.mmu.log_info("Testing confugaration: compression=%s, tension=%s, order=%s" % (compression_sensor_filament_present, tension_sensor_filament_present, 'compression -> tension' if not order else 'tension -> compression'))
                     if order == 0:
                         if compression_sensor is not None:
                             if compression_sensor_filament_present != compression_sensor.runout_helper.filament_present: toggle_compression = True
@@ -102,11 +101,9 @@ class MmuTest:
                         if compression_sensor is not None:
                             if compression_sensor_filament_present != compression_sensor.runout_helper.filament_present: toggle_compression = True
                             compression_sensor.runout_helper.note_filament_present(compression_sensor_filament_present)
-                    # check state and try to find problematic sync state
                     if compression_sensor_filament_present and not tension_sensor_filament_present: sync_state_float = 1.0
                     elif not compression_sensor_filament_present and tension_sensor_filament_present: sync_state_float = -1.0
                     else: sync_state_float = 0.0
-                    # wait for callback to be finished
                     tests.append([(compression_sensor_filament_present, tension_sensor_filament_present, order, toggle_compression, toggle_tension), sync_state_float])
 
             else :

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -240,7 +240,7 @@ class MmuSensors:
         real_pin = pin_resolver.aliases.get(pin_params['pin'], '_real_')
         return real_pin == ''
 
-        # Button event handlers for sync-feedback
+    # Button event handlers for sync-feedback
     # Feedback state should be between -1 (expanded) and 1 (compressed)
     def _sync_tension_callback(self, eventtime, tension_state, runout_helper):
         from .mmu import Mmu # For sensor names
@@ -250,12 +250,11 @@ class MmuSensors:
         compression_state = compression_sensor.runout_helper.filament_present if has_active_compression else False
 
         if tension_enabled:
-            if has_active_compression:
-                if compression_state:
-                    logging.info("Malfunction of sync-feedback unit: both tension and compression sensors are triggered at the same time!")
-                    event_value = 0  # neutral for malfunction
-                else:
-                    event_value = -(tension_state * 2 - 1) # -1 or 1
+            if has_active_compression and compression_state:
+                logging.info("Malfunction of sync-feedback unit: both tension and compression sensors are triggered at the same time!")
+                event_value = 0  # neutral for malfunction
+            elif has_active_compression:
+                event_value = -(tension_state * 2 - 1) # -1 or 1
             else:
                 event_value = -tension_state # -1 or 0 (neutral)
         else:

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -251,10 +251,13 @@ class MmuSensors:
 
         if tension_enabled:
             if has_active_compression and compression_state:
-                logging.info("Malfunction of sync-feedback unit: both tension and compression sensors are triggered at the same time!")
-                event_value = 0  # neutral for malfunction
-            elif has_active_compression:
-                event_value = -(tension_state * 2 - 1) # -1 or 1
+                if tension_state and compression_state:
+                    logging.info("Malfunction of sync-feedback unit: both tension and compression sensors are triggered at the same time!")
+                    event_value = 0
+                elif tension_state and not compression_state:
+                    event_value = -1
+                elif not tension_state and compression_state:
+                    event_value = 1
             else:
                 event_value = -tension_state # -1 or 0 (neutral)
         else:
@@ -271,10 +274,13 @@ class MmuSensors:
 
         if compression_enabled:
             if has_active_tension and tension_state:
-                logging.info("Malfunction of sync-feedback unit: both tension and compression sensors are triggered at the same time!")
-                event_value = 0  # neutral for malfunction
-            elif has_active_tension:
-                event_value = compression_state * 2 - 1  # 1 or -1
+                if compression_state and tension_state:
+                    logging.info("Malfunction of sync-feedback unit: both tension and compression sensors are triggered at the same time!")
+                    event_value = 0
+                elif compression_state and not tension_state:
+                    event_value = 1
+                elif not compression_state and tension_state:
+                    event_value = -1
             else:
                 event_value = compression_state  # 1 or 0 (neutral)
         else:

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -120,13 +120,12 @@ class MmuRunoutHelper:
                 self.reactor.register_callback(lambda reh: self._insert_event_handler(eventtime))
 
         else: # Remove or Runout detected
+            self.min_event_systime = self.reactor.NEVER
             if is_printing and self.runout_suspended is False and self.runout_gcode:
-                self.min_event_systime = self.reactor.NEVER
                 #logging.info("MMU: filament sensor %s: runout event detected, Eventtime %.2f" % (self.name, eventtime))
                 self.reactor.register_callback(lambda reh: self._runout_event_handler(eventtime))
             elif self.remove_gcode and (not is_printing or self.insert_remove_in_print):
                 # Just a "remove" event
-                self.min_event_systime = self.reactor.NEVER
                 #logging.info("MMU: filament sensor %s: remove event detected, Eventtime %.2f" % (self.name, eventtime))
                 self.reactor.register_callback(lambda reh: self._remove_event_handler(eventtime))
 

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -247,7 +247,7 @@ class MmuSensors:
         from .mmu import Mmu # For sensor names
         tension_enabled = runout_helper.sensor_enabled
         compression_sensor = self.printer.lookup_object("filament_switch_sensor %s_sensor" % Mmu.SENSOR_COMPRESSION, None)
-        has_active_compression = compression_sensor.runout_helper.sensor_enabled if compression_sensor else False
+        has_active_compression = (compression_sensor.runout_helper.sensor_enabled and compression_sensor.runout_helper.filament_present) if compression_sensor else False
 
         if tension_enabled and not has_active_compression:
             self.printer.send_event("mmu:sync_feedback", eventtime, -(state * 2 - 1)) # -1 or 1
@@ -258,7 +258,7 @@ class MmuSensors:
         from .mmu import Mmu # For sensor names
         compression_enabled = runout_helper.sensor_enabled
         tension_sensor = self.printer.lookup_object("filament_switch_sensor %s_sensor" % Mmu.SENSOR_TENSION, None)
-        has_active_tension = tension_sensor.runout_helper.sensor_enabled if tension_sensor else False
+        has_active_tension = (tension_sensor.runout_helper.sensor_enabled and tension_sensor.runout_helper.filament_present) if tension_sensor else False
 
         if compression_enabled and not has_active_tension:
             self.printer.send_event("mmu:sync_feedback", eventtime, state * 2 - 1) # 1 or -1


### PR DESCRIPTION
Hi @moggieuk ,

It's me at it again =) I'm currently experiencing issues regarding the sync_feedback feature and whilst reading through the implementation i noticed some things.
- I might have stumbled upon some bugs see commit 944bbbdc2e67797799005c1ae48e0a6e1a8d40d8. Is this intended ? It seemed weird you would reset the direction to state but it might not have consequences.
- Another strange thing here see commit 0b9695eb236fd27cef46096541ca3d5463661fe1. I feels like the `multiplier = 1` should more depend on the state rather than the direction ?
- In the sensor description, i might not have understood this correctly but it seems we should check for filament_present additionally to enabled ? (see commit 4d92abd8de5790bf3ddf8da1f027178336216b08)
 
Additionally I'm experiencing issues on my compression+tension feedback sensor setup (hence the deep dive into the code) and found that in my case having compression and tension detected simultaneously is actually not an error but more a "buggy" neutral position. In some cases i felt like the some "tension" or "compression" button events wouldn't result in a multiplier change (not sure why but maybe when both are triggered ?).

My current fix (might not be final) is to use the timer you coded and additionally to direction changes check for state changes. I should not have to do this but this would ensure the code would auto-fix it's state periodically see bc949a1c0a1d7fcc0fe66b7a03c1f68f2321eb62.

Let me get your thoughts on this matter whenever you are available. I'll keep on trying to fix the "intended" event based sync_feedback.