### PR TITLE
v4 ported - Defer MMU LED effect frame updates instead of rendering synchronously on enable/disable

### DIFF
--- a/extras/mmu_led_effect.py
+++ b/extras/mmu_led_effect.py
@@ -681,7 +681,8 @@ class _ledEffect:
         if self.enabled != state:
             self.enabled = state
             self.nextEventTime = self.handler.reactor.NOW
-            self.handler._getFrames(self.handler.reactor.NOW)
+            if hasattr(self.handler, "frameTimer") and self.handler.frameTimer is not None:
+                self.handler.reactor.update_timer(self.handler.frameTimer, self.handler.reactor.NOW)
     
     def reset_frame(self):
         for layer in self.layers:


### PR DESCRIPTION
### Description
This fixes an MMU LED transition issue where LEDs could fail during the automatic handoff from initialized to ready (ie on klipper restart), even though manual one-by-one SET_LED commands worked correctly. 

The failure was reproducible in a larger (8 lane) multi-MCU MMU topology with one MCU per lane and multiple LEDs attached to each MCU (5 LED's per MCU).

In that setup, the transition could escalate from LED update errors into an unhandled reactor RecursionError, followed by Klipper shutdown. The same underlying bug existed before, but it did not become visible in smaller or more centralized setups (ie one MCU handling one strip of LED's)

**Note that with 6 lanes the system was functional, addition of the 7th tripped it past the point where this was reproducible on every klipper restart.**

### Klipper Log
[klippy.log](https://github.com/user-attachments/files/26490592/klippy.log)

```
Unhandled exception during run
Traceback (most recent call last):
  File "/home/pi/klipper/klippy/klippy.py", line 177, in run
    self.reactor.run()
  File "/home/pi/klipper/klippy/reactor.py", line 329, in run
    g_next.switch()
  File "/home/pi/klipper/klippy/reactor.py", line 374, in _dispatch_loop
    timeout = self._check_timers(eventtime, busy)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/klipper/klippy/reactor.py", line 177, in _check_timers
    t.waketime = waketime = t.callback(eventtime)
                            ^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/klipper/klippy/reactor.py", line 51, in invoke
    self.reactor.unregister_timer(self.timer)
  File "/home/pi/klipper/klippy/reactor.py", line 151, in unregister_timer
    timers.pop(timers.index(timer_handler))
```

### Root cause
The root cause was that `_ledEffect.set_enabled()` forced an immediate frame render by calling `_getFrames()` synchronously every time an effect was enabled or disabled.

That is problematic because `_getFrames()` is the normal frame-processing path used by the handler to build LED frames and then immediately transmit all affected chains via `_transmit_chain()` which sets `need_transmit` and directly calls the helper transmit function.

At the same time, the MMU virtual LED chain layer also performs immediate transmit calls in `VirtualMmuLedChain.update_leds()`, again by setting `need_transmit` and calling the helper transmit routine directly.

This meant that effect transitions were not just updating state. They could synchronously enter the frame-processing path and trigger immediate LED transmits from more than one layer. In practice, a single automatic state transition could therefore create a tightly clustered burst of inline LED work instead of letting the existing frame timer process it in the normal scheduler-driven path. `_MMU_SET_LED_EFFECT` can also replace overlapping effects, which increases the amount of enable/disable activity during a transition.

**This appears to be topology-sensitive rather than purely LED-count-sensitive.** In a smaller setup, such as 5 lanes EMU, the same issue path could still exist, **but the amount of synchronous work during the initialized to ready handoff was lower**. There were fewer active lane-level segments, immediate transmits, and therefore opportunities for the synchronous set_enabled() path to collide with the normal timer-driven frame path.

**Similarly when the same overall LED load was centralized under a single MCU** (eg ERCF, EMU with all LED's daisy chained), the topology was simpler even if the total number of LEDs was high. There was still work to do, but it was not spreading that work out across as many independent MCU-owned endpoints. That reduces coordination pressure and makes the timing less fragile.

**In the failing setup, the LED effect code was operating across MMU units, segments, and per-gate effects,** while the MMU LED layer maps those virtual segments onto real chains and immediately transmits them. As more lanes and independent MCU-owned chains are added, the same synchronous effect-transition behavior becomes much easier to trip.

### Fix
Instead of calling `_getFrames()` synchronously from `set_enabled()`, this change wakes the existing frame timer and lets the normal reactor based frame update path process the change.

This removes the unsafe behavior of rendering and transmitting LED frames inline during effect enabling or disabling. Effect transitions are now schedule frame work instead of recursively performing it immediately.

### EMU config if relevant:
```
[neopixel mmu0_leds] # one block per lane (Lane 0)
pin: mmu0:MMU_NEOPIXEL
chain_count: 5			# four for the eject button and one for the box
color_order: GRBW		

[neopixel mmu1_leds] # one block per lane (Lane 1)
pin: mmu1:MMU_NEOPIXEL
chain_count: 5			# four for the eject button and one for the box
color_order: GRBW	

[neopixel mmu2_leds] # one block per lane (Lane 1)
pin: mmu2:MMU_NEOPIXEL
chain_count: 5			# four for the eject button and one for the box
color_order: GRBW	

[neopixel mmu3_leds] # one block per lane (Lane 1)
pin: mmu3:MMU_NEOPIXEL
chain_count: 5			# four for the eject button and one for the box
color_order: GRBW

[neopixel mmu4_leds] # one block per lane (Lane 1)
pin: mmu4:MMU_NEOPIXEL
chain_count: 5			# four for the eject button and one for the box
color_order: GRBW

[neopixel mmu5_leds] # one block per lane (Lane 1)
pin: mmu5:MMU_NEOPIXEL
chain_count: 5			# four for the eject button and one for the box
color_order: GRBW

[neopixel mmu6_leds] # one block per lane (Lane 1)
pin: mmu6:MMU_NEOPIXEL
chain_count: 5			# four for the eject button and one for the box
color_order: GRBW

[neopixel mmu7_leds] # one block per lane (Lane 1)
pin: mmu7:MMU_NEOPIXEL
chain_count: 5			# four for the eject button and one for the box
color_order: GRBW

# MMU LED EFFECT SEGMENTS ----------------------------------------------------------------------------------------------

[mmu_leds unit0]
exit_leds:
  neopixel:mmu0_leds (1,2,3,4) # add/remove lines to match number of lanes. LED 1-4 is for the button
  neopixel:mmu1_leds (1,2,3,4)
  neopixel:mmu2_leds (1,2,3,4)
  neopixel:mmu3_leds (1,2,3,4)
  neopixel:mmu4_leds (1,2,3,4)
  neopixel:mmu5_leds (1,2,3,4)
  neopixel:mmu6_leds (1,2,3,4)
  neopixel:mmu7_leds (1,2,3,4)
entry_leds:
  neopixel:mmu0_leds (5) # add/remove lines to match number of lanes. LED 5 is for the box
  neopixel:mmu1_leds (5)
  neopixel:mmu2_leds (5)
  neopixel:mmu3_leds (5)
  neopixel:mmu4_leds (5)
  neopixel:mmu5_leds (5)
  neopixel:mmu6_leds (5)
  neopixel:mmu7_leds (5)
frame_rate: 20

enabled: True                           # True = LEDs are enabled at startup (MMU_LED can control), False = Disabled
animation: True                         # True = Use led-animation-effects, False = Static LEDs
exit_effect: gate_status                #    off|gate_status|filament_color|slicer_color|r,g,b|_effect_
entry_effect: filament_color            #    off|gate_status|filament_color|slicer_color|r,g,b|_effect_
status_effect: off                      # on|off|gate_status|filament_color|slicer_color|r,g,b|_effect_
logo_effect: (0, 0, 0)                        #    off                                        |r,g,b|_effect_
white_light: (1, 1, 1)                  # RGB color for static white light
black_light: (1, 1, 1)                  # RGB color used to represent "black" (filament)
empty_light: (0.0, 0.0, 0.0)                  # RGB color used to represent empty gate
```