### PR TITLE
load all (UI_SPACE) from .mmu_shared

### DIFF
--- a/extras/mmu/mmu_calibration_manager.py
+++ b/extras/mmu/mmu_calibration_manager.py
@@ -17,7 +17,7 @@ import logging, math
 # Happy Hare imports
 
 # MMU subcomponent clases
-from .mmu_shared           import MmuError
+from .mmu_shared           import *
 
 
 class MmuCalibrationManager:


### PR DESCRIPTION
Prevent unhandled exception when running MMU_CALIBRATE_ENCODER

```
Traceback (most recent call last):
  File "/home/pi/klipper/klippy/extras/mmu/mmu_calibration_manager.py", line 353, in calibrate_encoder
    self.mmu.log_always("%s+ counts: %d" % (UI_SPACE*2, counts))
                                            ^^^^^^^^
NameError: name 'UI_SPACE' is not defined

During handling of the above exception, another exception occurred:
```