### PR TITLE
Enable purging (blobifier) when run out occurs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 my_*.cfg
+.DS_Store

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -5009,7 +5009,7 @@ class Mmu:
             # Deal with purging
             if purge == self.PURGE_SLICER and not skip_extruder:
                 self.log_debug("Purging expected to be performed by slicer")
-            elif purge == self.PURGE_STANDALONE and not skip_extruder and not self.is_handling_runout:
+            elif purge == self.PURGE_STANDALONE and not skip_extruder:
                 with self._wrap_track_time('purge'):
                     sync = (self.is_printing() and self.sync_purge) or self._standalone_sync
                     self.sync_gear_to_extruder(sync, current=True)
@@ -7385,7 +7385,7 @@ class Mmu:
                 self._eject_from_gate() # Push completely out of gate
                 self.select_gate(next_gate) # Necessary if unloaded to waste gate
                 self._remap_tool(self.tool_selected, next_gate)
-                self._select_and_load_tool(self.tool_selected, purge=self.PURGE_NONE)
+                self._select_and_load_tool(self.tool_selected, purge=self.PURGE_STANDALONE) # if user has set up standalone purging, respect option and purge.
             else:
                 raise MmuError("Runout detected on %s\nEndlessSpool mode is off - manual intervention is required" % sensor)
 


### PR DESCRIPTION
Restoring previous behaviour where after a run out and endless spool triggering, the purge macros (blobifier) where invoked. In previous releases that was done automatically as the blobifier was tied to the post load macro user hook. 

This is particularly helpful to avoid blobs on the print if the toolhead dimensions and ooze reduction are not spot on (which is not as critical when a purge macro is used) and to ensure consistent nozzle pressure when the new filament is loaded and any air pockets in the nozzle caused by filament retraction, loading and inevitable ooze during the process, are purged out.

![IMG_6320](https://github.com/user-attachments/assets/fce89b49-c81c-40bf-bdff-cdb8116338ff)

Tested with an endless spool operation in latest HH with success.

(also adding .DS_Store files automatically generated by MacOS to the git ignore list to prevent them polluting the repo).