### PR TITLE
Cast UNLOAD parameter as int, so it can be set as false in MMU_END macro

### DIFF
--- a/config/base/mmu_software.cfg
+++ b/config/base/mmu_software.cfg
@@ -266,7 +266,7 @@ gcode:
 [gcode_macro MMU_END]
 description: Called when ending print to finalize MMU
 gcode:
-    {% set unload = params.UNLOAD|default(0) %}
+    {% set unload = params.UNLOAD|default(0)|int %}
     {% set vars = printer['gcode_macro _MMU_SOFTWARE_VARS'] %}
     {% set unload_tool = vars.unload_tool|lower == 'true' %}
     {% set reset_ttg = vars.reset_ttg|lower == 'true' %}


### PR DESCRIPTION
I noticed that I cannot use `MMU_END` macro's `UNLOAD` parameter as false, because it is not casted as int, and string "0" is considered true in the if statement. So the unload happens even if you call this macro like

    MMU_END UNLOAD=0

Tested the jinja [here](http://jinja.quantprogramming.com/).
![Screenshot_20250524_111403](https://github.com/user-attachments/assets/795fcb2f-b0c2-40da-9d9c-b1be34cb2175)
