### PR TITLE
Refactor & rename MMU_QUERY_FPS macro and comments

### DIFF
--- a/config/base/mmu_software.cfg
+++ b/config/base/mmu_software.cfg
@@ -515,16 +515,22 @@ gcode:
     MMU_CHECK_GATE GATE={gate} TOOL={tool} GATES={gates} TOOLS={tools}
 
 
-##########################################################################
-# Macro to query filament pressure sensor (proportional sync feedback) state
+###########################################################################
+# Macro to query filament pressure sensor (proportional sync sensor) state
 #
-[gcode_macro MMU_QUERY_FPS]
-description: Show raw and normalised filament pressure sensor (proportional sync feedback) readings
+[gcode_macro MMU_QUERY_PSS]
+description: "Show raw and scaled filament pressure sensor (Proportional Sync Sensor) readings"
 variable_sensor: "filament_proportional"
 gcode:
     {% set name = params.SENSOR|default(sensor) %}
     {% set obj  = printer[name] %}
-    M118 FPS Enabled: {obj.enabled} Value: {obj.value|float|round(3)} Raw Value: {obj.value_raw|float|round(3)}
+
+    {% if obj.set_point is defined %}
+       M118 PSS Enabled: {obj.enabled}  Value: {obj.value|float|round(3)}  Raw Value: {obj.value_raw|float|round(3)}  Centre Set Point: {obj.set_point|float|round(3)}  Scaling Factor: {obj.scale|float|round(2)}
+    {% else %}
+       M118 PSS Enabled: {obj.enabled}  Value: {obj.value|float|round(3)}  Raw Value: {obj.value_raw|float|round(3)}
+    {% endif %} 
+
     
 [gcode_macro MMU_ADJUST_TENSION]
 description: Sets filament tension to neutral using the sync-feedback buffer sensor


### PR DESCRIPTION
Renamed to ``MMU_QUERY_PSS`` (**P**roportional **S**ync **S**ensor) to make more generic and added conditional logic to display additional attributes when ``sync_feedback_analog_debug: True`` is set.  May rollup functionality into ``MMU_SENSORS`` and delete in future. In the meantime its needed to help calibrate and confirm proportional sensor operation.