### PR TITLE
Change default of pin_loc_compressed from None to -999

### DIFF
--- a/config/base/mmu_cut_tip.cfg
+++ b/config/base/mmu_cut_tip.cfg
@@ -175,8 +175,8 @@ gcode:
     {% set vars = printer['gcode_macro _MMU_CUT_TIP_VARS'] %}
     {% set cutting_axis = vars['cutting_axis'] %}
 
-    {% set pin_loc = vars['pin_loc_compressed']|default(None)|float %}
-    {% if pin_loc is not none %}
+    {% set pin_loc = vars['pin_loc_compressed']|default(-999)|float %}
+    {% if pin_loc != -999 %}
         # Old one-dimensional pin_loc_compressed config
         {% if cutting_axis == "x" %}
             {% set pin_loc_compressed_x = pin_loc %}


### PR DESCRIPTION
I believe that the default being None and then setting the type as a float leads to python internally converting it to a 0. I changed it to -999 as the default to be unambiguous about what it is attempting to evaluate and it highly unlikely that someone has a real value of -999.