### PR TITLE
fix: Prevent BLOBIFIER from continuing purge after MMU_PAUSE

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -322,6 +322,7 @@ gcode:
     {% set from_tool = printer.mmu.last_tool %}
     {% set to_tool = printer.mmu.tool %}
     {% set bl_count = printer['gcode_macro _BLOBIFIER_COUNT'] %}
+    {% set bl_pause = printer['gcode_macro _BLOBIFIER_PAUSE_STATE'] %}
     {% set pos = printer.gcode_move.gcode_position %}
     {% set safe = printer['gcode_macro _BLOBIFIER_SAFE_DESCEND'] %}
     {% set ignore_safe = safe.print_height < force_safe_descend_height_until %}
@@ -445,55 +446,59 @@ gcode:
 
       # Repeat the process until purge_len is reached
       {% for blob in range(blobs) %}
-        RESPOND MSG={"'BLOBIFIER: Blob %d of %d (%.1fmm)'" % (blob + 1, blobs, purge_per_blob)}
+        {% if bl_pause.in_pause %}
+          SET_GCODE_VARIABLE MACRO=_BLOBIFIER_PAUSE_STATE VARIABLE=remaining_purge_length VALUE={bl_pause.remaining_purge_length + purge_per_blob}
+        {% else %}
+          RESPOND MSG={"'BLOBIFIER: Blob %d of %d (%.1fmm)'" % (blob + 1, blobs, purge_per_blob)}
 
-        {% if safe.tray or ignore_safe %}
-          G1 Z{tray_top + purge_start} F{travel_spd_z}
-        {% endif %}
-
-        # relative positioning
-        G91 
-        # relative extrusion
-        M83
-
-        # Purge filament in a pulsating motion to purge the filament quicker and better
-        {% for pulse in range(pulses_per_blob) %}
-          # Calculations to determine z-speed
-          {% set purged_this_blob = pulse * purge_per_pulse %}
-          {% set z_last_pos = purge_start + ((purged_this_blob)/purge_length_maximum)**z_raise_exp * z_raise %}
-          {% set z_pos = purge_start + ((purged_this_blob + purge_per_pulse)/purge_length_maximum)**z_raise_exp * z_raise %}
-          {% set z_up = z_pos - z_last_pos %}
-          {% set speed = z_up / pulse_duration %}
-
-          # Purge quickly
-          G1 Z{z_up * pulse_time_constant} E{purge_per_pulse * 0.95} F{speed}
-          # Purge a tiny bit slowly
-          G1 Z{z_up * (1 - pulse_time_constant)} E{purge_per_pulse * 0.05} F{speed}
-
-          # retract and unretract filament every now and then for thorough cleaning
-          {% if pulse % pulses_per_retract == 0 and pulse > 0 %}
-            G1 E-2 F1800
-            G1 E2 F800
+          {% if safe.tray or ignore_safe %}
+            G1 Z{tray_top + purge_start} F{travel_spd_z}
           {% endif %}
-        {% endfor %}
 
-        # ==================================================================================
-        # ==================== DEPOSIT BLOB ================================================
-        # ==================================================================================
-        {% if safe.tray or ignore_safe %}
-          # Raise z a bit to relieve pressure on the blob preventing it to go sideways
-          G1 Z{eject_hop} F{travel_spd_z}
-          # Retract the tray
-          BLOBIFIER_SERVO POS=in
-          # Move the toolhead down to purge_start height lowering the blob below the tray
-          G90 # absolute positioning
-          G1 Z{tray_top} F{travel_spd_z}
-          # Extend the tray to 'cut off' the blob and prepare for the next blob
-          BLOBIFIER_SERVO POS=out
-          BLOBIFIER_SERVO POS=in
-          BLOBIFIER_SERVO POS=out
-          # Keep track of the # of blobs
-          _BLOBIFIER_COUNT
+          # relative positioning
+          G91 
+          # relative extrusion
+          M83
+
+          # Purge filament in a pulsating motion to purge the filament quicker and better
+          {% for pulse in range(pulses_per_blob) %}
+            # Calculations to determine z-speed
+            {% set purged_this_blob = pulse * purge_per_pulse %}
+            {% set z_last_pos = purge_start + ((purged_this_blob)/purge_length_maximum)**z_raise_exp * z_raise %}
+            {% set z_pos = purge_start + ((purged_this_blob + purge_per_pulse)/purge_length_maximum)**z_raise_exp * z_raise %}
+            {% set z_up = z_pos - z_last_pos %}
+            {% set speed = z_up / pulse_duration %}
+
+            # Purge quickly
+            G1 Z{z_up * pulse_time_constant} E{purge_per_pulse * 0.95} F{speed}
+            # Purge a tiny bit slowly
+            G1 Z{z_up * (1 - pulse_time_constant)} E{purge_per_pulse * 0.05} F{speed}
+
+            # retract and unretract filament every now and then for thorough cleaning
+            {% if pulse % pulses_per_retract == 0 and pulse > 0 %}
+              G1 E-2 F1800
+              G1 E2 F800
+            {% endif %}
+          {% endfor %}
+
+          # ==================================================================================
+          # ==================== DEPOSIT BLOB ================================================
+          # ==================================================================================
+          {% if safe.tray or ignore_safe %}
+            # Raise z a bit to relieve pressure on the blob preventing it to go sideways
+            G1 Z{eject_hop} F{travel_spd_z}
+            # Retract the tray
+            BLOBIFIER_SERVO POS=in
+            # Move the toolhead down to purge_start height lowering the blob below the tray
+            G90 # absolute positioning
+            G1 Z{tray_top} F{travel_spd_z}
+            # Extend the tray to 'cut off' the blob and prepare for the next blob
+            BLOBIFIER_SERVO POS=out
+            BLOBIFIER_SERVO POS=in
+            BLOBIFIER_SERVO POS=out
+            # Keep track of the # of blobs
+            _BLOBIFIER_COUNT
+          {% endif %}
         {% endif %}
       {% endfor %}
     {% endif %}
