### PR TITLE
BLOBIFIER: Turn off the part cooling fan before nozzle cleaning

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -479,6 +479,11 @@ gcode:
             G1 E2 F800
           {% endif %}
         {% endfor %}
+		
+		{% if part_cooling_fan >= 0 %}
+		# Reset part cooling fan if it was changed
+		M106 S{(backup_fan_speed * 255)|int}
+		{% endif %}
 
         # ==================================================================================
         # ==================== DEPOSIT BLOB ================================================
@@ -520,10 +525,6 @@ gcode:
     G90 # absolute positioning
     G1 Z{restore_z} F{travel_spd_z}
     
-    {% if part_cooling_fan >= 0 %}
-      # Reset part cooling fan if it was changed
-      M106 S{(backup_fan_speed * 255)|int}
-    {% endif %}
     
     M220 S{(backup_feedrate * 100)|int}
   {% endif %}


### PR DESCRIPTION
Changed blobifier.cfg GCODE, so the part cooling fan turns off before nozzle cleaning with brush for better cleaning.