### PR TITLE
fix: ensure rgb hex is no more than 6 characters

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -1023,7 +1023,7 @@ class Mmu:
         elif color == '':
             color = "#000000"
         rgb_hex = color.lstrip('#').lower()
-        return rgb_hex
+        return rgb_hex[0:6]
 
     # This retuns a convenient RGB fraction tuple for controlling LEDs E.g. (0.32, 0.56, 1.00)
     # or integer version (82, 143, 255)


### PR DESCRIPTION
Previously if the color had an alpha channel (e.g. DFB1C0FF), then in `_color_to_rgb_tuple` it would not parse the color and just return all black. In my latest print I had the following colors (first 3 from spoolman via alpha mainsail ui, last one was manual)

```
color_list = ['111111FF', 'CFCCD6FF', 'DFB1C0FF', '042f56']
```

Then doing a test with, the following, both got mapped to `042f56` since that one is closest to black.

```
print(_find_closest_color('042F56', color_list))
print(_find_closest_color('CFCCD6', color_list))
```