### PR TITLE
Fix: Prevent early writing to save_variables to allow startup flexibility

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -264,7 +264,7 @@ class Mmu:
         self._last_tool = self._next_tool = self.TOOL_GATE_UNKNOWN
         self._next_gate = None
         self.toolchange_retract = 0.          # Set from mmu_macro_vars
-        self._can_write_variables = True
+        self._can_write_variables = False
         self.toolchange_purge_volume = 0.
         self.mmu_logger = None                # Setup on connect
         self._standalone_sync = False         # Used to indicate synced extruder intention whilst out of print
@@ -932,6 +932,8 @@ class Mmu:
                 m.handle_disconnect()
 
     def handle_ready(self):
+        self._can_write_variables = True
+
         # Pull retraction length from macro config
         sequence_vars_macro = self.printer.lookup_object("gcode_macro _MMU_SEQUENCE_VARS", None)
         if sequence_vars_macro:


### PR DESCRIPTION
It is possible that a write to "save_variables" is requested before klipper has fully started. This fix prevents that.