### PR TITLE
Add an option to suppress the Kalico warning

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -484,6 +484,8 @@ class Mmu:
 
         # Turn off splash bling for boring people
         self.serious = config.getint('serious', 0, minval=0, maxval=1)
+        # Suppress the Kalico warning for dangerous people
+        self.suppress_kalico_warning = config.getint('suppress_kalico_warning', 0, minval=0, maxval=1)
 
         # Currently hidden and testing options
         self.test_random_failures = config.getint('test_random_failures', 0, minval=0, maxval=1)
@@ -1269,7 +1271,10 @@ class Mmu:
             msg = '{1}(\_/){0}\n{1}( {0}*,*{1}){0}\n{1}(")_("){0} {5}{2}H{0}{3}a{0}{4}p{0}{2}p{0}{3}y{0} {4}H{0}{2}a{0}{3}r{0}{4}e{0} {1}%s{0} {2}R{0}{3}e{0}{4}a{0}{2}d{0}{3}y{0}{1}...{0}{6}' % self._fversion(self.config_version)
             self.log_always(msg, color=True)
             if self.kalico:
-                self.log_error("Warning: You are running on Kalico (Danger-Klipper). Support is not guaranteed!")
+                if self.suppress_kalico_warning:
+                    self.log_trace("Warning: You are running on Kalico (Danger-Klipper). Support is not guaranteed! Message was suppressed.")
+                else:
+                    self.log_error("Warning: You are running on Kalico (Danger-Klipper). Support is not guaranteed!")
             self._set_print_state("initialized")
 
             # Use pre-gate sensors to adjust gate map

--- a/install.sh
+++ b/install.sh
@@ -1073,7 +1073,7 @@ copy_config_files() {
             echo "# SUPPLEMENTAL USER CONFIG retained after upgrade --------------------------------------------------------------------" >> $dest
             echo "#" >> $dest
             supplemental_params="cad_gate0_pos cad_gate_width cad_bypass_offset cad_last_gate_offset cad_block_width cad_bypass_block_width cad_bypass_block_delta cad_selector_tolerance gate_material gate_color gate_spool_id gate_status gate_filament_name gate_temperature gate_speed_override endless_spool_groups tool_to_gate_map"
-            hidden_params="test_random_failures test_random_failures test_disable_encoder test_force_in_print serious"
+            hidden_params="test_random_failures test_random_failures test_disable_encoder test_force_in_print serious suppress_kalico_warning"
             for var in $(set | grep '^_param_' | cut -d'=' -f1 | sort); do
                 param=${var#_param_}
                 for item in ${supplemental_params} ${hidden_params}; do


### PR DESCRIPTION
The warning that Kalico is supported on a best-effort basis only is very useful, but seeing an error every time you boot Klipper gets very old quickly, and it may even mask real errors, which you've now become desensitized to.

I am proposing a new, hidden config option that suppresses the warning. It still emits a message at trace level so if digging into a nitty gritty it's still obvious Kalico is in use.
If the new option is to be documented on the wiki, it should probably come with a big warning to please never forget to mention running Kalico when seeking support.

I've remembered to add the option to `hidden_params` in the installer so an upgrade does not eat the setting.

To suppress the warning, simply set `suppress_kalico_warning: 1` in `mmu_parameters.cfg`.