### PR TITLE
fix: initialize led animation when using multiple units

### DIFF
--- a/extras/mmu/mmu_led_manager.py
+++ b/extras/mmu/mmu_led_manager.py
@@ -23,7 +23,8 @@ class MmuLedManager:
     def __init__(self, mmu):
         self.mmu = mmu
         self.mmu_machine = mmu.mmu_machine
-        self.inside_timer = self.pending_update = False
+        self.inside_timer = False
+        self.pending_update = [False] * self.mmu_machine.num_units
         self.effect_state = {} # Current state used to minimise updates {unit: {segment: effect}}
 
         # Event handlers
@@ -41,9 +42,9 @@ class MmuLedManager:
 
     def led_timer_handler(self, eventtime):
         self.inside_timer = True
-        self.pending_update = False
         try:
             for unit in range(self.mmu_machine.num_units):
+                self.pending_update[unit] = False
                 self._set_led(unit, None, exit_effect='default', entry_effect='default', status_effect='default', logo_effect='default')
         finally:
             self.inside_timer = False
@@ -51,7 +52,7 @@ class MmuLedManager:
 
     def schedule_led_command(self, duration, unit):
         if not self.inside_timer:
-            self.pending_update = True
+            self.pending_update[unit] = True
             self.mmu.reactor.update_timer(self.led_timer, self.mmu.reactor.monotonic() + duration)
 
     cmd_MMU_SET_LED_help = "Directly control MMU leds"
@@ -327,7 +328,7 @@ class MmuLedManager:
     # (this could be changed to klipper event)
     def print_state_changed(self, state, old_state):
         gate = self.mmu.gate_selected
-        if state in ['initilized', 'printing', 'ready', 'cancelled', 'standby']:
+        if state in ['initialized', 'printing', 'ready', 'cancelled', 'standby']:
             units_to_update = range(self.mmu_machine.num_units)
         else:
             units_to_update = [self.mmu.unit_selected]
@@ -565,7 +566,7 @@ class MmuLedManager:
                 return
 
             # Don't allow changes to shortcut animations - important changes will be seen when update timer fires
-            if self.pending_update:
+            if self.pending_update[unit]:
                 return
 
             # Schedule a return to defaults after duration


### PR DESCRIPTION
This fixes so that all units will display the rainbow initialized animation instead of only the unit with the currently selected gate. There were two issues preventing the initialized animation from running on all units...

1. Typo that caused the animation to run only on the unit with the "selected" gate instead of on all units
2. The animation on the second (or more) units would hit an early return based on 'pending_update' because the first unit's initialized animation was running