### PR TITLE
fix: When automatically heating extruder, use gate temperature on gate 0 as well

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -3560,7 +3560,7 @@ class Mmu:
         current_temp = extruder.get_status(0)['temperature']
         current_target_temp = extruder.heater.target_temp
         klipper_minimum_temp = extruder.get_heater().min_extrude_temp
-        default_extruder_temp = self.gate_temperature[self.gate_selected] if self.gate_selected > 0 else self.default_extruder_temp
+        default_extruder_temp = self.gate_temperature[self.gate_selected] if self.gate_selected >= 0 else self.default_extruder_temp
         self.log_trace("_ensure_safe_extruder_temperature: current_temp=%s, paused_extruder_temp=%s, current_target_temp=%s, klipper_minimum_temp=%s, default_extruder_temp=%s, source=%s" % (current_temp, self.paused_extruder_temp, current_target_temp, klipper_minimum_temp, default_extruder_temp, source))
 
         if source == "pause":


### PR DESCRIPTION
When changing tools from idle, loading or unloading gate 0 did not use the gate temperature, but the default  temperature.

I believe the `> 0` check was in error because there's two constants for unknown and bypass in the negative, but 0 should already represent a valid gate.

I only tested that is now correctly uses the gate temperature when automatically heating for gate 0, but no other scenario.