### PR TITLE
Make the warning on `servo_always_active` and `servo_active_down` more explicit

### DIFF
--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -59,8 +59,8 @@ servo_down_angle: 30			# ERCF: MG90S: 140 ; SAVOX SH0255MG: 30  ; Tradrack: 1
 servo_move_angle: 109			# Optional angle used when selector is moved (defaults to up position)
 servo_duration: 0.4			# Duration of PWM burst sent to servo (default non-active mode, automatically turns off)
 servo_dwell: 0.5			# Minimum time given to servo to complete movement prior to next move
-servo_always_active: 0 			# CAUTION - WILL DAMAGE COMMON SERVOS: 1=Force servo to always stay active, 0=Release after movement
-servo_active_down: 0			# CAUTION - WILL DAMAGE COMMON SERVOS: 1=Force servo to stay active when down only, 0=Release after movement
+servo_always_active: 0 			# CAUTION - WILL DAMAGE COMMON SERVOS, PLEASE USE AT YOUR OWN RISK: 1=Force servo to always stay active, 0=Release after movement
+servo_active_down: 0			# CAUTION - WILL DAMAGE COMMON SERVOS, PLEASE USE AT YOUR OWN RISK: 1=Force servo to stay active when down only, 0=Release after movement
 servo_buzz_gear_on_down: 0		# Whether to "buzz" the gear stepper on down to aid engagement
 
 

--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -59,8 +59,8 @@ servo_down_angle: 30			# ERCF: MG90S: 140 ; SAVOX SH0255MG: 30  ; Tradrack: 1
 servo_move_angle: 109			# Optional angle used when selector is moved (defaults to up position)
 servo_duration: 0.4			# Duration of PWM burst sent to servo (default non-active mode, automatically turns off)
 servo_dwell: 0.5			# Minimum time given to servo to complete movement prior to next move
-servo_always_active: 0 			# CAUTION: 1=Force servo to always stay active, 0=Release after movement
-servo_active_down: 0			# CAUTION: 1=Force servo to stay active when down only, 0=Release after movement
+servo_always_active: 0 			# CAUTION - WILL DAMAGE COMMON SERVOS: 1=Force servo to always stay active, 0=Release after movement
+servo_active_down: 0			# CAUTION - WILL DAMAGE COMMON SERVOS: 1=Force servo to stay active when down only, 0=Release after movement
 servo_buzz_gear_on_down: 0		# Whether to "buzz" the gear stepper on down to aid engagement
 
 


### PR DESCRIPTION
As discussed on #637, this makes the warning more forceful.

After trying out some wordings, I settled on "will" because it's not a matter of *if* but *when*, but say "common servos" to make room for the rare setups that do require it.

I am however not married to this wording and am happy to consider alternatives.