### PR TITLE
automapping: convert hex strings so uppercase before comparing

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -7716,7 +7716,7 @@ class Mmu:
                     if strategy == self.AUTOMAP_FILAMENT_NAME:
                         equal = self._compare_unicode(tool_to_remap[tool_field], gate_feature)
                     elif strategy == self.AUTOMAP_COLOR:
-                        equal = tool_to_remap[tool_field].ljust(8,'F') == gate_feature.ljust(8,'F')
+                        equal = tool_to_remap[tool_field].upper().ljust(8,'F') == gate_feature.upper().ljust(8,'F')
                     else:
                         equal = tool_to_remap[tool_field] == gate_feature
                     if equal:


### PR DESCRIPTION
Small addition to #700: It was still possible to end up with dissimilar case on hex strings, so a gcode file asking for `0004ff` would not match a filament mapped as `0004FF` and vice versa.