### PR TITLE
Fix extruder_name for multiextruders printers.

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -3748,7 +3748,7 @@ class Mmu:
             if wait and new_target_temp >= klipper_minimum_temp and abs(new_target_temp - current_temp) > self.extruder_temp_variance:
                 with self.wrap_action(self.ACTION_HEATING):
                     self.log_info("Waiting for extruder to reach target (%s) temperature: %.1f%sC" % (source, new_target_temp, UI_DEGREE))
-                    self.gcode.run_script_from_command("TEMPERATURE_WAIT SENSOR=extruder MINIMUM=%.1f MAXIMUM=%.1f" % (new_target_temp - self.extruder_temp_variance, new_target_temp + self.extruder_temp_variance))
+                    self.gcode.run_script_from_command("TEMPERATURE_WAIT SENSOR=%s MINIMUM=%.1f MAXIMUM=%.1f" % (self.extruder_name, new_target_temp - self.extruder_temp_variance, new_target_temp + self.extruder_temp_variance))
 
     def _selected_tool_string(self, tool=None):
         if tool is None:


### PR DESCRIPTION
Fix extruder_name for multiextruders printers.
This line was not using self.extruder_name and it was hardcoded to "extruder"