### PR TITLE
fix(boxturtle): Increase default gate_preload_homing_max to 200

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1453,6 +1453,7 @@ questionaire() {
             _param_extruder_homing_endstop="none"
             _param_gate_homing_endstop="mmu_gate"
             _param_gate_homing_max=300
+            _param_gate_preload_homing_max=200
             _param_gate_parking_distance=100
             _param_gate_final_eject_distance=100
             _param_has_filament_buffer=0


### PR DESCRIPTION
The previous default of 70 was too short and made it so you had to be really fast once you get the filament through the pre-load sensor. Setting this to something longer allows it to essentially try preloading longer so you have more time to get that filament pushed down to the gear