### PR TITLE
fix: Convert sensors to a text format before passing it to the log

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -4562,7 +4562,10 @@ class Mmu:
                 # Sensor validation
                 if self.sensor_manager.check_all_sensors_before(self.FILAMENT_POS_START_BOWDEN, self.gate_selected, loading=False) is False:
                     sensors = self.sensor_manager.get_all_sensors()
-                    self.log_warning("Warning: Possible sensor malfunction - a sensor indicated filament not present before unloading bowden: %s\nWill attempt to continue..." % sensors)
+                    sensor_msg = ''
+                    for name, state in sensors.items():
+                        sensor_msg += "%s (%s), " % (name.upper(), "Disabled" if state is None else ("Detected" if state is True else "Empty"))
+                    self.log_warning("Warning: Possible sensor malfunction - a sensor indicated filament not present before unloading bowden: %s\nWill attempt to continue..." % sensor_msg)
 
                 # "Fast" unload
                 _,_,_,delta = self.trace_filament_move("Fast unloading move through bowden", -length, track=True, encoder_dwell=bool(self.autotune_rotation_distance))


### PR DESCRIPTION
Otherwise the sensors are in a JSON format and then the log formatter thinks the `{ ... }` are placeholders of some sort and would lead to the following error:

```
  File "/home/pi/klipper/klippy/extras/mmu/mmu.py", line 4565, in _unload_bowden
    self.log_warning("Warning: Possible sensor malfunction - a sensor indicated filament not present before unloading bowden: %s\nWill attempt to continue..." % sensors)
  File "/home/pi/klipper/klippy/extras/mmu/mmu.py", line 1803, in log_warning
    self.log_always("{2}%s{0}" % msg, color=True)
  File "/home/pi/klipper/klippy/extras/mmu/mmu.py", line 1806, in log_always
    html_msg, msg = self._color_message(msg) if color else (msg, msg)
                    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/klipper/klippy/extras/mmu/mmu.py", line 1785, in _color_message
    html_msg = msg.format('</span>', '<span style=\"color:#C0C0C0\">', '<span style=\"color:#FF69B4\">', '<span style=\"color:#90EE90\">', '<span style=\"color:#87CEEB\">', '<b>', '</b>')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: "'mmu_pre_gate_0'"
MCU 'EBBCan' shutdown: Command request
```

> [!NOTE]
> This fixes the logging for this one case, but still leaves open the possibility if another log message tries log JSON with color'ing it would still fail. I've you've got other ideas for solving it more generically so that we can log JSON if desired, i'm open to exploring it more.

resolves: #734