### PR TITLE
add gate available_status for leds

### DIFF
--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -425,8 +425,8 @@ frame_rate: 24
 #
 enabled: True				# True = LEDs are enabled at startup (MMU_LED can control), False = Disabled
 animation: True				# True = Use led-animation-effects, False = Static LEDs
-exit_effect: gate_status		#    off|gate_status|filament_color|slicer_color|r,g,b|_effect_
-entry_effect: filament_color		#    off|gate_status|filament_color|slicer_color|r,g,b|_effect_
+exit_effect: gate_status		#    off|gate_status|available_status|filament_color|slicer_color|r,g,b|_effect_
+entry_effect: filament_color		#    off|gate_status|available_status|filament_color|slicer_color|r,g,b|_effect_
 status_effect: filament_color		# on|off|gate_status|filament_color|slicer_color|r,g,b|_effect_
 logo_effect: (0, 0, 0.3)		#    off                                        |r,g,b|_effect_
 white_light: (1, 1, 1)			# RGB color for static white light
@@ -455,3 +455,4 @@ effect_gate_unknown:       mmu_static_orange,       (0.5, 0.2, 0)
 effect_gate_unknown_sel:   mmu_ready_orange,        (0.75, 0.3, 0)
 effect_gate_empty:         mmu_static_black,        (0, 0, 0)
 effect_gate_empty_sel:     mmu_ready_orange2,       (0.1, 0.04, 0)
+effect_gate_available2:    mmu_static_white,        (1, 1, 1)

--- a/config/base/mmu_leds.cfg
+++ b/config/base/mmu_leds.cfg
@@ -58,6 +58,10 @@ layers:       breathing 2 0 subtract (0,0.35,0)
 define_on:    gates
 layers:       static 0 0 top (0.5,0.2,0)
 
+[mmu_led_effect mmu_static_white]
+define_on:    gates
+layers:       static 0 0 top (1,1,1)
+
 [mmu_led_effect mmu_ready_orange]
 define_on:    gates
 layers:       breathing 2 0 subtract (0.35,0.14,0)

--- a/extras/mmu/mmu_led_manager.py
+++ b/extras/mmu/mmu_led_manager.py
@@ -103,8 +103,8 @@ class MmuLedManager:
         + "UNIT          = #(int) default all units\n"
         + "ENABLE        = [0|1]\n"
         + "ANIMATION     = [0|1]\n"
-        + "EXIT_EFFECT   = [off|gate_status|filament_color|slicer_color|r,g,b|_effect_]\n"
-        + "ENTRY_EFFECT  = [off|gate_status|filament_color|slicer_color|r,g,b|_effect_]\n"
+        + "EXIT_EFFECT   = [off|gate_status|available_status|filament_color|slicer_color|r,g,b|_effect_]\n"
+        + "ENTRY_EFFECT  = [off|gate_status|available_status|filament_color|slicer_color|r,g,b|_effect_]\n"
         + "STATUS_EFFECT = [off|on|filament_color|slicer_color|r,g,b|_effect_]\n"
         + "LOGO_EFFECT   = [off|r,g,b|_effect_]\n"
         + "REFRESH       = [0|1]\n"
@@ -410,7 +410,7 @@ class MmuLedManager:
     def gate_map_changed(self, gate):
         if gate is not None and gate < 0:
             gate = None
-        gate_effects = {'gate_status', 'filament_color', 'slicer_color'}
+        gate_effects = {'gate_status', 'available_status', 'filament_color', 'slicer_color'}
         units = [self.mmu_machine.get_mmu_unit_by_gate(gate)] if gate is not None else self.mmu_machine.units
         for mmu_unit in units:
             leds = mmu_unit.leds
@@ -605,6 +605,22 @@ class MmuLedManager:
                             key = 'gate_empty'
 
                         return self.effect_name(unit, '%s%s' % (key, suffix))
+
+                    if gate is not None:
+                        set_gate_effect(_effect_for_gate(gate), unit, segment, gate, fadetime=fadetime)
+                    else:
+                        for g in range(mmu_unit.first_gate, mmu_unit.first_gate + mmu_unit.num_gates):
+                            set_gate_effect(_effect_for_gate(g), unit, segment, g, fadetime=fadetime)
+
+                elif effect == "available_status":
+                    def _effect_for_gate(g):
+                        status = self.mmu.gate_status[g]
+                        if status > self.mmu.GATE_EMPTY:
+                            key = 'gate_available2'
+                        else:
+                            key = 'gate_empty'
+                        
+                        return self.effect_name(unit, '%s' % key)
 
                     if gate is not None:
                         set_gate_effect(_effect_for_gate(gate), unit, segment, gate, fadetime=fadetime)

--- a/extras/mmu_leds.py
+++ b/extras/mmu_leds.py
@@ -114,6 +114,7 @@ class MmuLeds:
         self.white_light = MmuLeds.string_to_rgb(config.get('white_light', '(1,1,1)'))
         self.black_light = MmuLeds.string_to_rgb(config.get('black_light', '(0.01,0,0.02)'))
         self.empty_light = MmuLeds.string_to_rgb(config.get('empty_light', '(0,0,0)'))
+        self.loaded_light = MmuLeds.string_to_rgb(config.get('loaded_light', '(1,1,1)'))
 
         # Read operation to effect mappings
         self.effects = {}
@@ -135,7 +136,8 @@ class MmuLeds:
             'effect_gate_empty',
             'effect_gate_available_sel',
             'effect_gate_unknown_sel',
-            'effect_gate_empty_sel'
+            'effect_gate_empty_sel',
+            'effect_gate_available2'
         ]
         for key in effect_keys:
             parts = [part.strip() for part in config.get(key, '').split(",", 1)]


### PR DESCRIPTION
*ready for review other than a wording issue I'd like feedback on*

I wanted to have the LEDs inside my EMU boxes illuminated based on gate availability, but without the transient statuses (preloading, loading, etc). Just one effect when filament is available, and another when it's not.

`effect_gate_available2` is a silly name, but I can't come up with anything better that's not ludicrously wordy. Draft status purely for that. I'd be happy to have suggestions for a more proper wording!

A branch based on `flowguard` is available at [`burkfers:flowguard_available_status`](https://github.com/burkfers/Happy-Hare/tree/flowguard_available_status) for easier testing; I'm sure we're all loving the beta branch.