### PR TITLE
Refactor averaging and p_sensor calibration logic in mmu.py

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -2702,7 +2702,7 @@ class Mmu:
             """
             sensor = self.sensor_manager.all_sensors.get(self.SENSOR_PROPORTIONAL)
             
-            k = 0.1 # 1st order,low pass filer coefficient, 0.1 for 10 samples 
+            k = 0.1 # 1st order,low pass filter coefficient, 0.1 for 10 samples 
             avg = sensor.get_status(0).get('value_raw', None)
 
             for _ in range(int(max(1, n-1))):
@@ -2711,7 +2711,6 @@ class Mmu:
                 if raw is None or not isinstance(raw, float):
                     return None
                 avg += k * (raw - avg) # 1st order low pass filter
-
             return (avg)
 
         def _sd(xs):


### PR DESCRIPTION
For @moggieuk to evaluate and adapt. 

Less aggressive p_sensor calibration routine.  It seeks 1.8 * max sensor range in either direction in 2mm steps to quantify ADC range and midpoint. Compression first, breaking out once target value stops increasing (< 0.1 delta). Backs off outer sensor limit and does the same for Tension. ADC sampling algorithm changed to use simple 1st order low pass filter & upped to 10 samples with smaller delay to smooth / normalise.

Provided it can reach sensor extremes (within 1.8 * max sensor range including filament spring), it should work from any starting point.   Much less aggressive on MMU systems like mine with low bowden/filament spring and high gear stepper run_current. Even with run_current dropped to sync level, previous calibration approach was still a little too brutal.  

```
$ MMU_CALIBRATE_PSENSOR
// DEBUG: Modifying MMU stepper_mmu_gear run current to 20% (0.24A) while calibrating sync_feedback psensor
// Starting calibration. Please excuse the noise - you might hear a bit of grinding but it won't take long!
// Finding compression limit stepping up to 13.00mm
// Seeking ... ADC value 0.5756
// Seeking ... ADC value 0.9105
// Seeking ... ADC value 0.9828
// Seeking ... ADC value 0.9830
// Seeking ... ADC value 0.9842
// Backing off compressed limit
// Finding tension limit stepping up to 13.00mm
// Seeking ... ADC value 0.5640
// Seeking ... ADC value 0.4220
// Seeking ... ADC value 0.0922
// Seeking ... ADC value 0.0078
// Seeking ... ADC value 0.0069
// Calibration Results:
// As wired the recommended setting (in mmu_hardware.cfg) is:
// [mmu_sensors]
// sync_feedback_analog_max_compression: 0.9842
// sync_feedback_analog_max_tension: 0.0069
// sync_feedback_analog_neutral_point: 0.4955
// DEBUG: Restoring MMU stepper_mmu_gear run current to 100% (1.20A)
```