### PR TITLE
fix: return status for rotary selector

### DIFF
--- a/extras/mmu/mmu_selector.py
+++ b/extras/mmu/mmu_selector.py
@@ -1178,6 +1178,7 @@ class RotarySelector(BaseSelector, object):
         status.update({
             'grip': "Gripped" if self.grip_state == self.mmu.FILAMENT_DRIVE_STATE else "Released",
         })
+        return status
 
     def get_mmu_status_config(self):
         msg = "\nSelector is %s" % ("HOMED" if self.is_homed else "NOT HOMED")

--- a/extras/mmu/mmu_selector.py
+++ b/extras/mmu/mmu_selector.py
@@ -1392,6 +1392,7 @@ class RotarySelector(BaseSelector, object):
             pass # Home not found
         mcu_position = self.selector_stepper.get_mcu_position()
         traveled = abs(mcu_position - init_mcu_pos) * self.selector_stepper.get_step_dist()
+        return traveled, homed
 
 
 


### PR DESCRIPTION
Fixes issue reported [here](https://discord.com/channels/1305204275315474452/1307001795096084500/1340910903603888170).

[klippy.log](https://github.com/user-attachments/files/18821198/klippy.39.log)

First exception during startup:

```
Unhandled exception during run
Traceback (most recent call last):
  File "/home/pi/klipper/klippy/klippy.py", line 176, in run
    self.reactor.run()
  File "/home/pi/klipper/klippy/reactor.py", line 292, in run
    g_next.switch()
  File "/home/pi/klipper/klippy/reactor.py", line 340, in _dispatch_loop
    timeout = self._check_timers(eventtime, busy)
  File "/home/pi/klipper/klippy/reactor.py", line 158, in _check_timers
    t.waketime = waketime = t.callback(eventtime)
  File "/home/pi/klipper/klippy/webhooks.py", line 496, in _do_query
    res = query[obj_name] = po.get_status(eventtime)
  File "/home/pi/klipper/klippy/extras/mmu/mmu.py", line 1391, in get_status
    status.update(self.selector.get_status())
TypeError: 'NoneType' object is not iterable
```
