### PR TITLE
Sync feedback corner cases 

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -2916,7 +2916,7 @@ class Mmu:
         if not self.is_enabled: return
         if abs(state) <= 1:
             self.sync_feedback_last_state = float(state)
-            self.log_trace("Got sync force feedback update. State: %s" % self._get_sync_feedback_string(detail=True))
+            self.log_trace("Got sync force feedback update. State: %s (%s)" % (self._get_sync_feedback_string(detail=True), float(state)))
             if self.sync_feedback_enable and self.sync_feedback_operational:
                 self._update_sync_multiplier()
         else:
@@ -2978,9 +2978,11 @@ class Mmu:
             if go_slower(self.sync_feedback_last_state, self.sync_feedback_last_direction):
                 # Expanded when extruding or compressed when retracting, so decrease the rotation distance of gear stepper to speed it up
                 multiplier = 1. - (abs(1. - self.sync_multiplier_low) * abs(self.sync_feedback_last_state))
+                self.log_trace("Slowing gear motor down")
             else:
                 # Compressed when extruding or expanded when retracting, so increase the rotation distance of gear stepper to slow it down
                 multiplier = 1. + (abs(1. - self.sync_multiplier_high) * abs(self.sync_feedback_last_state))
+                self.log_trace("Speeding gear motor up")
         self.log_trace("Updated sync multiplier: %.4f" % multiplier)
         self._set_rotation_distance(self._get_rotation_distance(self.gate_selected) / multiplier)
 

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -2914,9 +2914,9 @@ class Mmu:
     # or can be a proportional float value between -1.0 and 1.0
     def _handle_sync_feedback(self, eventtime, state):
         if not self.is_enabled: return
-        self.log_trace("Got sync force feedback update. State: %s" % state)
         if abs(state) <= 1:
             self.sync_feedback_last_state = float(state)
+            self.log_trace("Got sync force feedback update. State: %s" % self._get_sync_feedback_string(detail=True))
             if self.sync_feedback_enable and self.sync_feedback_operational:
                 self._update_sync_multiplier()
         else:

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -2988,20 +2988,17 @@ class Mmu:
         has_tension = self.sensor_manager.has_sensor(self.SENSOR_TENSION)
         has_compression = self.sensor_manager.has_sensor(self.SENSOR_COMPRESSION)
 
-        sss = self.SYNC_STATE_NEUTRAL
-        if has_tension and not has_compression:
-            sss = self.SYNC_STATE_EXPANDED if self.sensor_manager.check_sensor(self.SENSOR_TENSION) else self.SYNC_STATE_COMPRESSED
+        if has_tension and has_compression:
+            if self.sensor_manager.check_sensor(self.SENSOR_TENSION) == self.sensor_manager.check_sensor(self.SENSOR_COMPRESSION):
+                sss = self.SYNC_STATE_NEUTRAL
+            elif self.sensor_manager.check_sensor(self.SENSOR_TENSION) and not self.sensor_manager.check_sensor(self.SENSOR_COMPRESSION):
+                sss = self.SYNC_STATE_EXPANDED
+            else:
+                sss = self.SYNC_STATE_COMPRESSED
         elif has_compression and not has_tension:
             sss = self.SYNC_STATE_COMPRESSED if self.sensor_manager.check_sensor(self.SENSOR_COMPRESSION) else self.SYNC_STATE_EXPANDED
-        elif has_compression and has_tension:
-            state_expanded = self.sensor_manager.check_sensor(self.SENSOR_TENSION)
-            state_compressed = self.sensor_manager.check_sensor(self.SENSOR_COMPRESSION)
-            if state_expanded and state_compressed:
-                self.log_error("Both expanded and compressed sync feedback sensors are triggered at the same time. Check hardware!")
-            elif state_expanded:
-                sss = self.SYNC_STATE_EXPANDED
-            elif state_compressed:
-                sss = self.SYNC_STATE_COMPRESSED
+        else:
+            sss = self.SYNC_STATE_EXPANDED if self.sensor_manager.check_sensor(self.SENSOR_TENSION) else self.SYNC_STATE_COMPRESSED
         return sss
 
     # Ensure correct sync_feedback starting assumption by generating a fake event

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -47,19 +47,19 @@ class SyncStateTest(object):
             if self.compression_state == self.tension_state:
                 self.expected = 0.
             elif not self.compression_state and self.tension_state:
