### PR TITLE
fix: Add whitespace between end quote and comment marker

### DIFF
--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -328,8 +328,8 @@ variable_simple_tip_forming     : True		; True = Perform simple tip forming, Fal
 # Change to X and Y stepper current during the cut operation. Technically any stepper
 # current can be modified by adding the stepper name to the list. Be careful not to
 # overload your steppers but generally up to 150% is safe
-variable_cut_axis_steppers      : 'stepper_x, stepper_y'; Comma separated list of stepper names to increase current for cutting
-variable_cut_stepper_current    : 100			; % of stepper current to use for cutting motion (100 to disable)
+variable_cut_axis_steppers      : 'stepper_x, stepper_y'	; Comma separated list of stepper names to increase current for cutting
+variable_cut_stepper_current    : 100				; % of stepper current to use for cutting motion (100 to disable)
 
 # This should be the position of the toolhead where the cutter arm just
 # lightly touches the depressor pin


### PR DESCRIPTION
This resolves klipper invalid syntax error reported [here](https://discord.com/channels/1305204275315474452/1329355247478505472/1362672240856137812)