### PR TITLE
Enrich purge macro message to include extra info 

### DIFF
--- a/config/base/mmu_purge.cfg
+++ b/config/base/mmu_purge.cfg
@@ -54,7 +54,7 @@ gcode:
         G1 E{retracted_length} F{unretract_speed|abs * 60}
     {% endif %}
 
-    MMU_LOG MSG="Purging {purge_len | round(1)}mm of filament"
+    MMU_LOG MSG="Purging {purge_len | round(1)}mm of filament including {extruder_filament_remaining | round(1)}mm remaining in extruder (Total {(filament_cross_section * purge_len) | round(1)}mm³)"
 
     # Purge in segments so it is still possible to detect clogs and pause
     {% set num_segments = (purge_len // segment_len) | int %}


### PR DESCRIPTION
Enrich purge message to include extra info for extruder_filament_remaining (mm) and total purge volume (mm³) for clarity e.g.

Purging 62.0mm filament including 30.0mm remaining in extruder (Total 149.1mm³)