-                self.expected = -1.
-            elif self.compression_state and not self.tension_state:
                 self.expected = 1.
+            elif self.compression_state and not self.tension_state:
+                self.expected = -1.
         elif self.compression_sensor:
             if self.compression_state:
-                self.expected = 1.
-            else:
                 self.expected = -1.
+            else:
+                self.expected = 1.
         elif self.tension_sensor:
             if self.tension_state:
-                self.expected = -1.
-            else:
                 self.expected = 1.
+            else:
+                self.expected = -1.
         else :
             self.expected = 0.
 

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -71,27 +71,29 @@ class MmuTest:
                 gathered_states = []
                 tests = []
 
-                def get_float_state(has_compr_sensor, has_tension_sensor, is_compressed=None, is_tensioned=None):
+                def get_float_state(has_compr_sensor, has_tension_sensor, is_compressed, is_tensioned):
                     '''
                     Return the expected float state with given inputs and current sensor states.
                     '''
                     if has_compr_sensor and has_tension_sensor:
-                        if (is_compressed and is_tensioned) or (not is_compressed and not is_tensioned):
+                        if is_compressed == is_tensioned:
                             return 0.
                         elif not is_compressed and is_tensioned:
-                            return 1.
-                        elif is_compressed and not is_tensioned:
                             return -1.
+                        elif is_compressed and not is_tensioned:
+                            return 1.
                     elif has_compr_sensor:
                         if is_compressed:
-                            return -1.
-                        else:
                             return 1.
+                        else:
+                            return -1.
                     elif has_tension_sensor:
                         if is_tensioned:
-                            return 1.
-                        else:
                             return -1.
+                        else:
+                            return 1.
+                    else :
+                        return 0.
                 def test_2_string(test):
                     has_compr_sensor = test[0] is not None
                     has_tens_sensor = test[1] is not None

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -46,20 +46,20 @@ class SyncStateTest(object):
         if self.compression_sensor and self.tension_sensor:
             if self.compression_state == self.tension_state:
                 self.expected = 0.
-            elif not self.compression_state and self.tension_state:
-                self.expected = 1.
             elif self.compression_state and not self.tension_state:
+                self.expected = 1.
+            elif not self.compression_state and self.tension_state:
                 self.expected = -1.
         elif self.compression_sensor:
             if self.compression_state:
-                self.expected = -1.
-            else:
                 self.expected = 1.
+            else:
+                self.expected = -1.
         elif self.tension_sensor:
             if self.tension_state:
-                self.expected = 1.
-            else:
                 self.expected = -1.
+            else:
+                self.expected = 1.
         else :
             self.expected = 0.
 

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -113,7 +113,7 @@ class MmuTest:
             compression_test_sensor = self.mmu.printer.lookup_object("filament_switch_sensor %s_sensor" % self.mmu.SENSOR_COMPRESSION, None)
             if compression_test_sensor is None:
                 sensors._create_mmu_sensor(config, self.mmu.SENSOR_COMPRESSION, None, 'test_'+self.mmu.SENSOR_COMPRESSION+'_pin', 0, button_handler=sensors._sync_compression_callback)
-                compression_test_sensor = self.mmu.printer.lookup_object(self.mmu.printer.lookup_object("filament_switch_sensor %s_sensor" % self.mmu.SENSOR_COMPRESSION))
+                compression_test_sensor = self.mmu.printer.lookup_object("filament_switch_sensor %s_sensor" % self.mmu.SENSOR_COMPRESSION)
                 sensors_to_remove.append(self.mmu.SENSOR_COMPRESSION)
             tension_test_sensor = self.mmu.printer.lookup_object("filament_switch_sensor %s_sensor" % self.mmu.SENSOR_TENSION, None)
             if tension_test_sensor is None:

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -262,12 +262,12 @@ class MmuTest:
                 ppins = self.mmu.printer.lookup_object('pins')
                 for sensor in sensors_to_remove:
                     self.mmu.printer.objects.pop("filament_switch_sensor test_%s_sensor"  % sensor)
