### PR TITLE
automapping by color: handle alpha values

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -7707,6 +7707,8 @@ class Mmu:
                     # When matching by name normalize possible unicode characters and match case-insensitive
                     if strategy == self.AUTOMAP_FILAMENT_NAME:
                         equal = self._compare_unicode(tool_to_remap[tool_field], gate_feature)
+                    elif strategy == self.AUTOMAP_COLOR:
+                        equal = tool_to_remap[tool_field].ljust(8,'F') == gate_feature.ljust(8,'F')
                     else:
                         equal = tool_to_remap[tool_field] == gate_feature
                     if equal:


### PR DESCRIPTION
Slicers generally send the color information as RGB, but Mainsail and Fluidd will set color information as RGBA, at least when using spoolman.
This leads to matching filaments not being chosen when using the exact color strategy.

This change pads both halves of the comparison with an FF alpha value as necessary, enabling colors without alpha information to match fully opaque colors.

@ammmze suggested another elif to ensure the non-color-values in other exact comparison strategies are not padded. I chose to check for the `AUTOMAP_COLOR` strategy to match the existing condition.

Draft while I wait for an opportunity to test.