### PR TITLE
bug(FlowGuard): Ensures that FlowGuard is activated quickly but not immediately

### DIFF
--- a/extras/mmu/mmu_sync_controller.py
+++ b/extras/mmu/mmu_sync_controller.py
@@ -868,7 +868,7 @@ class _FlowguardEngine(object):
             changed_state = (state_now != self._arm_last_state)
             moved = abs(self._arm_motion_mm) > 0.0
             near_neutral = abs(sensor_reading) < cfg.autotune_stable_x_thresh
-            if moved and (changed or near_neutral):
+            if moved and (changed_state or near_neutral):
                 self._armed = True
             else:
                 return self.status()


### PR DESCRIPTION
## Description
Previously the starting of FlowGuard would be delayed on analog p-type sensors. This PR fixes that so that FlowGuard is enabled as soon as the buffer gets to new-neutral position.  The "flowrate" is also now correctly displayed which only occurs when FLowGuard is active/armed.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
![flowrate copy](https://github.com/user-attachments/assets/f9b7503f-ebbb-49e7-b682-0f67f7ccf211)

## [optional] Are there any post-deployment tasks we need to perform?
n/a
