### PR TITLE
Adjust set_direction() so it does not execute set_dir_inverted() for extruder stepper

### DIFF
--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -1230,7 +1230,8 @@ class MmuPrinterRail(_StepperPrinterRail, object):
 
     def set_direction(self, direction):
         for stepper in self.steppers:
-            stepper.set_dir_inverted(direction)
+            if stepper._name != "extruder":
+                stepper.set_dir_inverted(direction)
 
     class MockEndstop:
         def add_stepper(self, *args, **kwargs):


### PR DESCRIPTION
My custom mmu requires the gear stepper to be reversed for 2 out of my 4 gates. An issue arises when performing a sync'd gear+extruder move for a gate that requiers the gear to be reversed. The code that reverses the gear stepper will inadvertently reverse the extruder stepper as well. This is because the extruder stepper was temporarily added to the rail object's `steppers[]` list for the gear+extruder sync.

This proposed solution is to skip any stepper that is named "extruder" so that only gear steppers are affected.