### PR TITLE
Blobifier purge sequence improvements

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -208,12 +208,18 @@ variable_eject_hop: 1.0
 # Dwell time (ms) after purging and before cleaning to relieve pressure from the nozzle.
 variable_pressure_release_time: 1000
 
-# Set the part cooling fan speed. Disabling can help prevent the nozzle from cooling down 
-# and stimulate flow, Enabling it can prevent blobs from sticking together. Values range 
-# from 0 .. 1, or -1 if you don't want it changed.
-#variable_part_cooling_fan: -1              # Leave it unchanged
-#variable_part_cooling_fan:  0              # Disable the fan
-variable_part_cooling_fan:  1               # Run it at full speed
+# Amount (mm) to retract between blobs to reduce string formation and allow for a cleaner purge.
+variable_retract_between_blobs: 5
+
+# Set the part cooling fan speed during purging (variable_part_cooling_fan) and
+# during the blob depositing process (variable_part_cooling_fan_blob_deposit)
+# Low fan speeds during purging help ensure the pellets are well formed and reduces
+# the probability of the pellets coming unstuck from tray due to material shrinkage.
+# Setting the blob depositing fan speed to high (100%) helps freeze the blob, unstick
+# the blob from the nozzle and shrink it a little allowing for a cleaner blob depositing
+
+variable_part_cooling_fan:  0.3             # Fan speed to use during purging (-1 is unchanged, 0 is off, 0.1-1.0 for fan speed %)
+variable_part_cooling_fan_blob_deposit: 1   # Fan speed to use during blob depositing (-1 is unchanged, 0 is off, 0.1-1.0 for fan speed %
 
 # Define the part fan name if you are using a fan other than [fan]
 # Applies to [fan_generic] or other fan definitons
@@ -301,11 +307,14 @@ gcode:
     RESPOND MSG="BLOBIFIER: QGL not applied! run quad_gantry_level before blobbing"
   {% else %}
     
-    # Part cooling fan
+
+    # Always backup part cooling fan speed
+    {% set fan = fan_name|string %}
+    # Save the part cooling fan speed to be enabled again later
+    {% set backup_fan_speed = (printer[fan].speed if printer[fan] is defined else printer.fan.speed) %}
+    
+    # Part cooling fan set for purging
     {% if part_cooling_fan >= 0 %}
-      {% set fan = fan_name|string %}
-      # Save the part cooling fan speed to be enabled again later
-      {% set backup_fan_speed = (printer[fan].speed if printer[fan] is defined else printer.fan.speed) %}
       # Set part cooling fan speed
       M106 S{part_cooling_fan * 255}
     {% endif %}
@@ -458,6 +467,12 @@ gcode:
         G91 
         # relative extrusion
         M83
+        
+        # Un-retract other than the first purge, to re-prime nozzle
+        {% if not loop.first %} 
+          M400
+          G1 E{retract_between_blobs} F{sequence_vars.retract_speed * 60}
+        {% endif %}
 
         # Purge filament in a pulsating motion to purge the filament quicker and better
         {% for pulse in range(pulses_per_blob) %}
@@ -479,11 +494,26 @@ gcode:
             G1 E2 F800
           {% endif %}
         {% endfor %}
-
+        
         # ==================================================================================
         # ==================== DEPOSIT BLOB ================================================
         # ==================================================================================
+        
+        # Perform retraction
+        {% if loop.last %} 
+          # This is the last blob - retract to match what Happy Hare is expecting
+          G1 E-{park_vars.retracted_length} F{sequence_vars.retract_speed * 60}
+        {% else %}
+          # This is an in between blob - retract by the in between blobs retraction value
+          G1 E-{retract_between_blobs} F{sequence_vars.retract_speed * 60}
+        {% endif %}
+
         {% if safe.tray or ignore_safe %}
+          # Set blob depositing fan speed
+          {% if part_cooling_fan_blob_deposit >= 0 %}
+            M106 S{(part_cooling_fan_blob_deposit * 255)|int}
+          {% endif %}
+          
           # Raise z a bit to relieve pressure on the blob preventing it to go sideways
           G1 Z{eject_hop} F{travel_spd_z}
           # Retract the tray
@@ -491,18 +521,32 @@ gcode:
           # Move the toolhead down to purge_start height lowering the blob below the tray
           G90 # absolute positioning
           G1 Z{tray_top} F{travel_spd_z}
+          
+          # Dwell to release pressure before cutting the blob off
+          M400
+          G4 P{pressure_release_time}
+          
           # Extend the tray to 'cut off' the blob and prepare for the next blob
           BLOBIFIER_SERVO POS=out
           BLOBIFIER_SERVO POS=in
           BLOBIFIER_SERVO POS=out
           # Keep track of the # of blobs
           _BLOBIFIER_COUNT
+          
+          # Set purging fan speed
+          {% if part_cooling_fan < 0 %} 
+            # If part cooling fan is unchanged and equal to print speed fan
+            M106 S{(backup_fan_speed * 255)|int}
+          {% elif part_cooling_fan >= 0 %}
+            # If specific part cooling fan speed is set
+            M106 S{(part_cooling_fan * 255)|int}
+          {% endif %}
+          
         {% endif %}
       {% endfor %}
     {% endif %}
     {% if safe.tray or ignore_safe %}
       G1 Z{tray_top + 1} F{travel_spd_z}
-      G4 P{pressure_release_time}
     {% endif %}
     {% if safe.brush or ignore_safe %}
       BLOBIFIER_CLEAN
@@ -513,17 +557,12 @@ gcode:
     # ======================================================================================
     # ==================== RESTORE STATE ===================================================
     # ======================================================================================
-
-    # Retract to match what Happy Hare is expecting
-    G1 E-{park_vars.retracted_length} F{sequence_vars.retract_speed * 60}
         
     G90 # absolute positioning
     G1 Z{restore_z} F{travel_spd_z}
     
-    {% if part_cooling_fan >= 0 %}
-      # Reset part cooling fan if it was changed
-      M106 S{(backup_fan_speed * 255)|int}
-    {% endif %}
+    # Reset part cooling fan unconditionally
+    M106 S{(backup_fan_speed * 255)|int}
     
     M220 S{(backup_feedrate * 100)|int}
   {% endif %}


### PR DESCRIPTION
Following 8+ months of running the blobifier macros in a semi-custom manner, I am proposing the below changes to the purge sequence and logic:

### Changes:

1. **Retraction in between purge loops (poops)**: Introduced variable to perform a small retraction value in-between the formation of purge poops. This assists un-sticking the blob from the nozzle and reduces stringing when depositing the blob. New variable: variable_retract_between_blobs with 5mm default retraction value.
2. **Fan handling during purging and cutting**: Introduced new variable to set the fan speed to a (higher) value during poop depositing. This helps solidify the blob and deposit it cleanly, while also allowing for a lower fan speed during purging, which helps keep the material soft and adhered to the servo tray. New variable: variable_part_cooling_fan_blob_deposit with 100% fan speed as the default. Now also the purging default fan speed value (variable_part_cooling_fan) is 30%.

### Next steps:

Testers wanted to test these amendments. My tests show results like the below:

![IMG_6330](https://github.com/user-attachments/assets/02e9a208-506f-4d2e-8518-e2936cbf6ee9)

https://youtube.com/shorts/P2c9okgFZ-0


### Further PR's in the pipeline:
1. Implement long retraction and push back to further clean the nozzle when high volume purges are requested
2. Implement pause on purge if runout occurs.

