### PR TITLE
Accommodate fans other than [fan] in Blobifier

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -218,6 +218,7 @@ variable_part_cooling_fan:  1               # Run it at full speed
 # Define the part fan name if you are using a fan other than [fan]
 # Applies to [fan_generic] or other fan definitons
 # Example would be if you are using auxiliary fan control in Orcaslicer (https://github.com/SoftFever/OrcaSlicer/wiki/Auxiliary-fan)
+# If you are unsure if you need this, then probably just leave it commented out.
 
 #variable_fan_name: "fan_generic fan0"
 

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -215,6 +215,13 @@ variable_pressure_release_time: 1000
 #variable_part_cooling_fan:  0              # Disable the fan
 variable_part_cooling_fan:  1               # Run it at full speed
 
+# Define the part fan name if you are using a fan other than [fan]
+# Applies to [fan_generic] or other fan definitons
+# Example would be if you are using auxiliary fan control in Orcaslicer (https://github.com/SoftFever/OrcaSlicer/wiki/Auxiliary-fan)
+
+#variable_fan_name: "fan_generic fan0"
+
+
 
 # ========================================================================================
 # ==================== PURGE LENGTH TUNING ===============================================
@@ -292,8 +299,9 @@ gcode:
     
     # Part cooling fan
     {% if part_cooling_fan >= 0 %}
+      {% set fan = fan_name|string %}
       # Save the part cooling fan speed to be enabled again later
-      {% set backup_fan_speed = printer.fan.speed %}
+      {% set backup_fan_speed = (printer[fan].speed if printer[fan] is defined else printer.fan.speed) %}
       # Set part cooling fan speed
       M106 S{part_cooling_fan * 255}
     {% endif %}


### PR DESCRIPTION
Added a variable (fan_name) to allow restoring fan speed after using Blobifier if one is using a fan definition other than [fan] for a part fan.

For example, I am using the [auxiliary fan functionality](https://github.com/SoftFever/OrcaSlicer/wiki/Auxiliary-fan) in OrcaSlicer which has a different configuration in order to use properly in which the part fan is controlled using a [fan_generic] definition and an override of the M106 command. Therefore, using printer.fan.speed to get the current fan speed and save it as `backup_fan_speed` will result in the "true" part fan being set to 0.

The implementation is compatible with either configuration of part fan with the variable providing a default example which is the suggested configuration provided by the OrcaSlicer wiki.