### PR TITLE
feat: Add 'aht10' to environment manager humidity sensors

### DIFF
--- a/extras/mmu/mmu_environment_manager.py
+++ b/extras/mmu/mmu_environment_manager.py
@@ -56,7 +56,7 @@ class MmuEnvironmentManager:
     CHECK_INTERVAL = 30 # How often to check heater and environment sensors (seconds)
 
     # Environment sensor chips with humidity
-    ENV_SENSOR_CHIPS = ["bme280", "htu21d", "sht3x", "lm75"]
+    ENV_SENSOR_CHIPS = ["bme280", "htu21d", "sht3x", "lm75", "aht10"]
 
     # Drying states (mostly relevant for per-gate heaters)
     DRYING_STATE_NONE      = ''


### PR DESCRIPTION
`aht10` is the name of humidity sensors implemented in aht10.py in Klipper and Kalico. AHT1X, AHT2X and AHT3X create objects with the `aht10` name prefix when used. This sensor is used in ViVid and Qidi Box MMUs.