### PR TITLE
bypass change: adjust wording in config comment

### DIFF
--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -101,7 +101,7 @@ mmu_version: {mmu_version}			# MMU hardware version number (add mod suffix docum
 #variable_rotation_distances: {variable_rotation_distances}		# 1 = If MMU design has dissimilar drive/BMG gears, thus rotation distance, 0 = One drive gear (e.g. Tradrack)
 #require_bowden_move: {require_bowden_move}			# 1 = If MMU design has bowden move that is included in load/unload, 0 = zero length bowden (skip bowden move)
 #filament_always_gripped: {filament_always_gripped}		# 1 = Filament is always trapped by MMU (most type-B designs), 0 = MMU can release filament
-#has_bypass: {has_bypass}				# 1 = Bypass gate available, 0 = No filament bypass possible
+#has_bypass: {has_bypass}				# 1 = Integrated bypass gate available, 0 = No integrated bypass; Bypassing only possible via PTFE
 
 homing_extruder: 1			# CAUTION: Normally this should be 1. 0 will disable the homing extruder capability
 

--- a/config/base/mmu_hardware.cfg.kms
+++ b/config/base/mmu_hardware.cfg.kms
@@ -95,7 +95,7 @@ mmu_version: 1.0			# MMU hardware version number (add mod suffix documented abov
 #variable_rotation_distances: 1		# 1 = If MMU design has dissimilar drive/BMG gears, thus rotation distance, 0 = One drive gear (e.g. Tradrack)
 #require_bowden_move: 1			# 1 = If MMU design has bowden move that is included in load/unload, 0 = zero length bowden (skip bowden move)
 #filament_always_gripped: 1		# 1 = Filament is always trapped by MMU (most type-B designs), 0 = MMU can release filament
-#has_bypass: {has_bypass}				# 1 = Bypass gate available, 0 = No filament bypass possible
+#has_bypass: {has_bypass}				# 1 = Integrated bypass gate available, 0 = No integrated bypass; Bypassing only possible via PTFE
 
 homing_extruder: 1			# CAUTION: Normally this should be 1. 0 will disable the homing extruder capability
 

--- a/config/base/mmu_hardware.cfg.vvd
+++ b/config/base/mmu_hardware.cfg.vvd
@@ -81,7 +81,7 @@ mmu_version: 1.0			# MMU hardware version number (add mod suffix documented abov
 #variable_rotation_distances: 1		# 1 = If MMU design has dissimilar drive/BMG gears, thus rotation distance, 0 = One drive gear (e.g. Tradrack)
 #require_bowden_move: 1			# 1 = If MMU design has bowden move that is included in load/unload, 0 = zero length bowden (skip bowden move)
 #filament_always_gripped: 1		# 1 = Filament is always trapped by MMU (most type-B designs), 0 = MMU can release filament
-#has_bypass: {has_bypass}				# 1 = Bypass gate available, 0 = No filament bypass possible
+#has_bypass: {has_bypass}				# 1 = Integrated bypass gate available, 0 = No integrated bypass; Bypassing only possible via PTFE
 
 homing_extruder: 1			# CAUTION: Normally this should be 1. 0 will disable the homing extruder capability
 


### PR DESCRIPTION
The wording in the comment next to the bypass in the `mmu_hardware` template now makes clear that bypassing is now always possible and the parameter only specifies whether it's an integrated bypass gate.