### PR TITLE
fix: correct the led spec for per-gate leds with multiple units

### DIFF
--- a/extras/mmu_led_effect.py
+++ b/extras/mmu_led_effect.py
@@ -88,7 +88,7 @@ class MmuLedEffect:
                         # Per gate
                         if segment in MmuLeds.PER_GATE_SEGMENTS and (not define_on or 'gates' in define_on):
                             for idx in range(mmu_unit.first_gate, mmu_unit.first_gate + mmu_unit.num_gates):
-                                led0 = idx * leds_per_gate - mmu_unit.first_gate + 1
+                                led0 = (idx - mmu_unit.first_gate) * leds_per_gate + 1
                                 led_spec = str(led0)
                                 if leds_per_gate > 1:
                                     led_spec = "%d-%d" % (led0, led0 + leds_per_gate - 1)


### PR DESCRIPTION
In my config i've got a 4 lane BT and currently a 1 lane EMU, here's an excerpt of the led configuration:

```
[mmu_leds unit0] # 4 lane BT ... 1 led per lane
exit_leds: neopixel:mmu_leds (1-4)

[mmu_leds unit1] # 1 lane EMU ... 3 led per lane (2 in button, 1 illuminating spool)
exit_leds: neopixel:emu0_leds (1-2)
entry_leds: neopixel:emu0_leds (3)
```

During initialization, HH would try to set a per-gate effect on the exit_leds which then triggered an internal error while running `_MMU_SET_LED_EFFECT` because it was trying to set led index 4, which doesn't exist on a 3 led chain.

Through some debugging, I found it trying to create `mmu_breathing_red_entry_4` with a spec of `unit1_mmu_entry_leds (5-6)` (which would translate to led index 4-5...both invalid).

Now with this fix it is creating it with a spec of `unit1_mmu_entry_leds (1-2)`.