### PR TITLE
fix MMU_GATE_MAP cant update when disable spoolman

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -7857,7 +7857,7 @@ class Mmu:
                             continue
 
                         # Only update gate attributes if we have a valid spool_id
-                        if fil and fil.get('spool_id', -1) != -1:
+                        if fil and (fil.get('spool_id', -1) != -1 or self.spoolman_support == self.SPOOLMAN_OFF):
                             self.gate_filament_name[gate] = fil.get('name', '')
                             self.gate_material[gate] = fil.get('material', '')
                             self.gate_color[gate] = fil.get('color', '')


### PR DESCRIPTION
Fixed the issue where opening the ***EditFilaments*** interface on the **_Fluidd_** interface would result in the inability to save the material configuration. 

This is because the code has enabled `spool_id`protection. However, when SpoolMan is not installed or enabled, the `spool_id`defaults to -1, making it impossible to write data normally. 

Modifying the save judgment in the *EditFilaments* interface might also fix this issue. This problem only occurs when the MAP parameter of MMU_GATE_MAP is written.