### PR TITLE
MMU_PURGE Flowguard support: MMU_SYNC_FEEDBACK ADJUST_TENSION=1

### DIFF
--- a/config/base/mmu_purge.cfg
+++ b/config/base/mmu_purge.cfg
@@ -72,9 +72,7 @@ gcode:
 
     # Adjust tension and centre sensor to ensure we don't accidentally trigger FlowGuard runout when print resumes
     {% if printer.mmu.sync_feedback_enabled %}
-        MMU_LOG MSG="BLOBIFIER: Sync Feedback/FlowGuard enabled, adjusting tension"
         MMU_SYNC_FEEDBACK ADJUST_TENSION=1  
-        M400
     {% endif %}
 
     MMU_LOG MSG="Purging complete"


### PR DESCRIPTION
Conditional MMU_SYNC_FEEDBACK ADJUST_TENSION callout  to prevent FlowGuard runout during print resume.