-                    config.fileconfig.pop("filament_switch_sensor test_%s_sensor"  % sensor)
+                    config.fileconfig.pop("filament_switch_sensor %s_sensor"  % sensor)
                     share_name = "%s:%s" % (ppins.parse_pin('test_'+sensor+'_pin')['chip_name'], ppins.parse_pin('test_'+sensor+'_pin')['pin'])
                     ppins.active_pins.pop(share_name)
                     for cmd, (__, val) in self.mmu.gcode.mux_commands.items() :
-                        if ("test_%s_sensor" % sensor) in [k for k in [v for v in val.keys() if v]]:
-                            self.mmu.gcode.mux_commands[cmd][1].pop(("test_%s_sensor" % sensor))
+                        if ("%s_sensor" % sensor) in [k for k in [v for v in val.keys() if v]]:
+                            self.mmu.gcode.mux_commands[cmd][1].pop(("%s_sensor" % sensor))
 
                 # restore the original sensor state
                 compression_test_sensor.runout_helper.sensor_enabled = saved_compr

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -62,10 +62,8 @@ class MmuTest:
             # create phony sensors for testing purposes (will be removed after the test)
             sensors : MmuSensors = self.mmu.printer.lookup_object("mmu_sensors")
             config = self.mmu.config.getsection('mmu_sensors')
-            compr_switch_pins = self.mmu.printer.lookup_object("filament_switch_sensor %s_sensor" % self.mmu.SENSOR_COMPRESSION).runout_helper.switch_pin
-            tens_switch_pins = self.mmu.printer.lookup_object("filament_switch_sensor %s_sensor" % self.mmu.SENSOR_TENSION).runout_helper.switch_pin
-            sensors._create_mmu_sensor(config, 'test_'+self.mmu.SENSOR_COMPRESSION, None, compr_switch_pins, 0, button_handler=sensors._sync_compression_callback)
-            sensors._create_mmu_sensor(config, 'test_'+self.mmu.SENSOR_TENSION, None, tens_switch_pins, 0, button_handler=sensors._sync_tension_callback)
+            sensors._create_mmu_sensor(config, 'test_'+self.mmu.SENSOR_COMPRESSION, None, 'test_'+self.mmu.SENSOR_COMPRESSION+'_pin', 0, button_handler=sensors._sync_compression_callback)
+            sensors._create_mmu_sensor(config, 'test_'+self.mmu.SENSOR_TENSION, None, 'test_'+self.mmu.SENSOR_TENSION+'_pin', 0, button_handler=sensors._sync_tension_callback)
             compression_test_sensor = self.mmu.printer.lookup_object("filament_switch_sensor test_%s_sensor" % self.mmu.SENSOR_COMPRESSION)
             tension_test_sensor = self.mmu.printer.lookup_object("filament_switch_sensor test_%s_sensor" % self.mmu.SENSOR_TENSION)
             if sync_state == 'loop':

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -70,6 +70,8 @@ class MmuTest:
                 nb_iterations = gcmd.get_int('LOOP', 1000, minval=1, maxval=10000000)
                 gathered_states = []
                 tests = []
