### PR TITLE
Blobifier: Display correct variable value for z_raise_exp validation check

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -894,7 +894,7 @@ gcode:
 
   # Z raise exponent
   {% if bl.z_raise_exp > 1 or bl.z_raise_exp < 0.5 %}
-    {action_respond_info("BLOBIFIER: variable_z_raise_exp has value: %f. This value is out of spec (0.5 ... 1.0)." % (bl.z_raise))}
+    {action_respond_info("BLOBIFIER: variable_z_raise_exp has value: %f. This value is out of spec (0.5 ... 1.0)." % (bl.z_raise_exp))}
   {% endif %}
 
   # cap user defined accels at printer max_accel if greater


### PR DESCRIPTION
Fixes https://github.com/moggieuk/Happy-Hare/issues/655. Correct variable used to display current value for z_raise_exp (was incorrectly using z_raise). Ready to merge.