### PR TITLE
Blobifier: implement runout detection and set PA to zero when purging.

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -329,6 +329,12 @@ gcode:
     # Set feedrate to 100% for correct speed purging
     {% set backup_feedrate = printer.gcode_move.speed_factor %}
     M220 S100
+    
+    # Backup and zero Pressure Advance during blobbing
+    {% set backup_pa = printer.extruder.pressure_advance|default(0.0)|float %}
+    RESPOND MSG={"'BLOBIFIER: Setting PA to zero (was %.4f)'" % (backup_pa)}
+    SET_PRESSURE_ADVANCE ADVANCE=0
+
 
     # ======================================================================================
     # ==================== DEFINE BASIC VARIABLES ==========================================
@@ -478,7 +484,7 @@ gcode:
         # Un-retract other than the first purge, to re-prime nozzle
         {% if not loop.first %} 
           M400
-          G1 E{retract_between_blobs} F{sequence_vars.retract_speed * 60}
+          __BLOBIFIER_EXTRUDER_MOVE E={retract_between_blobs} EXTRUDER_SPEED={sequence_vars.retract_speed * 60}
         {% endif %}
 
         # Purge filament in a pulsating motion to purge the filament quicker and better
@@ -491,15 +497,16 @@ gcode:
           {% set speed = z_up / pulse_duration %}
 
           # Purge quickly
-          G1 Z{z_up * pulse_time_constant} E{purge_per_pulse * 0.95} F{speed}
+          __BLOBIFIER_EXTRUDER_MOVE EXTRUDER_SPEED={speed} E={purge_per_pulse * 0.95} NEW_Z={z_up * pulse_time_constant}
           # Purge a tiny bit slowly
-          G1 Z{z_up * (1 - pulse_time_constant)} E{purge_per_pulse * 0.05} F{speed}
+          __BLOBIFIER_EXTRUDER_MOVE EXTRUDER_SPEED={speed} E={purge_per_pulse * 0.05} NEW_Z={z_up * (1 - pulse_time_constant)}
 
           # retract and unretract filament every now and then for thorough cleaning
           {% if pulse % pulses_per_retract == 0 and pulse > 0 %}
-            G1 E-2 F1800
-            G1 E2 F800
+            __BLOBIFIER_EXTRUDER_MOVE E=-2 EXTRUDER_SPEED=1800
+            __BLOBIFIER_EXTRUDER_MOVE E=2  EXTRUDER_SPEED=800
           {% endif %}
+
         {% endfor %}
         
         # ==================================================================================
@@ -509,11 +516,12 @@ gcode:
         # Perform retraction
         {% if loop.last %} 
           # This is the last blob - retract to match what Happy Hare is expecting
-          G1 E-{park_vars.retracted_length} F{sequence_vars.retract_speed * 60}
+          __BLOBIFIER_EXTRUDER_MOVE E=-{park_vars.retracted_length} EXTRUDER_SPEED={sequence_vars.retract_speed * 60}
         {% else %}
           # This is an in between blob - retract by the in between blobs retraction value
-          G1 E-{retract_between_blobs} F{sequence_vars.retract_speed * 60}
+          __BLOBIFIER_EXTRUDER_MOVE E=-{retract_between_blobs} EXTRUDER_SPEED={sequence_vars.retract_speed * 60}
         {% endif %}
+
 
         {% if safe.tray or ignore_safe %}
           # Set blob depositing fan speed
@@ -571,7 +579,12 @@ gcode:
     # Reset part cooling fan unconditionally
     M106 S{(backup_fan_speed * 255)|int}
     
+    # Restore feedrate
     M220 S{(backup_feedrate * 100)|int}
+    
+    # Restore Pressure Advance
+    RESPOND MSG={"'BLOBIFIER: Restoring PA to %.4f'" % (backup_pa)}
+    SET_PRESSURE_ADVANCE ADVANCE={backup_pa}
   {% endif %}
 
   # Retract the tray
@@ -579,6 +592,29 @@ gcode:
   
   RESTORE_GCODE_STATE NAME=BLOBIFIER_state 
 
+##########################################################################################
+# Extrusion helper that allows for check of "runout/clog" indicator
+#
+[gcode_macro __BLOBIFIER_EXTRUDER_MOVE]
+description: Extruder move (optional Z) with clog/runout guard
+# Parameters:
+#   EXTRUDER_SPEED in mm/min
+#   E             in mm
+#   NEW_Z         in mm
+gcode:
+    {% set extruder_speed = params.EXTRUDER_SPEED|float %}
+    {% set E = params.E|float %}
+    {% set new_z = params.NEW_Z|default(None) %}
+
+    {% set clog_runout_detected = printer.mmu.clog_runout_detected|default(false)|lower == 'true' %}
+
+    {% if not clog_runout_detected %}
+        {% if new_z is not none %}
+            G1 Z{new_z} E{E} F{extruder_speed}
+        {% else %}
+            G1 E{E} F{extruder_speed}
+        {% endif %}
+    {% endif %}
 
 ##########################################################################################
 # Wipes the nozzle on the brass brush


### PR DESCRIPTION
As per title, this PR implements runout detection in a similar manner to the "stock" mmu purge macro. It also sets PA to zero when purging (and resets to previous value at the end) to avoid needless compensation by the extruder when creating blobs at high purge velocity. 


Testers wanted please