### PR TITLE
Delete MMU_ADJUST_TENSION gcode macro

### DIFF
--- a/config/base/mmu_software.cfg
+++ b/config/base/mmu_software.cfg
@@ -527,12 +527,6 @@ gcode:
     M118 PSENSOR Enabled: {obj.enabled}  Value: {obj.value|float|round(3)}  Raw Value: {obj.value_raw|float|round(3)}
 
 
-[gcode_macro MMU_ADJUST_TENSION]
-description: Sets filament tension to neutral using the sync-feedback buffer sensor
-gcode:
-    MMU_SYNC_FEEDBACK ADJUST_TENSION=1
-
-
 ###########################################################################
 # Aliases (for backward compatibility) of previously well used commands...
 #


### PR DESCRIPTION
Removed MMU_ADJUST_TENSION macro and its description.