### PR TITLE
Implement has_sensor method, returning self.sync_feedback_enabled to suppress errors as temp workaround

### DIFF
--- a/extras/mmu/mmu_sync_feedback_manager.py
+++ b/extras/mmu/mmu_sync_feedback_manager.py
@@ -121,7 +121,7 @@ class MmuSyncFeedbackManager:
         return msg
 
     def has_sensor(self): ## PAUL, quick hack to suppress errors in interim until response coded 
-        return False
+        return self.sync_feedback_enabled
         
 
     def check_test_config(self, param):


### PR DESCRIPTION
Added method to object to suppress sensor manager errors.

Review broader sensor manager context and required changes to enable ``MMU_STATUS SHOWDETAIL=1`` and other upstream dependencies.