### PR TITLE
Spelling error for BLOBIFIER macro in comment in mmu_parameters.cfg

### DIFF
--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -365,7 +365,7 @@ slicer_tip_park_pos: 0			# This specifies the position of filament in extruder a
 # The default is for no (empty) macro so purging will not be done out of a print and thus wipetower. Two options are shipped with
 # Happy Hare but you can also build your own custom one:
 #   _MMU_PURGE .. default purging that just dumps the desired amount of filament (setup correct parking before enabling this!)
-#   BLOBIFER   .. for excellent Blobifer addon (https://github.com/Dendrowen/Blobifier)
+#   BLOBIFIER   .. for excellent Blobifer addon (https://github.com/Dendrowen/Blobifier)
 #
 # Often it is useful to increase the extruder current for the often rapid puring movement to ensure high torque and no skipped steps
 #


### PR DESCRIPTION
Spelling error in blobifier macro name in comment. 

If copied and pasted will not call the macro.

