### PR TITLE
Changed PrinterRail to GenericPrinterRail as per the klipper class

### DIFF
--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -822,7 +822,7 @@ class MmuHoming(Homing, object):
 
 # Extend PrinterRail to allow for multiple (switchable) endstops and to allow for no default endstop
 # (defined in stepper.py)
-class MmuPrinterRail(stepper.PrinterRail, object):
+class MmuPrinterRail(stepper.GenericPrinterRail, object):
     def __init__(self, config, **kwargs):
         self.printer = config.get_printer()
         self.config = config


### PR DESCRIPTION
Was getting an error after upgrading klipper and Happy-Hare:
 - klipper module 'stepper' has no attribute 'PrinterRail'

After investigating the code, it seems that the class PrinterRail in the klipper stepper.py file is now GenericPrinterRail