### PR TITLE
feat(blobifier): allow setting y offset for blobifier and brush

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -105,6 +105,9 @@ variable_brush_accel: 0
 # adjustments small though! (0.1mm - 0.5mm) and increase it until it works.
 variable_skew_correction: 0.1
 
+# offset subtracted from the Y max position to position the toolhead during purging.
+variable_y_offset: 0
+
 # These parameters define the size of the brush. Update as necessary. A visual reference
 # is provided below.
 #
@@ -127,6 +130,9 @@ variable_brush_start:           67  # For 300mm build
 
 # width of the brush
 variable_brush_width: 35
+
+# offset subtracted from the y max to perform brushing.
+variable_brush_y_offset: 0
 
 # Location of where to purge. The tray is 15mm in length, so if you assemble it against 
 # the side of the bed (default), 10mm is a good location
@@ -340,7 +346,7 @@ gcode:
     {% set ignore_safe = safe.print_height < force_safe_descend_height_until %}
     {% set restore_z = [printer['gcode_macro BLOBIFIER_PARK'].restore_z,pos.z]|max %}
     {% set pos_max = printer.toolhead.axis_maximum %}
-    {% set position_y = pos_max.y - skew_correction %}
+    {% set position_y = pos_max.y - skew_correction - y_offset %}
 
     # Get purge volumes from the slicer (if set up right. see 
     # https://github.com/moggieuk/Happy-Hare/wiki/Gcode-Preprocessing)
@@ -581,7 +587,7 @@ gcode:
 gcode:
   {% set bl = printer['gcode_macro BLOBIFIER'] %}
   {% set pos_max = printer.toolhead.axis_maximum %}
-  {% set position_y = pos_max.y - bl.skew_correction %}
+  {% set position_y = pos_max.y - bl.skew_correction - bl.brush_y_offset %}
   {% set original_accel = printer.toolhead.max_accel %}
   {% set original_minimum_cruise_ratio = printer.toolhead.minimum_cruise_ratio %}
   {% set pos = printer.gcode_move.gcode_position %}
@@ -631,7 +637,7 @@ gcode:
   {% set pos = printer.gcode_move.gcode_position %}
   {% set safe = printer['gcode_macro _BLOBIFIER_SAFE_DESCEND'] %}
   {% set pos_max = printer.toolhead.axis_maximum %}
-  {% set position_y = pos_max.y - bl.skew_correction %}
+  {% set position_y = pos_max.y - bl.skew_correction - bl.y_offset %}
 
   SET_GCODE_VARIABLE MACRO=BLOBIFIER_PARK VARIABLE=restore_z VALUE={pos.z}
 
@@ -755,9 +761,10 @@ variable_print_layer_height: 0.3
 gcode:
   {% set bl = printer['gcode_macro BLOBIFIER'] %}
   {% set pos_max = printer.toolhead.axis_maximum %}
-  {% set position_y = pos_max.y - bl.skew_correction %}
+  {% set position_y = pos_max.y - bl.skew_correction - bl.y_offset %}
+  {% set brush_position_y = pos_max.y - bl.skew_correction - bl.brush_y_offset %}
   {% set tray = [bl.purge_x + bl.toolhead_x, position_y - bl.toolhead_y] %}
-  {% set brush = [bl.brush_start + bl.brush_width + bl.toolhead_x, position_y - bl.toolhead_y] %}
+  {% set brush = [bl.brush_start + bl.brush_width + bl.toolhead_x, brush_position_y - bl.toolhead_y] %}
   {% set shake = [bl.purge_x + bl.toolhead_x, position_y - bl.toolhead_y - 4] %}
   {% set objects = printer.exclude_object.objects | map(attribute='polygon') %}
 
@@ -836,7 +843,7 @@ gcode:
   G90
   {% set shakes = params.SHAKES|default(10)|int %}
   {% set pos_max = printer.toolhead.axis_maximum %}
-  {% set position_y = pos_max.y - bl.skew_correction %}
+  {% set position_y = pos_max.y - bl.skew_correction - bl.y_offset %}
   
   # move to save y if not already there
   {% if printer.toolhead.position.y != position_y %}


### PR DESCRIPTION
These changes are based on @igiannakas [custom blobifier macros](https://github.com/igiannakas/Voron-backups/blob/fbbabc2590192f0845cb33a478a22adbb719428a/printer_data/config/macros/custom_blobifier.cfg). It allows one to specify an offset subtracted from y max position for purging and brushing. One change from his implementation is the ability to set the blobifier offset independent from the brush offset.

One thing still missing that he's got is the ability to have blobifier clean without changing Z ... at some point i'd like to get integrated in here too along with the option to have the nozzle seal on something other than the blobifier tray...specifically i've got a place next to the brush that is fixed to the gantry, so its always available at any Z position.