### PR TITLE
feat: Add filament_switch_sensor warnings

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -1276,6 +1276,15 @@ class Mmu:
                     self.log_trace(msg + " Message was suppressed.")
                 else:
                     self.log_warning(msg)
+            # Look for filament_switch_sensors already configured to warn for possible conflicts
+            for section in self.config.get_prefix_sections('filament_switch_sensor'):
+                # Determine if this is created by HH or user
+                fsensor = self.printer.lookup_object(section.get_name())
+                if not isinstance(fsensor.runout_helper, MmuRunoutHelper):
+                    fsensor_name = section.get_name().split()[1]
+                    pause_on_runout = section.getboolean('pause_on_runout', False)
+                    pause_on_runout_msg = " and/or pause during prints unintentionally" if pause_on_runout else ""
+                    self.log_warning("Warning: filament_switch_sensor '%s' found in printer configuration. This may interfere with MMU functionality%s." % (fsensor_name, pause_on_runout_msg))
             self._set_print_state("initialized")
 
             # Use pre-gate sensors to adjust gate map


### PR DESCRIPTION
I've had several 3MS users ask for help related to unexpected print pauses, where the solution is to remove all `filament_switch_sensor` sections from the configuration, since they can pause prints unintentionally. 

This PR displays a warning on `MMU_BOOTUP` if there are `filament_switch_sensor`s found in the config that are not created by HH (user-created).