+                global finished
+                finished = False
 
                 def get_float_state(has_compr_sensor, has_tension_sensor, is_compressed, is_tensioned):
                     '''
@@ -104,6 +106,13 @@ class MmuTest:
                     while len(gathered_states) != len(tests):
                         pass
                     display_results()
+                    global finished
+                    finished = True
+                def wait_run():
+                    global finished
+                    while not finished:
+                        pass
+                    finished = False
                 def display_results():
                     nb_tests_by_expected = {}
                     self.mmu.log_info("NB Gathered states: %s" % len(gathered_states))
@@ -219,7 +228,10 @@ class MmuTest:
                                 compr_test_sensor.runout_helper.note_filament_present(compression_sensor_filament_present)
                                 tests.append([(compr_test_sensor, tens_test_sensor, compression_sensor_filament_present, tension_sensor_filament_present, toggle_compression, toggle_tension), sync_state_float])
 
-                self.mmu.printer.send_event("mmu:test_gen_finished")
+                    self.mmu.printer.send_event("mmu:test_gen_finished")
+                    wait_run()
+                    gathered_states = []
+                    tests = []
                 # remove test sensors and associated config
                 ppins = self.mmu.printer.lookup_object('pins')
                 for sensor in [self.mmu.SENSOR_COMPRESSION, self.mmu.SENSOR_TENSION]:

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -261,7 +261,7 @@ class MmuTest:
                 # remove test sensors and associated config
                 ppins = self.mmu.printer.lookup_object('pins')
                 for sensor in sensors_to_remove:
-                    self.mmu.printer.objects.pop("filament_switch_sensor test_%s_sensor"  % sensor)
+                    self.mmu.printer.objects.pop("filament_switch_sensor %s_sensor"  % sensor)
                     config.fileconfig.pop("filament_switch_sensor %s_sensor"  % sensor)
                     share_name = "%s:%s" % (ppins.parse_pin('test_'+sensor+'_pin')['chip_name'], ppins.parse_pin('test_'+sensor+'_pin')['pin'])
                     ppins.active_pins.pop(share_name)

--- a/extras/mmu/mmu_test.py
+++ b/extras/mmu/mmu_test.py
@@ -231,7 +231,6 @@ class MmuTest:
                     self.mmu.log_info(">>>>>> Testing sensor configuration '%s'" % sensor_scenario)
 
                     while len(tests) < nb_iterations:
-                        self.mmu.log_trace(" -- Generated test: %s" % len(tests))
                         compression_sensor_filament_present = compression_test_sensor.runout_helper.filament_present
                         tension_sensor_filament_present = tension_test_sensor.runout_helper.filament_present
                         toggle_compression = "no change"
@@ -243,6 +242,7 @@ class MmuTest:
                                 compression_test_sensor.runout_helper.note_filament_present(compression_sensor_filament_present)
                                 triggered_sensor = "compression"
                                 toggle_compression = "rising edge" if compression_sensor_filament_present else "falling edge"
+                                self.mmu.log_trace(" -- Generated test: %s" % len(tests))
                                 tests.append(SyncStateTest(compression_test_sensor, tension_test_sensor, compression_sensor_filament_present, tension_sensor_filament_present, toggle_compression, toggle_tension, triggered_sensor, len(tests)))
                         else :
                             tension_sensor_filament_present = random.choice([True, False])
@@ -250,6 +250,7 @@ class MmuTest:
                                 tension_test_sensor.runout_helper.note_filament_present(tension_sensor_filament_present)
                                 triggered_sensor = "tension"
                                 toggle_tension = "rising edge" if tension_sensor_filament_present else "falling edge"
+                                self.mmu.log_trace(" -- Generated test: %s" % len(tests))
                                 tests.append(SyncStateTest(compression_test_sensor, tension_test_sensor, compression_sensor_filament_present, tension_sensor_filament_present, toggle_compression, toggle_tension, triggered_sensor, len(tests)))
 
 

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -264,7 +264,7 @@ class MmuSensors:
                     event_value = 0
                 elif tension_state and not compression_state:
                     event_value = -1
-                elif not tension_state and compression_state:
+                else:
                     event_value = 1
             else:
                 if tension_state :
@@ -289,7 +289,7 @@ class MmuSensors:
                     event_value = 0
                 elif compression_state and not tension_state:
                     event_value = 1
-                elif not compression_state and tension_state:
+                else:
                     event_value = -1
             else:
                 if compression_state:

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -263,20 +263,20 @@ class MmuSensors:
                 if tension_state == compression_state:
                     event_value = 0
                 elif tension_state and not compression_state:
-                    event_value = -1
-                else:
                     event_value = 1
+                else:
+                    event_value = -1
             else:
                 if tension_state :
-                    event_value = -1
-                else:
                     event_value = 1
+                else:
+                    event_value = -1
         else:
             if has_active_compression:
                 if compression_state:
-                    event_value = 1
-                else:
                     event_value = -1
+                else:
+                    event_value = 1
             else:
                 event_value = 0
 
@@ -294,20 +294,20 @@ class MmuSensors:
                 if tension_state == compression_state:
                     event_value = 0
                 elif compression_state and not tension_state:
-                    event_value = 1
-                else:
                     event_value = -1
+                else:
+                    event_value = 1
             else:
                 if compression_state:
-                    event_value = 1
-                else:
                     event_value = -1
+                else:
+                    event_value = 1
         else:
             if has_active_tension:
                 if tension_state:
-                    event_value = -1
-                else:
                     event_value = 1
+                else:
+                    event_value = -1
             else:
                 event_value = 0
 

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -259,16 +259,18 @@ class MmuSensors:
         compression_state = compression_sensor.runout_helper.filament_present if has_active_compression else False
 
         if tension_enabled:
-            if has_active_compression and compression_state:
-                if tension_state and compression_state:
-                    logging.info("Malfunction of sync-feedback unit: both tension and compression sensors are triggered at the same time!")
+            if has_active_compression:
+                if tension_state == compression_state:
                     event_value = 0
                 elif tension_state and not compression_state:
                     event_value = -1
                 elif not tension_state and compression_state:
                     event_value = 1
             else:
-                event_value = -tension_state # -1 or 0 (neutral)
+                if tension_state :
+                    event_value = -1
+                else:
+                    event_value = 1
         else:
             event_value = 0 # Neutral
 
@@ -282,16 +284,18 @@ class MmuSensors:
         tension_state = tension_sensor.runout_helper.filament_present if has_active_tension else False
 
         if compression_enabled:
-            if has_active_tension and tension_state:
-                if compression_state and tension_state:
-                    logging.info("Malfunction of sync-feedback unit: both tension and compression sensors are triggered at the same time!")
+            if has_active_tension:
+                if tension_state == compression_state:
                     event_value = 0
                 elif compression_state and not tension_state:
                     event_value = 1
                 elif not compression_state and tension_state:
                     event_value = -1
             else:
-                event_value = compression_state # 1 or 0 (neutral)
+                if compression_state:
+                    event_value = 1
+                else:
+                    event_value = -1
         else:
             event_value = 0 # Neutral
 

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -272,7 +272,13 @@ class MmuSensors:
                 else:
                     event_value = 1
         else:
-            event_value = 0 # Neutral
+            if has_active_compression:
+                if compression_state:
+                    event_value = 1
+                else:
+                    event_value = -1
+            else:
+                event_value = 0
 
         self.printer.send_event("mmu:sync_feedback", eventtime, event_value)
 
@@ -297,7 +303,13 @@ class MmuSensors:
                 else:
                     event_value = -1
         else:
-            event_value = 0 # Neutral
+            if has_active_tension:
+                if tension_state:
+                    event_value = -1
+                else:
+                    event_value = 1
+            else:
+                event_value = 0
 
         self.printer.send_event("mmu:sync_feedback", eventtime, event_value)
 

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -263,20 +263,20 @@ class MmuSensors:
                 if tension_state == compression_state:
                     event_value = 0
                 elif tension_state and not compression_state:
-                    event_value = 1
-                else:
                     event_value = -1
+                else:
+                    event_value = 1
             else:
                 if tension_state :
-                    event_value = 1
-                else:
                     event_value = -1
+                else:
+                    event_value = 1
         else:
             if has_active_compression:
                 if compression_state:
-                    event_value = -1
-                else:
                     event_value = 1
+                else:
+                    event_value = -1
             else:
                 event_value = 0
 
@@ -294,20 +294,20 @@ class MmuSensors:
                 if tension_state == compression_state:
                     event_value = 0
                 elif compression_state and not tension_state:
-                    event_value = -1
-                else:
                     event_value = 1
+                else:
+                    event_value = -1
             else:
                 if compression_state:
-                    event_value = -1
-                else:
                     event_value = 1
+                else:
+                    event_value = -1
         else:
             if has_active_tension:
                 if tension_state:
-                    event_value = 1
-                else:
                     event_value = -1
+                else:
+                    event_value = 1
             else:
                 event_value = 0
 


### PR DESCRIPTION
Hi, here comes the PR that should cover missing cases for dual, single and non sensor configurations.

# theoretical values the tests were build upon
## Compression sensor only scenario

| compression state | tension state | triggered sensor | feedback value |
| ------------------|---------------|------------------|----------------|
| 0                 | 0             | compression      | -1             |
| 0                 | 1             | compression      | -1             |
| 1                 | 0             | compression      | 1              |
| 1                 | 1             | compression      | 1              |
| **0**             | **0**         | **tension**      | **-1**         |
| **0**             | **1**         | **tension**      | **-1**         |
| **1**             | **0**         | **tension**      | **1**          |
| **1**             | **1**         | **tension**      | **1**          |

## Tension sensor only scenario

| compression state | tension state | triggered sensor | feedback value |
| ------------------|---------------|------------------|----------------|
| **0**             | **0**         | **compression**  | **1**          |
| **0**             | **1**         | **compression**  | **-1**         |
| **1**             | **0**         | **compression**  | **1**          |
| **1**             | **1**         | **compression**  | **-1**         |
| 0                 | 0             | tension          | 1              |
| 0                 | 1             | tension          | -1             |
| 1                 | 0             | tension          | 1              |
| 1                 | 1             | tension          | -1             |

## Both sensors scenario

| compression state | tension state | triggered sensor | feedback value |
| ------------------|---------------|------------------|----------------|
| 0                 | 0             | compression      | 0              |
| 0                 | 1             | compression      | -1             |
| 1                 | 0             | compression      | 1              |
| 1                 | 1             | compression      | 0              |
| 0                 | 0             | tension          | 0              |
| 0                 | 1             | tension          | -1             |
| 1                 | 0             | tension          | 1              |
| 1                 | 1             | tension          | 0              |

## No sensors scenario

| compression state | tension state | triggered sensor | feedback value |
| ------------------|---------------|------------------|----------------|
| 0                 | 0             | compression      | 0              |
| 0                 | 1             | compression      | 0              |
| 1                 | 0             | compression      | 0              |
| 1                 | 1             | compression      | 0              |
| 0                 | 0             | tension          | 0              |
| 0                 | 1             | tension          | 0              |
| 1                 | 0             | tension          | 0              |
| 1                 | 1             | tension          | 0              |

# What changes ?
- Single sensor setups will now oscillate between `compressed` and `tensioned` and no longer fallback to neutral when the sensor is not triggerd (which sparked this PR initially).
- Sensors can trigger feedback events with corrected values even though disabled. This adds a little bit of safety in order to ensure that the system always behaves in the way the sensors are configured.
- The stress test suite has been updated to be able to iterate over all "sensor configurations" and randomly generate _realistic_ triggers. (This excludes switching sensors at the same time for instance)
- The `_MMU_TEST SYNC_STATE=loop` command will create missing sensors temporarily so that the tests do not rely on configured sensors.
- The test analysis in the mmu log file has been enhanced in order to facilitate debugging.

# :warning:  Important notes 
The tests and updated feedback logic has been tested by myself (dual sensors setup), and @burkfers with a single "compression" sensor to my knowledge.

I would be happy that somebody could confirm that the temporary sensor creation and removal in the test is done cleanly enough not to let some unwanted python objects in klipper after testing. 
