### PR TITLE
Add ability to specify X pos for shaker in Blobifier

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -264,6 +264,9 @@ variable_purge_length_addition: 0
 variable_max_blobs: 400
 # Enable the bucket shaker. You need to have the shaker.stl installed
 variable_enable_shaker: 1
+# Shaker position offset in X (relative to zero)
+# Allows negative positions. Add skew_correction separately if needed.
+variable_shaker_pos_x: 0
 # The number of back-and-forth motions of one shake
 variable_bucket_shakes: 10
 # During shaking acceleration can often be higher because you don't need to keep print 
@@ -777,7 +780,7 @@ gcode:
   {% set count = printer['gcode_macro _BLOBIFIER_COUNT'] %}
   {% set original_accel = printer.toolhead.max_accel %}
   {% set original_minimum_cruise_ratio = printer.toolhead.minimum_cruise_ratio %}
-  {% set position_x = bl.skew_correction %}
+  {% set position_x = bl.shaker_pos_x|default(0)|float + bl.skew_correction %}
 
   {% if "xyz" not in printer.toolhead.homed_axes %}
     {action_raise_error("BLOBIFIER: Not homed. Home xyz first")}

--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -822,7 +822,7 @@ class MmuHoming(Homing, object):
 
 # Extend PrinterRail to allow for multiple (switchable) endstops and to allow for no default endstop
 # (defined in stepper.py)
-class MmuPrinterRail(stepper.GenericPrinterRail, object):
+class MmuPrinterRail(stepper.PrinterRail, object):
     def __init__(self, config, **kwargs):
         self.printer = config.get_printer()
         self.config = config

--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -822,7 +822,7 @@ class MmuHoming(Homing, object):
 
 # Extend PrinterRail to allow for multiple (switchable) endstops and to allow for no default endstop
 # (defined in stepper.py)
-class MmuPrinterRail(stepper.PrinterRail, object):
+class MmuPrinterRail(stepper.GenericPrinterRail, object):
     def __init__(self, config, **kwargs):
         self.printer = config.get_printer()
         self.config = config


### PR DESCRIPTION
This PR introduces a new configurable parameter to the BLOBIFIER macro system, allowing users to define a custom X-axis position (shaker_pos_x) for the BLOBIFIER_SHAKE_BUCKET macro. This makes the macro compatible with setups where the shaker tray is positioned at a negative or non-standard X location.