### PR TITLE
 Added gate_status_exit Support and New Effects

### DIFF
--- a/config/base/mmu_leds.cfg
+++ b/config/base/mmu_leds.cfg
@@ -78,9 +78,9 @@ gcode:
     {% set set_led_vars = printer['gcode_macro _MMU_SET_LED'] %}
 
     {% set current = set_led_vars['current_exit_effect'] %}
-    {% set exit_effect=current if current in ["gate_status", "filament_color", "slicer_color"] else "" %}
+    {% set exit_effect=current if current in ["gate_status", "gate_status_exit", "filament_color", "slicer_color"] else "" %}
     {% set current = set_led_vars['current_entry_effect'] %}
-    {% set entry_effect=current if current in ["gate_status", "filament_color", "slicer_color"] else "" %}
+    {% set entry_effect=current if current in ["gate_status", "gate_status_exit", "filament_color", "slicer_color"] else "" %}
     {% set current = set_led_vars['current_status_effect'] %}
     {% set status_effect=current if current in ["filament_color", "slicer_color"] else "" %}
 
@@ -121,6 +121,7 @@ gcode:
         # Grab useful printer variables
         {% set mmu = printer['mmu'] %}
         {% set gate_status = mmu['gate_status'] %}
+        {% set gate_status_exit = mmu['gate_status'] %}
         {% set gate_color = mmu['gate_color'] %}
         {% set gate_color_rgb = mmu['gate_color_rgb'] %}
         {% set slicer_color_rgb = mmu['slicer_color_rgb'] %}
@@ -214,6 +215,33 @@ gcode:
                         {% endif %}
                     {% endfor %}
                 {% endif %}
+
+            {% elif effects[segment] == "gate_status_exit" %} # Filament availability
+                {% if gate >= 0 %}
+                    {% if gate == current_gate and is_loaded %}
+                        _SET_LED_EFFECT EFFECT=mmu_white_{segment}_{index} FADETIME={fadetime} REPLACE=1
+                    {% elif ggate_status_exit[gate] == -1 %}
+                        _SET_LED_EFFECT EFFECT=mmu_white_{segment}_{index} FADETIME={fadetime} REPLACE=1
+                    {% elif gate_status_exit[gate] > 0 %}
+                        _SET_LED_EFFECT EFFECT=mmu_white_{segment}_{index} FADETIME={fadetime} REPLACE=1
+                    {% else %}
+                        _STOP_LED_EFFECTS LEDS="mmu_{segment}_leds ({index})" FADETIME={fadetime}
+                    {% endif %}
+                {% else %}
+                    {% for status in gate_status_exit %}
+                        {% if loop.index0 == current_gate and is_loaded %}
+                            _SET_LED_EFFECT EFFECT=mmu_white_{segment}_{loop.index} FADETIME={fadetime} REPLACE=1
+                        {% elif status == -1 %}
+                            _SET_LED_EFFECT EFFECT=mmu_white_{segment}_{loop.index} FADETIME={fadetime} REPLACE=1
+                        {% elif status > 0 %}
+                            _SET_LED_EFFECT EFFECT=mmu_white_{segment}_{loop.index} FADETIME={fadetime} REPLACE=1
+                        {% else %}
+                            _STOP_LED_EFFECTS LEDS="mmu_{segment}_leds ({loop.index})" FADETIME={fadetime}
+                            SET_LED LED=mmu_{segment}_leds INDEX={loop.index} RED=0 GREEN=0 BLUE=0 TRANSMIT=1
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
+
 
             {% elif effects[segment] == "filament_color" %} # Filament color
                 {% if gate >= 0 %}
@@ -364,6 +392,7 @@ variable_effect_to_static_color: {
     'mmu_curtain': (0.5,0.2,0),
     'mmu_sparkle': (0.3,0.3,0.3),
     'mmu_rainbow': (0.5,0.2,0),
+    'mmu_white': (1,1,1),
     }
 gcode:
     {% set vars = printer['gcode_macro _MMU_LED_VARS'] %}
@@ -467,3 +496,6 @@ layers:       twinkle 8 0.15 top (0.3,0.3,0.3), (0.4,0,0.25)
 [mmu_led_effect mmu_rainbow]
 define_on:    entry,exit,status
 layers:       gradient  0.8  0.5 add (0.3, 0.0, 0.0), (0.0, 0.3, 0.0), (0.0, 0.0, 0.3)
+
+[mmu_led_effect mmu_white]
+layers:       static 0 0 top (1,1,1)

--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -136,6 +136,7 @@ gcode: # Leave empty
 #   'off'             - LED's off
 #   'on'              - LED's white
 #   'gate_status'     - indicate gate availability / status            (printer.mmu.gate_status)
+#   'gate_status_exit'- indicate gate's exit availability / status     (printer.mmu.gate_status_exit)
 #   'filament_color'  - display filament color defined in gate map     (printer.mmu.gate_color_rgb)
 #   'slicer_color'    - display slicer defined set color for each gate (printer.mmu.slicer_color_rgb)
 #   'r,g,b'           - display static r,g,b color e.g. "0,0,0.3" for dim blue
@@ -143,9 +144,9 @@ gcode: # Leave empty
 #
 variable_led_enable             : True			; True = LEDs are enabled at startup (MMU_LED can control), False = Disabled
 variable_led_animation          : True			; True = Use led-animation-effects, False = Static LEDs
-variable_default_exit_effect    : "gate_status"		;    off|gate_status|filament_color|slicer_color|r,g,b|_effect_
-variable_default_entry_effect   : "filament_color"	;    off|gate_status|filament_color|slicer_color|r,g,b|_effect_
-variable_default_status_effect  : "filament_color"	; on|off|gate_status|filament_color|slicer_color|r,g,b|_effect_
+variable_default_exit_effect    : "gate_status_exit"		;    off|gate_status|filament_color|slicer_color|gate_status_exit|r,g,b|_effect_
+variable_default_entry_effect   : "gate_status"	;    off|gate_status|filament_color|slicer_color|gate_status_exit|r,g,b|_effect_
+variable_default_status_effect  : "filament_color"	; on|off|gate_status|filament_color|slicer_color|gate_status_exit|r,g,b|_effect_
 variable_default_logo_effect    : "0,0,.3"		;    off                                        |r,g,b|_effect_
 variable_white_light            : (1, 1, 1)		; RGB color for static white light
 variable_black_light            : (.01, 0, .02)		; RGB color used to represent "black" (filament)


### PR DESCRIPTION
## MMU LED Control Enhancements: Added `gate_status_exit` Support and New Effects

### Description
This PR enhances the Happy Hare MMU LED control system with new functionality and improvements:

### New Features
**`gate_status_exit` mode**  
- New white LED effect variant for gate status indication  
- Provides visual distinction from standard `gate_status` (green/blue/orange)  
- Ideal for exit operation feedback  

**Static `mmu_white` effect**  
- Added to static LED conversion dictionary  
- Pure white RGB (1,1,1) for systems without `led_effects`  

### Improvements
Added `gate_status_exit` support in `_MMU_LED_GATE_MAP_CHANGED`  
Enhanced static LED fallback logic  

### Compatibility
Fully backward compatible  
Requires LED configuration in `mmu_hardware.cfg`  

### Modified Files:
```
mmu_leds.cfg
mmu_macro_vars.cfg
```
![20250401_185505](https://github.com/user-attachments/assets/ae4377ed-5b52-41dc-97e5-16bcc4679323)
