### PR TITLE
Tip forming part cooling fan assist for generic fan

### DIFF
--- a/config/base/mmu_form_tip.cfg
+++ b/config/base/mmu_form_tip.cfg
@@ -159,7 +159,7 @@ gcode:
     {% set toolchange_temp = vars['toolchange_temp']|default(0)|int %}
     {% set toolchange_use_fan = vars['toolchange_fan_assist']|default(false)|lower == 'true' %}
     {% set toolchange_fan_speed = vars['toolchange_fan_speed']|default(50)|int %}
-    {% set fan = fan_name|string %}
+    {% set fan = vars['fan_name']|string %}
 
     {% if toolchange_use_fan %}
         {% if (printer.fan is defined) or (printer[fan] is defined) %}

--- a/config/base/mmu_form_tip.cfg
+++ b/config/base/mmu_form_tip.cfg
@@ -159,10 +159,11 @@ gcode:
     {% set toolchange_temp = vars['toolchange_temp']|default(0)|int %}
     {% set toolchange_use_fan = vars['toolchange_fan_assist']|default(false)|lower == 'true' %}
     {% set toolchange_fan_speed = vars['toolchange_fan_speed']|default(50)|int %}
+    {% set fan = fan_name|string %}
 
     {% if toolchange_use_fan %}
-        {% if printer.fan is defined %}
-            {% set orig_fan_speed = printer.fan.speed %}
+        {% if (printer.fan is defined) or (printer[fan] is defined) %}
+            {% set orig_fan_speed = (printer[fan].speed if printer[fan] is defined else printer.fan.speed) %}
             M106 S{(toolchange_fan_speed / 100 * 255)|int}
             M109 S{toolchange_temp}
             M106 S{(orig_fan_speed * 255)|int}

--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -407,6 +407,7 @@ variable_ramming_volume_standalone : 0		; Volume in mm^3, 0 = disabled
 # moves. Temperature will be restored after tip creation is complete
 variable_toolchange_temp        : 0		; 0 = don't change temp, else temp to set
 variable_toolchange_fan_assist  : False		; Whether to use part cooling fan for quicker temp change
+#variable_fan_name: "fan_generic fan0"   ; Define the part fan name if you are using a fan other than [fan]
 variable_toolchange_fan_speed   : 50		; Fan speed % if using fan_assist enabled
 
 # Step 2 - Nozzle Separation


### PR DESCRIPTION
Added variable_fan_name for using [auxiliary fan](https://github.com/SoftFever/OrcaSlicer/wiki/Auxiliary-fan) in Orcaslicer, which redefines part cooling fan as a generic fan, during tip forming workflow.

See #649 for a similar use case.

#669