### PR TITLE
New Type A option that has no servo or espooler

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2108,6 +2108,7 @@ questionaire() {
             OPTIONS=() # reset option array
             option TYPE_A_WITH_ENCODER                            'Type-A (selector) with Encoder'
             option TYPE_A_NO_ENCODER                              'Type-A (selector), No Encoder'
+            option TYPE_A_NO_ENCODER_NO_SERVO_NO_ESPOOLER         'Type-A (selector), No Encoder, No Servo, No ESpooler'
             option TYPE_B_WITH_ENCODER                            'Type-B (mutliple filament drive steppers) with Encoder'
             option TYPE_B_WITH_SHARED_GATE_AND_ENCODER            'Type-B (multiple filament drive steppers) with shared Gate sensor and Encoder'
             option TYPE_B_WITH_SHARED_GATE_NO_ENCODER             'Type-B (multiple filament drive steppers) with shared Gate sensor, No Encoder'
@@ -2124,6 +2125,15 @@ questionaire() {
                     ;;
                 "$TYPE_A_NO_ENCODER")
                     HAS_ENCODER=no
+                    _param_gate_homing_endstop="mmu_gate"
+                    _param_extruder_homing_endstop="none"
+                    echo
+                    echo -e "${WARNING}    IMPORTANT: Since you have a custom MMU with selector you will need to setup some CAD dimensions in mmu_parameters.cfg... See doc"
+                    ;;
+                "$TYPE_A_NO_ENCODER_NO_SERVO_NO_ESPOOLER")
+                    HAS_ENCODER=no
+                    HAS_SERVO=no
+                    HAS_ESPOOLER=no
                     _param_gate_homing_endstop="mmu_gate"
                     _param_extruder_homing_endstop="none"
                     echo


### PR DESCRIPTION
I have a basic mmu system that has no servo or espooler and therefore use option 16 of the installer ("Other / Custom") to install Happy Hare. Without this change I must manually comment out a servo section in `mmu_hardware.cfg` and a servo section in `mmu_parameters.cfg` and  comment out the espooler section in `mmu_hardware.cfg` otherwise I encounter cryptic startup errors.

So in addition to fixing these startup issues I am able to use this new option to develop my custom mmu system without having to edit any of the base config files and can instead define my own custom config files which I include *after* the base config files. This lets me fully customize Happy Hare to work with my system and also easily (re)install Happy Hare on any of my other test machines

