### PR TITLE
fix crash upon warning during bowden calibration

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -4780,7 +4780,7 @@ class Mmu:
             raise MmuError("Failed to reach extruder '%s' endstop after moving %.1fmm" % (self.extruder_homing_endstop, max_length))
 
         if measured > (max_length * 0.8):
-            self.log_warning("Warning: 80%% of 'extruder_homing_max' was used homing. You may want to increase 'extruder_homing_max'" % self.VARS_MMU_CALIB_BOWDEN_LENGTH)
+            self.log_warning("Warning: 80%% of 'extruder_homing_max' was used homing. You may want to increase 'extruder_homing_max'")
 
         self._set_filament_pos_state(self.FILAMENT_POS_HOMED_EXTRUDER)
         return homing_movement, extra


### PR DESCRIPTION
There's an extraneous string replacement causing a crash if the warning message about exceeding 80% of `bowden_homing_max` is hit.

Discovery, log *and* on-printer verification of the fix courtesy of @chrisfo8390

```
Traceback (most recent call last):
  File "/home/pi/klipper/klippy/gcode.py", line 318, in _process_commands
    handler(gcmd)
  File "/home/pi/klipper/klippy/gcode.py", line 227, in func
    return origfunc(self._get_extended_params(params))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/klipper/klippy/extras/mmu/mmu.py", line 2637, in cmd_MMU_CALIBRATE_BOWDEN
    length = self.calibration_manager.calibrate_bowden_length_sensor(approx_bowden_length)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/klipper/klippy/extras/mmu/mmu_calibration_manager.py", line 271, in calibrate_bowden_length_sensor
    actual, extra = self.mmu._home_to_extruder(extruder_homing_max)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/klipper/klippy/extras/mmu/mmu.py", line 4783, in _home_to_extruder
    self.log_warning("Warning: 80%% of 'extruder_homing_max' was used homing. You may want to increase 'extruder_homing_max'" % self.VARS_MMU_CALIB_BOWDEN_LENGTH)
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: not all arguments converted during string formatting
```