@@ -530,6 +535,13 @@ gcode:
   
   RESTORE_GCODE_STATE NAME=BLOBIFIER_state 
 
+  {% if bl_pause.in_pause %}
+    {% if bl_pause.remaining_purge_length > 0 %}
+      MMU_PAUSE MSG={"Empty purge bucket! After clear and re-install the bucket, the remaining purge length(%d mm) will continue to be purged."} % (bl_pause.remaining_purge_length)}
+    {% else %}
+      MMU_PAUSE MSG="Empty purge bucket!"
+    {% endif %}
+  {% endif %}
 
 ##########################################################################################
 # Wipes the nozzle on the brass brush
@@ -733,6 +745,15 @@ gcode:
   {% endfor %}
 
 ##########################################################################################
+# Pause state and the remainging purge length.
+#
+[gcode_macro _BLOBIFIER_PAUSE_STATE]
+# Don't change these variables
+variable_in_pause: False
+variable_remaining_purge_length: 0
+gcode:
+
+##########################################################################################
 # Increment the blob count with 1 and check if the bucket is full. Pause 
 # the printer if it is.
 #
@@ -747,7 +768,7 @@ gcode:
   {% if current_blobs >= bl.max_blobs %}
     {action_respond_info("BLOBIFIER: Empty purge bucket!")}
     M117 Empty purge bucket!
-    MMU_PAUSE MSG="Empty purge bucket!"
+    SET_GCODE_VARIABLE MACRO=_BLOBIFIER_PAUSE_STATE VARIABLE=in_pause VALUE=True
   {% else %}
     SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=current_blobs VALUE={current_blobs + 1}
     _BLOBIFIER_SAVE_STATE
@@ -758,7 +779,7 @@ gcode:
   {% endif %}
 
 ##########################################################################################
-# Reset the blob count to 0
+# Reset the blob count to 0 and purge the remaining length after a pause.
 #
 [gcode_macro _BLOBIFIER_COUNT_RESET]
 gcode:
@@ -767,6 +788,16 @@ gcode:
   _BLOBIFIER_SAVE_STATE
   
   _BLOBIFIER_CALCULATE_NEXT_SHAKE
+
+  {% set bl_pause = printer['macro _BLOBIFIER_PAUSE'] %}
+  {% if bl_pause.in_pause and bl_pause.remaining_purge_length > 0 %}
+    SET_GCODE_VARIABLE MACRO=_BLOBIFIER_PAUSE VARIABLE=remaining_purge_length VALUE=0
+    SET_GCODE_VARIABLE MACRO=_BLOBIFIER_PAUSE VARIABLE=in_pause VALUE=False
+    BLOBIFIER PURGE_LENGTH={bl_pause.remaining_purge_length}    
+  {% else %}
+    SET_GCODE_VARIABLE MACRO=_BLOBIFIER_PAUSE VARIABLE=remaining_purge_length VALUE=0
+    SET_GCODE_VARIABLE MACRO=_BLOBIFIER_PAUSE VARIABLE=in_pause VALUE=False
+  {% endif %}
 
 ##########################################################################################
 # Shake the blob bucket to disperse the blobs


### PR DESCRIPTION
The BLOBIFIER macro continues to execute commands after calling MMU_PAUSE, which can lead to unintended purging at the park position. This fix ensures that the macro properly exits after pausing, preventing any remaining purge operations from being executed.

- Add early return after MMU_PAUSE to prevent continued execution
- Preserve remaining purge length for resumption after pause