### PR TITLE
Add condition for Kalico mcu lookup

### DIFF
--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -369,9 +369,12 @@ class MmuToolHead(toolhead.ToolHead, object):
         self.printer = config.get_printer()
         self.reactor = self.printer.get_reactor()
 
-        #self.all_mcus = [m for n, m in self.printer.lookup_objects(module='mcu')] # Older Klipper
-        #self.mcu = self.all_mcus[0]                                               # Older Klipper
-        self.mcu = self.printer.lookup_object('mcu') # Klipper approx >= 0.13.0-328 (safer lookup, guarantee's primary mcu or config error)
+        if self.mmu.kalico: # Kalico has not implemented the safe mcu lookup used by Klipper
+            logging.info("MMU: Running on Kalico, switching to the old mcu lookup")
+            self.all_mcus = [m for n, m in self.printer.lookup_objects(module='mcu')]
+            self.mcu = self.all_mcus[0]
+        else:
+            self.mcu = self.printer.lookup_object('mcu') # Klipper approx >= 0.13.0-328 (safer lookup, guarantee's primary mcu or config error)
 
         self._resync_lock = self.reactor.mutex()
 


### PR DESCRIPTION
Since Kalico isn't providing the mcu lookup that comes with newer Klipper versions, the latest Happy-Hare update breaks Kalico installations. 

By checking if we're running on Kalico, we can switch back to the old lookup for Kalico installs, and default to the new lookup for Klipper installs.