### PR TITLE
v4 ported - Utilise proportional sync sensor for senseless toolhead - extruder homing, bowden calibration, unload verification, filament position recovery.

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -6028,7 +6028,10 @@ class Mmu:
             detected = self.buzz_gear_motor()
             self.log_debug("Filament %s in encoder after buzzing gear motor" % ("detected" if detected else "not detected"))
         if detected is None:
-            self.log_debug("No sensors configured!")
+            if self.sensor_manager.has_sensor(self.SENSOR_PROPORTIONAL):
+                self.log_debug("No switch sensors or encoder available, will defer to proportional sensor")
+            else:
+                self.log_debug("No sensors configured!")
         return detected
 
     # Check for filament at currently selected gate

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -4859,7 +4859,7 @@ class Mmu:
     # threshold, confirming the extruder is actively pulling filament through.
     # Returns: total distance moved (mm) on success
     # Raises: MmuError if the sensor never drops below threshold
-    def _validate_extruder_entry_proportional(self):
+    def _validate_extruder_entry_proportional(self, max_steps=4):
         prop_sensor = self.sensor_manager.sensors.get(self.SENSOR_PROPORTIONAL)
         prop_threshold = self.proportional_extruder_threshold
         buffer_range = self.sync_feedback_manager.sync_feedback_buffer_maxrange
@@ -4874,7 +4874,6 @@ class Mmu:
 
         # Phase 2: Extruder-only steps to confirm grip by checking sensor drops below threshold
         step_size = buffer_range / 2.
-        max_steps = 4
         self.selector.filament_release()
         self.log_info("Proportional post-load validation: driving extruder-only in %.1fmm steps (up to %d) to confirm grip..." % (step_size, max_steps))
 
@@ -4987,7 +4986,9 @@ class Mmu:
                         raise MmuError("Failed to load filament passed the extruder entrance (sync-feedback buffer didn't detect neutral tension)")
 
             # Proportional sensor post-load validation: drive the extruder motor only to pull filament through then
-            # check the proportional sensor has dropped below the threshold, confirming extruder grip
+            # check the proportional sensor has dropped below the threshold, confirming extruder grip.
+            # Adaptive to available travel: always runs a synced grip-establishing feed, then fits as many
+            # extruder-only probe steps as the remaining load distance allows (up to a hard cap).
             elif (
                 self.gate_selected != self.TOOL_GATE_BYPASS
                 and self.toolhead_entry_tension_test
@@ -4996,12 +4997,21 @@ class Mmu:
                 and has_proportional
                 and self.extruder_homing_endstop == self.SENSOR_EXTRUDER_ENTRY_PROP
             ):
-                max_range = self.sync_feedback_manager.sync_feedback_buffer_maxrange * 2.5 # 0.5 synced grip + 4 * 0.5 extruder-only steps
-                if length > max_range:
-                    moved = self._validate_extruder_entry_proportional()
-                    length -= moved
+                buffer_range  = self.sync_feedback_manager.sync_feedback_buffer_maxrange
+                grip_distance = buffer_range * 0.50   # synced feed to establish extruder grip
+                step_size     = buffer_range / 2.     # extruder-only probe step
+                min_range     = grip_distance + step_size   # minimum budget for a meaningful validation (grip + 1 probe)
+                max_cap       = 4                     # hard cap on probe steps to avoid wasted travel when budget is large
+
+                if length >= min_range:
+                    max_steps = min(max_cap, int((length - grip_distance) // step_size))
+                    self.log_debug("Proportional post-load validation: grip %.1fmm + up to %d x %.1fmm probe step(s) (budget %.1fmm of %.1fmm available)"
+                                   % (grip_distance, max_steps, step_size, grip_distance + max_steps * step_size, length))
+                    moved = self._validate_extruder_entry_proportional(max_steps=max_steps)
+                    length = max(length - moved, 0)
                 else:
-                    self.log_info("Proportional post-load validation: skipped - remaining load distance (%.1fmm) is less than required validation move (%.1fmm)" % (length, max_range))
+                    self.log_info("Proportional post-load validation: skipped - remaining load distance (%.1fmm) is less than minimum validation move (%.1fmm = %.1fmm grip + %.1fmm probe)"
+                                  % (length, min_range, grip_distance, step_size))
 
             self.log_debug("Loading last %.1fmm to the nozzle..." % length)
             _,_,measured,delta = self.trace_filament_move("Loading filament to nozzle", length, speed=speed, motor=motor, wait=True)

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -429,6 +429,7 @@ class Mmu:
         self.gear_short_move_accel = config.getfloat('gear_short_move_accel', 400, minval=10.)
         self.gear_short_move_threshold = config.getfloat('gear_short_move_threshold', self.gate_homing_max, minval=1.)
         self.gear_homing_speed = config.getfloat('gear_homing_speed', 150, minval=1.)
+        self.proportional_homing_speed = config.getfloat('proportional_homing_speed', 10, minval=1.) # Dedicated speed for proportional sensor extruder homing
 
         self.extruder_load_speed = config.getfloat('extruder_load_speed', 15, minval=1.)
         self.extruder_unload_speed = config.getfloat('extruder_unload_speed', 15, minval=1.)
@@ -2608,6 +2609,7 @@ class Mmu:
         can_use_sensor = (
             self.extruder_homing_endstop in [
                 self.SENSOR_EXTRUDER_ENTRY,
+                self.SENSOR_EXTRUDER_ENTRY_PROP,
                 self.SENSOR_COMPRESSION,
                 self.SENSOR_GEAR_TOUCH
             ] and (
@@ -4772,11 +4774,14 @@ class Mmu:
             except Exception:
                 time.sleep(2.0)
 
-            self.log_debug("Homing to extruder '%s' virtual endstop, up to %.1fmm" % (self.extruder_homing_endstop, max_length))
-            actual,homed,measured,_ = self.trace_filament_move("Homing filament to extruder via proportional sensor", max_length, motor="gear", homing_move=1, endstop_name=self.SENSOR_EXTRUDER_ENTRY_PROP)
+            self.log_debug("Homing to extruder '%s' virtual endstop, up to %.1fmm at %.1fmm/s" % (self.extruder_homing_endstop, max_length, self.proportional_homing_speed))
+            actual,homed,measured,_ = self.trace_filament_move("Homing filament to extruder via proportional sensor", max_length, speed=self.proportional_homing_speed, motor="gear", homing_move=1, endstop_name=self.SENSOR_EXTRUDER_ENTRY_PROP)
             if homed:
                 self.log_debug("Extruder proportional endstop reached after %.1fmm (measured %.1fmm, sensor %.3f)" % (actual, measured, float(self.sync_feedback_manager._get_sensor_state())))
                 self._set_filament_pos_state(self.FILAMENT_POS_HOMED_ENTRY)
+
+                # Reduce calibrated length by buffer range to prevent overshooting into the buffer on subsequent loads
+                extra = -self.sync_feedback_manager.sync_feedback_buffer_range
 
             homing_movement = actual
 
@@ -7463,6 +7468,7 @@ class Mmu:
         self.gear_short_move_accel = gcmd.get_float('GEAR_SHORT_MOVE_ACCEL', self.gear_short_move_accel, minval=10.)
         self.gear_short_move_threshold = gcmd.get_float('GEAR_SHORT_MOVE_THRESHOLD', self.gear_short_move_threshold, minval=0.)
         self.gear_homing_speed = gcmd.get_float('GEAR_HOMING_SPEED', self.gear_homing_speed, above=1.)
+        self.proportional_homing_speed = gcmd.get_float('PROPORTIONAL_HOMING_SPEED', self.proportional_homing_speed, above=1.)
         self.extruder_homing_speed = gcmd.get_float('EXTRUDER_HOMING_SPEED', self.extruder_homing_speed, above=1.)
         self.extruder_load_speed = gcmd.get_float('EXTRUDER_LOAD_SPEED', self.extruder_load_speed, above=1.)
         self.extruder_unload_speed = gcmd.get_float('EXTRUDER_UNLOAD_SPEED', self.extruder_unload_speed, above=1.)
@@ -7635,6 +7641,7 @@ class Mmu:
             msg += "\ngear_short_move_accel = %.1f" % self.gear_short_move_accel
             msg += "\ngear_short_move_threshold = %.1f" % self.gear_short_move_threshold
             msg += "\ngear_homing_speed = %.1f" % self.gear_homing_speed
+            msg += "\nproportional_homing_speed = %.1f" % self.proportional_homing_speed
             msg += "\nextruder_homing_speed = %.1f" % self.extruder_homing_speed
             msg += "\nextruder_load_speed = %.1f" % self.extruder_load_speed
             msg += "\nextruder_unload_speed = %.1f" % self.extruder_unload_speed

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -4898,7 +4898,7 @@ class Mmu:
     def _validate_extruder_unload_proportional(self):
         prop_sensor = self.sensor_manager.sensors.get(self.SENSOR_PROPORTIONAL)
         buffer_range = self.sync_feedback_manager.sync_feedback_buffer_maxrange
-        probe_distance = buffer_range * 0.5
+        probe_distance = buffer_range # Tweak experimentally - set to buffer range to have a good "signal"
         settle_time = prop_sensor.report_time * 2 # Two full ADC cycles for a reliable reading
 
         pre_spin = prop_sensor.get_status(0).get('value', 0.)

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -112,6 +112,7 @@ class Mmu:
     SENSOR_EXTRUDER_NONE       = "none"           # Fake Extruder endstop aka don't attempt home
     SENSOR_EXTRUDER_COLLISION  = "collision"      # Fake Extruder endstop
     SENSOR_EXTRUDER_ENTRY      = "extruder"       # Extruder entry sensor
+    SENSOR_EXTRUDER_ENTRY_PROP = "proportional"   # Proportional sensor used to detect extruder entry
     SENSOR_GEAR_TOUCH          = "mmu_gear_touch" # Stallguard based detection
 
     SENSOR_COMPRESSION         = "filament_compression"  # Filament sync-feedback compression detection
@@ -125,7 +126,7 @@ class Mmu:
     SENSOR_SELECTOR_HOME       = "mmu_sel_home"   # For LinearSelector and LinearServoSelector
     SENSOR_PRE_GATE_PREFIX     = "mmu_pre_gate"
 
-    EXTRUDER_ENDSTOPS = [SENSOR_EXTRUDER_COLLISION, SENSOR_GEAR_TOUCH, SENSOR_EXTRUDER_ENTRY, SENSOR_EXTRUDER_NONE, SENSOR_COMPRESSION]
+    EXTRUDER_ENDSTOPS = [SENSOR_EXTRUDER_COLLISION, SENSOR_GEAR_TOUCH, SENSOR_EXTRUDER_ENTRY, SENSOR_EXTRUDER_ENTRY_PROP, SENSOR_EXTRUDER_NONE, SENSOR_COMPRESSION]
     GATE_ENDSTOPS     = [SENSOR_GATE, SENSOR_ENCODER, SENSOR_GEAR_PREFIX, SENSOR_EXTRUDER_ENTRY]
 
     # Statistics output types
@@ -4759,6 +4760,55 @@ class Mmu:
                 homing_movement = actual
             else:
                 raise MmuError("Cannot home to extruder using 'collision' method because encoder is not configured or disabled!")
+
+        elif self.extruder_homing_endstop == self.SENSOR_EXTRUDER_ENTRY_PROP:
+            has_proportional = self.sensor_manager.has_sensor(self.SENSOR_PROPORTIONAL)
+            if not has_proportional:
+                raise MmuError("Cannot home to extruder using 'proportional' method because proportional sync feedback sensor is not configured!")
+
+            actual = 0.
+            homed = False
+            per_side_range = float(self.sync_feedback_manager.sync_feedback_buffer_range) / 2.0
+
+            self.log_debug("Proportional sensor extruder homing: Pausing for 2 seconds to allow bowden to settle")
+            try:
+                self.reactor.pause(self.reactor.monotonic() + 2.0)
+            except Exception:
+                time.sleep(2.0)
+
+            self.log_debug("Homing to extruder '%s' endstop, up to %.1fmm with proportional steps" % (
+                self.extruder_homing_endstop, max_length))
+
+            while actual < max_length:
+                prop_state = float(self.sync_feedback_manager._get_sensor_state())
+                if prop_state >= 0.9:
+                    homed = True
+                    break
+
+                remaining_ratio = (0.9 - prop_state) / 0.9
+                move = per_side_range * remaining_ratio
+
+                if move < 1.0:
+                    move = 1.0
+
+                move = min(move, max_length - actual)
+
+                self.log_debug("Proportional homing: sensor=%.3f, move=%.2fmm" % (prop_state, move))
+
+                _, _, measured, _ = self.trace_filament_move(
+                    "Homing filament to extruder proportional threshold",
+                    move,
+                    motor="gear",
+                    wait=True
+                )
+                actual += move
+
+            if homed:
+                self.log_debug("Extruder proportional threshold reached after %.1fmm (sensor %.3f)" % (
+                    actual, float(self.sync_feedback_manager._get_sensor_state())))
+                self._set_filament_pos_state(self.FILAMENT_POS_HOMED_ENTRY)
+
+            homing_movement = actual
 
         else:
             self.log_debug("Homing to extruder '%s' endstop, up to %.1fmm" % (self.extruder_homing_endstop, max_length))

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -5947,6 +5947,15 @@ class Mmu:
         looks_loaded = self.sensor_manager.check_all_sensors_in_path()
         if not filament_detected:
             filament_detected = self.check_filament_in_mmu() # Include encoder detection method
+        if not filament_detected and self.sensor_manager.has_sensor(self.SENSOR_PROPORTIONAL):
+            # Proportional sensor is not in the standard sensor path list but can indicate filament
+            # presence. If the sensor is not in deep tension, filament is likely present and interacting
+            # with something (extruder entrance or grip)
+            prop_sensor = self.sensor_manager.sensors.get(self.SENSOR_PROPORTIONAL)
+            prop_value = prop_sensor.get_status(0).get('value', 0.)
+            if prop_value > -0.9:
+                filament_detected = True
+                self.log_info("Proportional sensor (%.3f) indicates filament present" % prop_value)
 
         # Definitely loaded
         if ts:
@@ -5954,7 +5963,16 @@ class Mmu:
 
         # Probably loaded: Unless strict we will continue to assume loaded in the absence of sensors to say otherwise
         elif not strict and self.filament_pos == self.FILAMENT_POS_LOADED and looks_loaded:
-            pass
+            # Without toolhead or physical extruder entry sensor, "looks_loaded" is based only on the
+            # gate sensor which cannot distinguish "in bowden" from "fully loaded". If proportional
+            # sensor is available and extruder can be heated, use it to verify extruder grip
+            if can_heat and ts is None and es is None and self.sensor_manager.has_sensor(self.SENSOR_PROPORTIONAL):
+                prop_result = self.check_filament_in_extruder_by_proportional()
+                if prop_result is True:
+                    self.log_info("Proportional sensor confirms extruder grip - filament loaded")
+                elif prop_result is False:
+                    self.log_info("Proportional sensor indicates no extruder grip - filament may not be fully loaded")
+                    self._set_filament_pos_state(self.FILAMENT_POS_IN_BOWDEN, silent=silent)
 
         # Somewhere in extruder
         elif filament_detected and can_heat and self.check_filament_in_extruder(): # Encoder based
@@ -5965,8 +5983,11 @@ class Mmu:
             self._set_filament_pos_state(self.FILAMENT_POS_IN_EXTRUDER, silent=silent) # Will start from tip forming
 
         # Proportional sensor based extruder grip detection (centre + retract test)
-        elif filament_detected and can_heat and self.sensor_manager.has_sensor(self.SENSOR_PROPORTIONAL) and self.check_filament_in_extruder_by_proportional():
-            self._set_filament_pos_state(self.FILAMENT_POS_IN_EXTRUDER, silent=silent) # Will start from tip forming on unload
+        # Gate on (filament_detected or gs) because filament_detected may be None when gate_selected
+        # is unknown (sensors in path can't be evaluated) but the gate sensor can still independently
+        # confirm filament presence. The two-phase test handles gear engagement internally.
+        elif (filament_detected or gs) and can_heat and self.sensor_manager.has_sensor(self.SENSOR_PROPORTIONAL) and self.check_filament_in_extruder_by_proportional():
+            self._set_filament_pos_state(self.FILAMENT_POS_LOADED, silent=silent)
 
         # At extruder entry
         elif es:
@@ -6075,8 +6096,9 @@ class Mmu:
     #     - Any other outcome (centred or partially moved) → filament is near the extruder but we
     #       cannot distinguish "at entry, not gripped" from "gripped and loaded" because both present
     #       a rigid wall for the gear motor to work against → proceed to phase 2
-    #   Phase 2: Small extruder-only retract proportional to the current sensor reading.
-    #     - If sensor shifts toward tension → extruder has grip → loaded
+    #   Phase 2: Small extruder-only retract to check for sensor response.
+    #     - If sensor shifts toward compression → extruder has grip (retract pushes filament back
+    #       into bowden, compressing the buffer) → loaded
     #     - If sensor unchanged → extruder has no grip → at entry but not gripped
     # Requires hot extruder for phase 2 to avoid grinding cold filament.
     # Returns True if extruder grip detected, False if not, None if test not possible
@@ -6098,7 +6120,7 @@ class Mmu:
         # but could be either at the entry or gripped — both present a rigid anchor for the gear motor.
         self.log_info("Proportional recovery phase 1: attempting to centre sensor...")
         self.selector.filament_drive()
-        _, success = self.sync_feedback_manager.adjust_filament_tension()
+        _, success = self.sync_feedback_manager.adjust_filament_tension(max_move=2*buffer_range)
         post_adjust = prop_sensor.get_status(0).get('value', 0.)
 
         if not success and post_adjust <= -0.9:
@@ -6108,23 +6130,23 @@ class Mmu:
 
         # Phase 2: Extruder-only retract to distinguish "at entry" from "gripped"
         # Retract distance proportional to current sensor reading to avoid oversized moves
-        self.log_info("Proportional recovery phase 2: extruder-only retract test (sensor=%.3f)..." % post_adjust)
         self._ensure_safe_extruder_temperature(wait=True)
 
-        # Scale retract: if sensor reads 0.5, retract 50% of buffer range
-        retract_proportion = max(abs(post_adjust), 0.1) # At least 10% to get a meaningful test
-        retract_distance = retract_proportion * buffer_range
+        # When the extruder retracts with grip, filament is pushed back into the bowden
+        # compressing the buffer — the sensor shifts toward compression (more positive).
+        retract_distance = buffer_range
         pre_retract = prop_sensor.get_status(0).get('value', 0.)
 
+        self.log_info("Proportional recovery phase 2: extruder-only retract test of %.1fmm (sensor=%.3f, buffer_range=%.1f)..." % (retract_distance, post_adjust, buffer_range))
         self.trace_filament_move("Proportional recovery: extruder retract test", -retract_distance, speed=self.extruder_unload_speed, motor="extruder", wait=True)
         self.movequeues_dwell(settle_time)
         post_retract = prop_sensor.get_status(0).get('value', 0.)
 
-        shift = pre_retract - post_retract # Positive means sensor moved toward tension
-        detected = shift > 0.1 # Any meaningful shift toward tension confirms extruder grip
+        shift = post_retract - pre_retract # Positive means sensor moved toward compression
+        detected = shift > 0.1 # Shift toward compression confirms extruder grip
 
-        self.log_info("Proportional recovery: pre_retract=%.3f, post_retract=%.3f, shift=%.3f - filament %s in extruder"
-                      % (pre_retract, post_retract, shift, "detected" if detected else "not detected"))
+        self.log_info("Proportional recovery: retracted %.1fmm, pre=%.3f, post=%.3f, shift=%.3f - filament %s loaded"
+                      % (retract_distance, pre_retract, post_retract, shift, "confirmed" if detected else "not"))
 
         # Return filament to original position if extruder had grip
         if detected:

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -4858,7 +4858,7 @@ class Mmu:
         buffer_range = self.sync_feedback_manager.sync_feedback_buffer_maxrange
 
         # Phase 1: Short synced move to feed filament into extruder gears and establish grip
-        grip_distance = buffer_range * 0.25
+        grip_distance = buffer_range * 0.50
         initial_state = prop_sensor.get_status(0).get('value', 0.)
         self.log_debug("Proportional post-load validation: sensor=%.3f, synced feed of %.1fmm to establish extruder grip..." % (initial_state, grip_distance))
         self.selector.filament_drive()
@@ -4962,7 +4962,7 @@ class Mmu:
                 and has_proportional
                 and self.extruder_homing_endstop == self.SENSOR_EXTRUDER_ENTRY_PROP
             ):
-                max_range = self.sync_feedback_manager.sync_feedback_buffer_maxrange * 2
+                max_range = self.sync_feedback_manager.sync_feedback_buffer_maxrange * 2.5 # 0.5 synced grip + 4 * 0.5 extruder-only steps
                 if length > max_range:
                     moved = self._validate_extruder_entry_proportional()
                     length -= moved

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -4846,20 +4846,31 @@ class Mmu:
         return step*i, homed, measured, delta
 
     # Validate that the extruder has gripped the filament after homing using the proportional sensor.
-    # Drives extruder motor only in incremental steps and checks the sensor drops below the trigger threshold,
-    # confirming the extruder is actively pulling filament through.
-    # Returns: distance moved (mm) on success
+    # First performs a short synced move (gear+extruder) to feed filament into the extruder gears and
+    # establish grip, since the extruder cannot grab filament on its own with the gear stepper off.
+    # Then drives extruder motor only in incremental steps and checks the sensor drops below the trigger
+    # threshold, confirming the extruder is actively pulling filament through.
+    # Returns: total distance moved (mm) on success
     # Raises: MmuError if the sensor never drops below threshold
     def _validate_extruder_entry_proportional(self):
         prop_sensor = self.sensor_manager.sensors.get(self.SENSOR_PROPORTIONAL)
         prop_threshold = self.proportional_extruder_threshold
+        buffer_range = self.sync_feedback_manager.sync_feedback_buffer_maxrange
 
-        step_size = self.sync_feedback_manager.sync_feedback_buffer_maxrange / 2.
-        max_steps = 4
+        # Phase 1: Short synced move to feed filament into extruder gears and establish grip
+        grip_distance = buffer_range * 0.25
         initial_state = prop_sensor.get_status(0).get('value', 0.)
-        self.log_debug("Proportional post-load validation: sensor=%.3f, driving extruder in %.1fmm steps (up to %d) to confirm entry..." % (initial_state, step_size, max_steps))
+        self.log_debug("Proportional post-load validation: sensor=%.3f, synced feed of %.1fmm to establish extruder grip..." % (initial_state, grip_distance))
+        self.selector.filament_drive()
+        self.trace_filament_move("Synced feed to establish extruder grip", grip_distance, speed=self.extruder_sync_load_speed, motor="gear+extruder", wait=True)
+        moved = grip_distance
 
-        moved = 0.
+        # Phase 2: Extruder-only steps to confirm grip by checking sensor drops below threshold
+        step_size = buffer_range / 2.
+        max_steps = 4
+        self.selector.filament_release()
+        self.log_debug("Proportional post-load validation: driving extruder-only in %.1fmm steps (up to %d) to confirm grip..." % (step_size, max_steps))
+
         for i in range(max_steps):
             self.trace_filament_move("Proportional extruder entry validation step %d" % (i + 1), step_size, speed=self.extruder_load_speed, motor="extruder", wait=True)
             moved += step_size

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -4766,46 +4766,16 @@ class Mmu:
             if not has_proportional:
                 raise MmuError("Cannot home to extruder using 'proportional' method because proportional sync feedback sensor is not configured!")
 
-            actual = 0.
-            homed = False
-            per_side_range = float(self.sync_feedback_manager.sync_feedback_buffer_range) / 2.0
-
             self.log_debug("Proportional sensor extruder homing: Pausing for 2 seconds to allow bowden to settle")
             try:
                 self.reactor.pause(self.reactor.monotonic() + 2.0)
             except Exception:
                 time.sleep(2.0)
 
-            self.log_debug("Homing to extruder '%s' endstop, up to %.1fmm with proportional steps" % (
-                self.extruder_homing_endstop, max_length))
-
-            while actual < max_length:
-                prop_state = float(self.sync_feedback_manager._get_sensor_state())
-                if prop_state >= 0.9:
-                    homed = True
-                    break
-
-                remaining_ratio = (0.9 - prop_state) / 0.9
-                move = per_side_range * remaining_ratio
-
-                if move < 1.0:
-                    move = 1.0
-
-                move = min(move, max_length - actual)
-
-                self.log_debug("Proportional homing: sensor=%.3f, move=%.2fmm" % (prop_state, move))
-
-                _, _, measured, _ = self.trace_filament_move(
-                    "Homing filament to extruder proportional threshold",
-                    move,
-                    motor="gear",
-                    wait=True
-                )
-                actual += move
-
+            self.log_debug("Homing to extruder '%s' virtual endstop, up to %.1fmm" % (self.extruder_homing_endstop, max_length))
+            actual,homed,measured,_ = self.trace_filament_move("Homing filament to extruder via proportional sensor", max_length, motor="gear", homing_move=1, endstop_name=self.SENSOR_EXTRUDER_ENTRY_PROP)
             if homed:
-                self.log_debug("Extruder proportional threshold reached after %.1fmm (sensor %.3f)" % (
-                    actual, float(self.sync_feedback_manager._get_sensor_state())))
+                self.log_debug("Extruder proportional endstop reached after %.1fmm (measured %.1fmm, sensor %.3f)" % (actual, measured, float(self.sync_feedback_manager._get_sensor_state())))
                 self._set_filament_pos_state(self.FILAMENT_POS_HOMED_ENTRY)
 
             homing_movement = actual

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -4776,16 +4776,16 @@ class Mmu:
             if not has_proportional:
                 raise MmuError("Cannot home to extruder using 'proportional' method because proportional sync feedback sensor is not configured!")
 
-            self.log_debug("Proportional sensor extruder homing: Pausing for 2 seconds to allow bowden to settle")
+            self.log_info("Proportional sensor extruder homing: Pausing for 2 seconds to allow bowden to settle")
             try:
                 self.reactor.pause(self.reactor.monotonic() + 2.0)
             except Exception:
                 time.sleep(2.0)
 
-            self.log_debug("Homing to extruder '%s' virtual endstop, up to %.1fmm at %.1fmm/s" % (self.extruder_homing_endstop, max_length, self.proportional_homing_speed))
+            self.log_info("Homing to extruder '%s' virtual endstop, up to %.1fmm at %.1fmm/s" % (self.extruder_homing_endstop, max_length, self.proportional_homing_speed))
             actual,homed,measured,_ = self.trace_filament_move("Homing filament to extruder via proportional sensor", max_length, speed=self.proportional_homing_speed, motor="gear", homing_move=1, endstop_name=self.SENSOR_EXTRUDER_ENTRY_PROP)
             if homed:
-                self.log_debug("Extruder proportional endstop reached after %.1fmm (measured %.1fmm, sensor %.3f)" % (actual, measured, float(self.sync_feedback_manager._get_sensor_state())))
+                self.log_info("Extruder proportional endstop reached after %.1fmm (measured %.1fmm, sensor %.3f)" % (actual, measured, float(self.sync_feedback_manager._get_sensor_state())))
                 self._set_filament_pos_state(self.FILAMENT_POS_HOMED_ENTRY)
 
                 # Reduce calibrated length by buffer range to prevent overshooting into the buffer on subsequent loads
@@ -4867,7 +4867,7 @@ class Mmu:
         # Phase 1: Short synced move to feed filament into extruder gears and establish grip
         grip_distance = buffer_range * 0.50
         initial_state = prop_sensor.get_status(0).get('value', 0.)
-        self.log_debug("Proportional post-load validation: sensor=%.3f, synced feed of %.1fmm to establish extruder grip..." % (initial_state, grip_distance))
+        self.log_info("Proportional post-load validation: sensor=%.3f, synced feed of %.1fmm to establish extruder grip..." % (initial_state, grip_distance))
         self.selector.filament_drive()
         self.trace_filament_move("Synced feed to establish extruder grip", grip_distance, speed=self.extruder_sync_load_speed, motor="gear+extruder", wait=True)
         moved = grip_distance
@@ -4876,19 +4876,46 @@ class Mmu:
         step_size = buffer_range / 2.
         max_steps = 4
         self.selector.filament_release()
-        self.log_debug("Proportional post-load validation: driving extruder-only in %.1fmm steps (up to %d) to confirm grip..." % (step_size, max_steps))
+        self.log_info("Proportional post-load validation: driving extruder-only in %.1fmm steps (up to %d) to confirm grip..." % (step_size, max_steps))
 
         for i in range(max_steps):
             self.trace_filament_move("Proportional extruder entry validation step %d" % (i + 1), step_size, speed=self.extruder_load_speed, motor="extruder", wait=True)
             moved += step_size
             prop_state = prop_sensor.get_status(0).get('value', 0.)
             if prop_state < prop_threshold:
-                self.log_debug("Proportional post-load validation: sensor dropped to %.3f after %.1fmm (step %d) - extruder entry confirmed" % (prop_state, moved, i + 1))
+                self.log_info("Proportional post-load validation: sensor dropped to %.3f after %.1fmm (step %d) - extruder entry confirmed" % (prop_state, moved, i + 1))
                 return moved
         else:
             prop_state = prop_sensor.get_status(0).get('value', 0.)
             self._set_filament_pos_state(self.FILAMENT_POS_EXTRUDER_ENTRY)
             raise MmuError("Failed to load filament past the extruder entrance (proportional sensor reads %.3f after %.1fmm, expected below %.2f)" % (prop_state, moved, prop_threshold))
+
+    # Validate that the extruder has released the filament after unloading using the proportional sensor.
+    # Spins the extruder forward by a small amount and checks the sensor reading doesn't change. If the
+    # filament has cleared, the extruder gears spin freely and the sensor is unaffected. If the extruder
+    # still grips the filament (which will be in tension from the gear pulling back during unload), the
+    # forward spin relieves that tension causing a measurable shift toward compression.
+    def _validate_extruder_unload_proportional(self):
+        prop_sensor = self.sensor_manager.sensors.get(self.SENSOR_PROPORTIONAL)
+        buffer_range = self.sync_feedback_manager.sync_feedback_buffer_maxrange
+        probe_distance = buffer_range * 0.5
+        settle_time = prop_sensor.report_time * 2 # Two full ADC cycles for a reliable reading
+
+        pre_spin = prop_sensor.get_status(0).get('value', 0.)
+        self.log_info("Proportional unload validation: sensor=%.3f, spinning extruder forward %.1fmm to verify filament released..." % (pre_spin, probe_distance))
+
+        self.trace_filament_move("Proportional unload validation: extruder forward spin", probe_distance, speed=self.extruder_load_speed, motor="extruder", wait=True)
+        self.movequeues_dwell(settle_time)
+        post_spin = prop_sensor.get_status(0).get('value', 0.)
+
+        shift = post_spin - pre_spin # Positive means sensor moved toward compression
+        self.log_info("Proportional unload validation: pre=%.3f, post=%.3f, shift=%.3f" % (pre_spin, post_spin, shift))
+
+        if shift > 0.1:
+            # Sensor shifted toward compression — extruder still has grip, filament not released
+            self.log_warning("Warning: Proportional unload validation failed - extruder may still be gripping filament (sensor shifted %.3f toward compression)\nWill attempt to continue..." % shift)
+        else:
+            self.log_info("Proportional unload validation: confirmed - extruder released filament")
 
     # Move filament from the extruder gears (entrance) to the nozzle
     # Returns any homing distance for automatic calibration logic
@@ -5134,6 +5161,20 @@ class Mmu:
                         self.log_warning("Warning: Encoder not sensing %s movement during final extruder retraction move\nConcluding filament either stuck in the extruder, tip forming erroneously completely ejected filament or filament was not fully loaded\nWill attempt to continue..." % msg)
 
                 self._set_filament_pos_state(self.FILAMENT_POS_END_BOWDEN)
+
+                # Proportional sensor unload validation: spin extruder forward and check sensor doesn't change.
+                # After unload, if the extruder still grips the filament the sensor will be in tension (gear pulled
+                # back against extruder grip). A forward extruder spin would relieve that tension causing the sensor
+                # to shift toward compression. If the filament has cleared, the extruder spins freely and the sensor
+                # reading is unchanged.
+                if (
+                    validate
+                    and self.sensor_manager.has_sensor(self.SENSOR_PROPORTIONAL)
+                    and self.extruder_homing_endstop == self.SENSOR_EXTRUDER_ENTRY_PROP
+                    and not extruder_only
+                    and self.gate_selected != self.TOOL_GATE_BYPASS
+                ):
+                    self._validate_extruder_unload_proportional()
 
             self._random_failure() # Testing
             self.movequeues_wait()
@@ -5923,6 +5964,10 @@ class Mmu:
             # even though TS doesn't see it. It's a pedantic option so on turned on by strict flag
             self._set_filament_pos_state(self.FILAMENT_POS_IN_EXTRUDER, silent=silent) # Will start from tip forming
 
+        # Proportional sensor based extruder grip detection (centre + retract test)
+        elif filament_detected and can_heat and self.sensor_manager.has_sensor(self.SENSOR_PROPORTIONAL) and self.check_filament_in_extruder_by_proportional():
+            self._set_filament_pos_state(self.FILAMENT_POS_IN_EXTRUDER, silent=silent) # Will start from tip forming on unload
+
         # At extruder entry
         elif es:
             self._set_filament_pos_state(self.FILAMENT_POS_HOMED_ENTRY, silent=silent) # Allows for fast bowden unload move
@@ -6022,6 +6067,70 @@ class Mmu:
                 detected = measured > self.encoder_min
                 self.log_debug("Filament %s in extruder" % ("detected" if detected else "not detected"))
         return detected, measured
+
+    # Check if filament is gripped by the extruder using the proportional sync feedback sensor.
+    # Uses a two-phase approach:
+    #   Phase 1: Attempt to centre the sensor using adjust_filament_tension (gear-only moves).
+    #     - If centering fails and sensor remains in deep tension (>90%) → filament is free in bowden
+    #     - Any other outcome (centred or partially moved) → filament is near the extruder but we
+    #       cannot distinguish "at entry, not gripped" from "gripped and loaded" because both present
+    #       a rigid wall for the gear motor to work against → proceed to phase 2
+    #   Phase 2: Small extruder-only retract proportional to the current sensor reading.
+    #     - If sensor shifts toward tension → extruder has grip → loaded
+    #     - If sensor unchanged → extruder has no grip → at entry but not gripped
+    # Requires hot extruder for phase 2 to avoid grinding cold filament.
+    # Returns True if extruder grip detected, False if not, None if test not possible
+    def check_filament_in_extruder_by_proportional(self):
+        if not self.sensor_manager.has_sensor(self.SENSOR_PROPORTIONAL):
+            return None
+
+        prop_sensor = self.sensor_manager.sensors.get(self.SENSOR_PROPORTIONAL)
+        buffer_range = self.sync_feedback_manager.sync_feedback_buffer_maxrange
+        settle_time = prop_sensor.report_time * 2 # Two full ADC cycles for a reliable reading
+
+        # Read baseline before any movement
+        baseline = prop_sensor.get_status(0).get('value', 0.)
+        self.log_info("Checking for filament in extruder using proportional sensor (baseline=%.3f)..." % baseline)
+
+        # Phase 1: Try to centre the sensor using gear-only tension adjustment.
+        # This can only definitively tell us if the filament is free in the bowden (deep tension
+        # after attempt). Centering success or partial movement means filament is near the extruder
+        # but could be either at the entry or gripped — both present a rigid anchor for the gear motor.
+        self.log_info("Proportional recovery phase 1: attempting to centre sensor...")
+        self.selector.filament_drive()
+        _, success = self.sync_feedback_manager.adjust_filament_tension()
+        post_adjust = prop_sensor.get_status(0).get('value', 0.)
+
+        if not success and post_adjust <= -0.9:
+            # Deep tension after adjustment attempt — nothing to compress against, filament is free
+            self.log_info("Proportional recovery: sensor still in deep tension (%.3f) after centering attempt - filament free in bowden" % post_adjust)
+            return False
+
+        # Phase 2: Extruder-only retract to distinguish "at entry" from "gripped"
+        # Retract distance proportional to current sensor reading to avoid oversized moves
+        self.log_info("Proportional recovery phase 2: extruder-only retract test (sensor=%.3f)..." % post_adjust)
+        self._ensure_safe_extruder_temperature(wait=True)
+
+        # Scale retract: if sensor reads 0.5, retract 50% of buffer range
+        retract_proportion = max(abs(post_adjust), 0.1) # At least 10% to get a meaningful test
+        retract_distance = retract_proportion * buffer_range
+        pre_retract = prop_sensor.get_status(0).get('value', 0.)
+
+        self.trace_filament_move("Proportional recovery: extruder retract test", -retract_distance, speed=self.extruder_unload_speed, motor="extruder", wait=True)
+        self.movequeues_dwell(settle_time)
+        post_retract = prop_sensor.get_status(0).get('value', 0.)
+
+        shift = pre_retract - post_retract # Positive means sensor moved toward tension
+        detected = shift > 0.1 # Any meaningful shift toward tension confirms extruder grip
+
+        self.log_info("Proportional recovery: pre_retract=%.3f, post_retract=%.3f, shift=%.3f - filament %s in extruder"
+                      % (pre_retract, post_retract, shift, "detected" if detected else "not detected"))
+
+        # Return filament to original position if extruder had grip
+        if detected:
+            self.trace_filament_move("Proportional recovery: re-feed after retract test", retract_distance, speed=self.extruder_load_speed, motor="extruder", wait=True)
+
+        return detected
 
     def buzz_gear_motor(self):
         if self.has_encoder():

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -4682,6 +4682,13 @@ class Mmu:
         # Shorten move by gate buffer used to ensure we don't overshoot homing point
         length -= self.gate_unload_buffer
 
+        # When using virtual endstops (proportional or compression) without a physical extruder/toolhead
+        # sensor, the extruder unload adds toolhead_unload_safety_margin to the blind move which
+        # overshoots the bowden start. Compensate here to prevent the bowden unload from overshooting
+        if self.extruder_homing_endstop in [self.SENSOR_EXTRUDER_ENTRY_PROP, self.SENSOR_COMPRESSION]:
+            if not self.sensor_manager.has_sensor(self.SENSOR_EXTRUDER_ENTRY) and not self.sensor_manager.has_sensor(self.SENSOR_TOOLHEAD):
+                length -= self.toolhead_unload_safety_margin
+
         try:
             if length > 0:
                 self.log_debug("Unloading bowden tube")

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -430,6 +430,7 @@ class Mmu:
         self.gear_short_move_threshold = config.getfloat('gear_short_move_threshold', self.gate_homing_max, minval=1.)
         self.gear_homing_speed = config.getfloat('gear_homing_speed', 150, minval=1.)
         self.proportional_homing_speed = config.getfloat('proportional_homing_speed', 10, minval=1.) # Dedicated speed for proportional sensor extruder homing
+        self.proportional_extruder_threshold = config.getfloat('proportional_extruder_threshold', 0.9, minval=0.1, maxval=1.0) # Threshold for proportional sensor extruder entry detection
 
         self.extruder_load_speed = config.getfloat('extruder_load_speed', 15, minval=1.)
         self.extruder_unload_speed = config.getfloat('extruder_unload_speed', 15, minval=1.)
@@ -4844,6 +4845,33 @@ class Mmu:
         self._set_filament_position(self._get_filament_position() - step) # Ignore last step movement
         return step*i, homed, measured, delta
 
+    # Validate that the extruder has gripped the filament after homing using the proportional sensor.
+    # Drives extruder motor only in incremental steps and checks the sensor drops below the trigger threshold,
+    # confirming the extruder is actively pulling filament through.
+    # Returns: distance moved (mm) on success
+    # Raises: MmuError if the sensor never drops below threshold
+    def _validate_extruder_entry_proportional(self):
+        prop_sensor = self.sensor_manager.sensors.get(self.SENSOR_PROPORTIONAL)
+        prop_threshold = self.proportional_extruder_threshold
+
+        step_size = self.sync_feedback_manager.sync_feedback_buffer_maxrange / 2.
+        max_steps = 4
+        initial_state = prop_sensor.get_status(0).get('value', 0.)
+        self.log_debug("Proportional post-load validation: sensor=%.3f, driving extruder in %.1fmm steps (up to %d) to confirm entry..." % (initial_state, step_size, max_steps))
+
+        moved = 0.
+        for i in range(max_steps):
+            self.trace_filament_move("Proportional extruder entry validation step %d" % (i + 1), step_size, speed=self.extruder_load_speed, motor="extruder", wait=True)
+            moved += step_size
+            prop_state = prop_sensor.get_status(0).get('value', 0.)
+            if prop_state < prop_threshold:
+                self.log_debug("Proportional post-load validation: sensor dropped to %.3f after %.1fmm (step %d) - extruder entry confirmed" % (prop_state, moved, i + 1))
+                return moved
+        else:
+            prop_state = prop_sensor.get_status(0).get('value', 0.)
+            self._set_filament_pos_state(self.FILAMENT_POS_EXTRUDER_ENTRY)
+            raise MmuError("Failed to load filament past the extruder entrance (proportional sensor reads %.3f after %.1fmm, expected below %.2f)" % (prop_state, moved, prop_threshold))
+
     # Move filament from the extruder gears (entrance) to the nozzle
     # Returns any homing distance for automatic calibration logic
     def _load_extruder(self, extruder_only=False):
@@ -4912,6 +4940,23 @@ class Mmu:
                     else:
                         self._set_filament_pos_state(self.FILAMENT_POS_EXTRUDER_ENTRY) # But could also still be POS_IN_BOWDEN!
                         raise MmuError("Failed to load filament passed the extruder entrance (sync-feedback buffer didn't detect neutral tension)")
+
+            # Proportional sensor post-load validation: drive the extruder motor only to pull filament through then
+            # check the proportional sensor has dropped below the threshold, confirming extruder grip
+            elif (
+                self.gate_selected != self.TOOL_GATE_BYPASS
+                and self.toolhead_entry_tension_test
+                and synced
+                and not has_toolhead
+                and has_proportional
+                and self.extruder_homing_endstop == self.SENSOR_EXTRUDER_ENTRY_PROP
+            ):
+                max_range = self.sync_feedback_manager.sync_feedback_buffer_maxrange * 2
+                if length > max_range:
+                    moved = self._validate_extruder_entry_proportional()
+                    length -= moved
+                else:
+                    self.log_info("Proportional post-load validation: skipped - remaining load distance (%.1fmm) is less than required validation move (%.1fmm)" % (length, max_range))
 
             self.log_debug("Loading last %.1fmm to the nozzle..." % length)
             _,_,measured,delta = self.trace_filament_move("Loading filament to nozzle", length, speed=speed, motor=motor, wait=True)
@@ -7469,6 +7514,12 @@ class Mmu:
         self.gear_short_move_threshold = gcmd.get_float('GEAR_SHORT_MOVE_THRESHOLD', self.gear_short_move_threshold, minval=0.)
         self.gear_homing_speed = gcmd.get_float('GEAR_HOMING_SPEED', self.gear_homing_speed, above=1.)
         self.proportional_homing_speed = gcmd.get_float('PROPORTIONAL_HOMING_SPEED', self.proportional_homing_speed, above=1.)
+        prev_threshold = self.proportional_extruder_threshold
+        self.proportional_extruder_threshold = gcmd.get_float('PROPORTIONAL_EXTRUDER_THRESHOLD', self.proportional_extruder_threshold, minval=0.1, maxval=1.0)
+        if self.proportional_extruder_threshold != prev_threshold:
+            prop_endstop = self.sensor_manager.sensors.get(self.SENSOR_EXTRUDER_ENTRY_PROP, None)
+            if prop_endstop is not None:
+                prop_endstop._threshold = self.proportional_extruder_threshold
         self.extruder_homing_speed = gcmd.get_float('EXTRUDER_HOMING_SPEED', self.extruder_homing_speed, above=1.)
         self.extruder_load_speed = gcmd.get_float('EXTRUDER_LOAD_SPEED', self.extruder_load_speed, above=1.)
         self.extruder_unload_speed = gcmd.get_float('EXTRUDER_UNLOAD_SPEED', self.extruder_unload_speed, above=1.)
@@ -7642,6 +7693,7 @@ class Mmu:
             msg += "\ngear_short_move_threshold = %.1f" % self.gear_short_move_threshold
             msg += "\ngear_homing_speed = %.1f" % self.gear_homing_speed
             msg += "\nproportional_homing_speed = %.1f" % self.proportional_homing_speed
+            msg += "\nproportional_extruder_threshold = %.2f" % self.proportional_extruder_threshold
             msg += "\nextruder_homing_speed = %.1f" % self.extruder_homing_speed
             msg += "\nextruder_load_speed = %.1f" % self.extruder_load_speed
             msg += "\nextruder_unload_speed = %.1f" % self.extruder_unload_speed

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -429,7 +429,7 @@ class Mmu:
         self.gear_short_move_accel = config.getfloat('gear_short_move_accel', 400, minval=10.)
         self.gear_short_move_threshold = config.getfloat('gear_short_move_threshold', self.gate_homing_max, minval=1.)
         self.gear_homing_speed = config.getfloat('gear_homing_speed', 150, minval=1.)
-        self.proportional_homing_speed = config.getfloat('proportional_homing_speed', 10, minval=1.) # Dedicated speed for proportional sensor extruder homing
+        self.proportional_homing_speed = config.getfloat('proportional_homing_speed', 15, minval=1., maxval=40.0) # Dedicated speed for proportional sensor extruder homing
         self.proportional_extruder_threshold = config.getfloat('proportional_extruder_threshold', 0.9, minval=0.1, maxval=1.0) # Threshold for proportional sensor extruder entry detection
 
         self.extruder_load_speed = config.getfloat('extruder_load_speed', 15, minval=1.)

--- a/extras/mmu/mmu_calibration_manager.py
+++ b/extras/mmu/mmu_calibration_manager.py
@@ -267,6 +267,9 @@ class MmuCalibrationManager:
             if self.mmu.extruder_homing_endstop in [self.mmu.SENSOR_EXTRUDER_ENTRY, self.mmu.SENSOR_COMPRESSION]:
                 if self.mmu.sensor_manager.check_sensor(self.mmu.extruder_homing_endstop):
                     raise MmuError("The %s sensor triggered before homing. Check filament and sensor operation" % self.mmu.extruder_homing_endstop)
+            elif self.mmu.extruder_homing_endstop == self.mmu.SENSOR_EXTRUDER_ENTRY_PROP:
+                if self.mmu.sensor_manager.check_sensor(self.mmu.SENSOR_EXTRUDER_ENTRY_PROP):
+                    raise MmuError("The proportional sensor is already above the extruder threshold before homing. Check filament and sensor operation")
 
             actual, extra = self.mmu._home_to_extruder(extruder_homing_max)
             measured = self.mmu.get_encoder_distance(dwell=True) + self.mmu._get_encoder_dead_space()

--- a/extras/mmu/mmu_sensor_manager.py
+++ b/extras/mmu/mmu_sensor_manager.py
@@ -44,6 +44,7 @@ class MmuSensorManager:
                 sensor_names.append(self.get_unit_sensor_name(self.mmu.SENSOR_PROPORTIONAL, i))
         sensor_names.extend([
             self.mmu.SENSOR_EXTRUDER_ENTRY,
+            self.mmu.SENSOR_EXTRUDER_ENTRY_PROP,
             self.mmu.SENSOR_TOOLHEAD
         ])
         mmu_sensors = self.mmu.printer.lookup_object("mmu_sensors")
@@ -69,6 +70,7 @@ class MmuSensorManager:
                 self.endstop_names.append(self.get_unit_sensor_name(self.mmu.SENSOR_TENSION, i))
         self.endstop_names.extend([
             self.mmu.SENSOR_EXTRUDER_ENTRY,
+            self.mmu.SENSOR_EXTRUDER_ENTRY_PROP,
             self.mmu.SENSOR_TOOLHEAD
         ])
         # TODO Assumes one stepper but in theory could be on all
@@ -78,7 +80,7 @@ class MmuSensorManager:
         for name in self.endstop_names:
             sensor = self.all_sensors.get(name, None)
             if sensor is not None:
-                if sensor.__class__.__name__ in ["MmuAdcSwitchSensor", "MmuHallEndstop"]:
+                if sensor.__class__.__name__ in ["MmuAdcSwitchSensor", "MmuHallEndstop", "MmuProportionalExtruderEndstop"]:
                     sensor_pin = sensor.runout_helper.switch_pin
                     mcu_endstop = self.mmu.gear_rail.add_extra_endstop(sensor_pin, name, mcu_endstop=sensor)
                 else:
@@ -92,7 +94,7 @@ class MmuSensorManager:
 
                 # This ensures rapid stopping of extruder stepper when endstop is hit on synced homing
                 # otherwise the extruder can continue to move a small (speed dependent) distance
-                if self.mmu.homing_extruder and name in [self.mmu.SENSOR_TOOLHEAD, self.mmu.SENSOR_COMPRESSION, self.mmu.SENSOR_TENSION]:
+                if self.mmu.homing_extruder and name in [self.mmu.SENSOR_TOOLHEAD, self.mmu.SENSOR_COMPRESSION, self.mmu.SENSOR_TENSION, self.mmu.SENSOR_EXTRUDER_ENTRY_PROP]:
                     mcu_endstop.add_stepper(self.mmu.mmu_extruder_stepper.stepper)
             else:
                 logging.warning("MMU: Filament sensor %s is not defined in [mmu_sensors]" % name)

--- a/extras/mmu/mmu_sync_feedback_manager.py
+++ b/extras/mmu/mmu_sync_feedback_manager.py
@@ -797,11 +797,11 @@ class MmuSyncFeedbackManager:
         if maxrange_span_mm <= 0.0:
             self.mmu.log_debug("Proportional adjust skipped: buffer maxrange <= 0")
             return 0., False
-        per_side_budget_mm = 0.5 * maxrange_span_mm
+        per_side_budget_mm = 0.65 * maxrange_span_mm
         nudge_mm = per_side_budget_mm * neutral_band
 
         # Cap total nudge iterations to stay within the overall sensor range
-        max_steps = int(math.ceil(maxrange_span_mm / nudge_mm))
+        max_steps = int(math.ceil(maxrange_span_mm * 1.5 / nudge_mm))
 
         moved_total_mm   = 0.0  # total net distance moved during this adjustment
         moved_nudges_mm  = 0.0  # sum of all nudge moves

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -352,6 +352,10 @@ class MmuProportionalSensor:
                 self._last_extreme = extreme
                 self.printer.send_event("mmu:sync_feedback", read_time, self.value)
 
+    @property
+    def report_time(self):
+        return self._report_time
+
     def get_status(self, eventtime):
         return {
             "enabled":          bool(self.runout_helper.sensor_enabled),

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -257,6 +257,7 @@ class MmuProportionalSensor:
         # State
         self.value_raw = 0.0 # Raw ADC value
         self.value = 0.0     # In [-1.0, 1.0]
+        self._endstop_listeners = [] # Callbacks for virtual endstop(s)
 
         # Setup ADC
         ppins = self.printer.lookup_object('pins')
@@ -320,6 +321,10 @@ class MmuProportionalSensor:
         if y >  1.0: y =  1.0
         return y
 
+    def register_endstop_listener(self, callback):
+        """Register a callback to be notified on each ADC reading: callback(read_time, mapped_value)"""
+        self._endstop_listeners.append(callback)
+
     def _adc_callback(self, *args):
         # Old klipper: _adc_callback(read_time, read_value)
         # New klipper: _adc_callback(samples) where samples is a list of (read_time, read_value)
@@ -333,7 +338,11 @@ class MmuProportionalSensor:
 
         self.value_raw = float(read_value)
         self.value = self._map_reading(read_value) # Mapped & scaled value
-        
+
+        # Notify any registered endstop listeners (e.g. proportional_extruder_entry virtual endstop)
+        for listener in self._endstop_listeners:
+            listener(read_time, self.value)
+
         # Publish sync-feedback event immediately if extreme to match switch sensors
         # TODO really extreme should be determined by is_extreme() in mmu_sync_feedback manager (with hysteresis), but object hasn't been created yet
         # TODO so for now, use absolute extremes
@@ -348,6 +357,116 @@ class MmuProportionalSensor:
             "enabled":          bool(self.runout_helper.sensor_enabled),
             "value":            self.value,             # in [-1.0, 1.0] (mapped)
             "value_raw":        self.value_raw,         # raw
+        }
+
+
+
+# -------------------------------------------------------------------------------------------------
+# Virtual endstop derived from the proportional sync-feedback sensor.
+# When the mapped sensor value crosses a configurable threshold (default 0.9 = heavy compression),
+# the endstop triggers, indicating that filament has reached the extruder entry. This allows
+# Klipper's native homing infrastructure (via gear_rail.add_extra_endstop) to be used for
+# filament homing at the extruder rather than a software polling loop.
+#
+# Implements the Klipper endstop interface: query_endstop, add_stepper, get_steppers,
+# home_start, home_wait, setup_pin. Follows the same pattern as MmuAdcSwitchSensor and
+# MmuHallEndstop.
+class MmuProportionalExtruderEndstop:
+
+    def __init__(self, config, proportional_sensor, name, threshold=0.9):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.name = name
+        self._proportional_sensor = proportional_sensor
+        self._threshold = threshold
+
+        # Endstop state
+        self._steppers = []
+        self._trigger_completion = None
+        self._last_trigger_time = None
+        self._homing = False
+        self._triggered = True # Default: home until filament detected (compression >= threshold)
+
+        # Register as a listener on the proportional sensor's ADC callback chain
+        proportional_sensor.register_endstop_listener(self._on_value_update)
+
+        # Attach runout_helper for sensor_manager compatibility (presence detection, enable/disable)
+        self.runout_helper = MmuRunoutHelper(
+            self.printer,
+            name,
+            0,                          # event_delay (not used)
+            {},                         # No gcode actions
+            insert_remove_in_print=False,
+            button_handler=None,
+            switch_pin=proportional_sensor._pin  # Reference the underlying analog pin
+        )
+
+        # Expose status
+        self.printer.add_object(self.name, self)
+
+
+    def _on_value_update(self, read_time, mapped_value):
+        """
+        Called by MmuProportionalSensor on every ADC reading.
+        mapped_value is in [-1.0, 1.0] where positive = compression.
+        We treat compression >= threshold as "filament present at extruder entry".
+        """
+        is_triggered = mapped_value >= self._threshold
+        self.runout_helper.note_filament_present(read_time, is_triggered)
+
+        if self._homing and self._trigger_completion is not None:
+            if is_triggered == self._triggered:
+                self._last_trigger_time = read_time
+                self._trigger_completion.complete(True)
+
+
+    # Required endstop interface methods -------
+
+    def query_endstop(self, print_time):
+        return self.runout_helper.filament_present
+
+
+    def setup_pin(self, pin_type, pin_name):
+        return self
+
+
+    def add_stepper(self, stepper):
+        self._steppers.append(stepper)
+
+
+    def get_steppers(self):
+        return list(self._steppers)
+
+
+    def home_start(self, print_time, sample_time, sample_count, rest_time, triggered):
+        self._trigger_completion = self.reactor.completion()
+        self._last_trigger_time = None
+        self._homing = True
+        self._triggered = triggered
+
+        if self.runout_helper.filament_present == self._triggered:
+            self._last_trigger_time = print_time
+            self._trigger_completion.complete(True)
+
+        return self._trigger_completion
+
+
+    def home_wait(self, home_end_time):
+        self._homing = False
+        self._trigger_completion = None
+
+        if self._last_trigger_time is None:
+            raise self.printer.command_error("No trigger on %s after full movement" % self.name)
+
+        return self._last_trigger_time
+
+
+    def get_status(self, eventtime=None):
+        return {
+            "filament_detected": bool(self.runout_helper.filament_present),
+            "enabled": bool(self.runout_helper.sensor_enabled),
+            "threshold": self._threshold,
+            "sensor_value": self._proportional_sensor.value,
         }
 
 
@@ -706,7 +825,14 @@ class MmuSensors:
         # Uses single analog input; value scaled in [-1, 1]
         analog_pin = config.get('sync_feedback_analog_pin', None)
         if analog_pin:
-            self.sensors[Mmu.SENSOR_PROPORTIONAL] = MmuProportionalSensor(config, name=Mmu.SENSOR_PROPORTIONAL)
+            prop_sensor = MmuProportionalSensor(config, name=Mmu.SENSOR_PROPORTIONAL)
+            self.sensors[Mmu.SENSOR_PROPORTIONAL] = prop_sensor
+
+            # Create virtual endstop for extruder entry detection from proportional sensor
+            threshold = config.getfloat('sync_feedback_analog_extruder_threshold', 0.9, minval=0.1, maxval=1.0)
+            self.sensors[Mmu.SENSOR_EXTRUDER_ENTRY_PROP] = MmuProportionalExtruderEndstop(
+                config, prop_sensor, Mmu.SENSOR_EXTRUDER_ENTRY_PROP, threshold=threshold
+            )
 
 
     def _create_mmu_sensor(

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -826,7 +826,7 @@ class MmuSensors:
             self.sensors[Mmu.SENSOR_PROPORTIONAL] = prop_sensor
 
             # Create virtual endstop for extruder entry detection from proportional sensor
-            threshold = config.getfloat('sync_feedback_analog_extruder_threshold', 0.9, minval=0.1, maxval=1.0)
+            threshold = config.getfloat('proportional_extruder_threshold', 0.9, minval=0.1, maxval=1.0)
             self.sensors[Mmu.SENSOR_EXTRUDER_ENTRY_PROP] = MmuProportionalExtruderEndstop(
                 config, prop_sensor, Mmu.SENSOR_EXTRUDER_ENTRY_PROP, threshold=threshold
             )

--- a/extras/mmu_sensors.py
+++ b/extras/mmu_sensors.py
@@ -365,12 +365,9 @@ class MmuProportionalSensor:
 # Virtual endstop derived from the proportional sync-feedback sensor.
 # When the mapped sensor value crosses a configurable threshold (default 0.9 = heavy compression),
 # the endstop triggers, indicating that filament has reached the extruder entry. This allows
-# Klipper's native homing infrastructure (via gear_rail.add_extra_endstop) to be used for
-# filament homing at the extruder rather than a software polling loop.
+# Klipper's native homing (via gear_rail.add_extra_endstop) to be used for
+# filament homing at the extruder.
 #
-# Implements the Klipper endstop interface: query_endstop, add_stepper, get_steppers,
-# home_start, home_wait, setup_pin. Follows the same pattern as MmuAdcSwitchSensor and
-# MmuHallEndstop.
 class MmuProportionalExtruderEndstop:
 
     def __init__(self, config, proportional_sensor, name, threshold=0.9):


### PR DESCRIPTION
## Experimental feature: use proportional sync feedback sensor for sensorless toolhead — extruder homing, bowden calibration, unload verification, and filament position recovery

This PR introduces a virtual endstop driven by the proportional sync feedback (PSF) sensor. It enables filament homing to the extruder without a physical extruder-entry switch.

When filament reaches the extruder entrance and begins to compress the buffer spring, the sensor value rises toward 1.0. When the mapped value crosses a configurable threshold, the virtual endstop "trips" and the gear-rail homing move completes — homing to the extruder entry using only the PSF.

### Implementation details

**Virtual endstop:** `MmuProportionalExtruderEndstop` (`mmu_sensors.py`)
A virtual endstop implementing the Klipper endstop interface (`query_endstop`, `home_start`, `home_wait`, `add_stepper`, `get_steppers`). It registers as a listener on the existing `MmuProportionalSensor` ADC callback chain via `register_endstop_listener()`. When the mapped sensor value crosses the configured threshold the endstop triggers, completing the homing move.

**Listener hook on `MmuProportionalSensor`** (`mmu_sensors.py`)
The proportional sensor now exposes an `_endstop_listeners` list and a `register_endstop_listener(callback)` method. On each ADC sample, after updating its own state, it notifies all registered listeners with `(read_time, mapped_value)`. This avoids duplicating ADC setup and ensures the endstop sees the same processed values as the rest of the system.

**Sensor manager** (`mmu_sensor_manager.py`)
The new `SENSOR_EXTRUDER_ENTRY_PROP` (`"proportional"`) sensor is added to the sensor name display list, the endstop registration list, and the rapid-stop stepper list. At startup, when a proportional sensor is configured, the sensor manager registers the virtual endstop on the gear rail via `gear_rail.add_extra_endstop()`.

**Homing logic** (`mmu.py`)
Proportional homing in `_home_to_extruder()` is implemented as a `trace_filament_move()` with `homing_move=1, endstop_name=SENSOR_EXTRUDER_ENTRY_PROP`. **A 2-second pause precedes the homing move to allow the bowden to settle after the fast approach move.**

**Bowden calibration support** (`mmu.py`, `mmu_calibration_manager.py`)
The proportional sensor is added to the allowable bowden-calibration sensor list. A pre-initiation check raises `MmuError` if the sensor is already above the extruder threshold before homing starts. **The calibrated bowden length is reduced by `sync_feedback_buffer_range`** to account for the buffer compression distance, preventing overshoot on subsequent loads.

**Post-load extruder entry validation** (`mmu.py`)
`_validate_extruder_entry_proportional(max_steps=4)` confirms the extruder has gripped the filament after homing:

1. **Phase 1 — synced grip:** runs a short `gear+extruder` synced feed of `0.5 × buffer_range` to seat filament in the extruder gears and establish grip.
2. **Phase 2 — extruder-only probes:** drives the extruder motor only, in steps of `0.5 × buffer_range`, up to `max_steps` (capped at 4). After each step it checks whether the sensor has dropped below `proportional_extruder_threshold`. A drop confirms the extruder is actively pulling filament through and relieving compression. If the sensor never drops, an `MmuError` is raised and filament position is set to `FILAMENT_POS_EXTRUDER_ENTRY`.
3. **Adaptive budgeting:** rather than skipping wholesale when the worst-case 4-step move won't fit, the caller now sizes `max_steps` to whatever the remaining nozzle-load distance allows: `max_steps = min(4, int((length − grip_distance) // step_size))`. Validation is only skipped when the remaining load distance is less than `grip_distance + step_size` (i.e. one synced grip move plus one probe step). This lets short toolhead geometries still get at least one meaningful probe instead of bypassing validation entirely. The check is gated by the same `toolhead_entry_tension_test` parameter as the switch-based compression-loading validation.

**Post-unload extruder validation** (`mmu.py`)
`_validate_extruder_unload_proportional()` confirms the extruder has fully released the filament after an unload. From the post-unload state it performs a short forward extruder-only spin of `buffer_range` and reads the sensor again after a settle dwell. If the sensor shifts toward compression by more than 0.1 the extruder is judged to still be gripping filament. Currently warns (does not error) on failure to mirror the existing encoder-based validation pattern.

**Filament recovery with proportional sensor** (`mmu.py`)
`recover_filament_pos()` now uses the PSF to determine filament state during `MMU_RECOVER` when no toolhead or extruder-entry switch is fitted. Three additions:

1. **Presence inference:** before any state branch, if no sensor in the path detected filament and a PSF is configured, a sensor reading above −0.9 (i.e. not in deep tension) marks `filament_detected = True`. This recovers the case where filament is present but no in-path switch can see it.
2. **"Probably loaded" verification (persisted LOADED state):** when filament position was persisted as `FILAMENT_POS_LOADED` and `looks_loaded` is true (gate confirmed), but no toolhead or entry sensor can verify extruder state, the proportional two-phase grip test is run. If grip is not confirmed, the state is demoted to `FILAMENT_POS_IN_BOWDEN`.
3. **Active grip detection (cascade):** when filament is detected (gate sensor or sensors in path) but position is not persisted as `LOADED`, the proportional two-phase grip test determines whether the extruder has grip. The gate condition was broadened to `(filament_detected or gs)` because `filament_detected` from `check_any_sensors_in_path()` returns `None` when `gate_selected` is unknown, while the gate sensor can still independently confirm filament presence via direct `check_sensor()`. If grip is confirmed, the state is set to `LOADED`.

The two-phase test `check_filament_in_extruder_by_proportional()`:

- **Phase 1:** engages the gear via `filament_drive()` and attempts to centre the sensor using `adjust_filament_tension(max_move=2 × buffer_range)`. If the sensor remains in deep tension (≤ −0.9) after the attempt, the filament is free in the bowden with nothing to compress against → returns `False`.
- **Phase 2:** performs an extruder-only retract of one full `buffer_range`. When the extruder has grip, the retract pushes filament back into the bowden and compresses the buffer — the sensor shifts toward compression (more positive). A shift > 0.1 confirms grip. Filament is re-fed to its original position after a successful detection.

Debug messaging in `check_filament_in_mmu()` was improved to distinguish "no sensors configured" from "no switch sensors or encoder available, will defer to proportional sensor" when a PSF is present.

### Parameters

**`proportional_homing_speed`** (default **15 mm/s**, range 1–40): governs the gear speed during proportional-sensor extruder homing. **A relatively slow speed is recommended to absorb the virtual portion of the endstop (ADC polling cadence and listener dispatch latency).** Not exposed in the default config files but accepts overrides; can also be tuned at runtime via `MMU_TEST_CONFIG PROPORTIONAL_HOMING_SPEED=…`.

**`proportional_extruder_threshold`** (default **0.9**, range 0.1–1.0): the mapped-sensor compression threshold at which the virtual endstop trips. Not exposed in the default config files; runtime-tunable via `MMU_TEST_CONFIG PROPORTIONAL_EXTRUDER_THRESHOLD=…`, which also pushes the new threshold into the registered endstop instance.

**`extruder_homing_endstop: proportional`** — set this to enable proportional-sensor extruder homing.

**`toolhead_entry_tension_test: 1`** — strongly recommended; gates the post-load entry validation.

### Tested and functional

1. Extruder homing using the proportional sync sensor only.
2. Bowden calibration using the PSF only.
3. Post-load extruder entry validation — adaptive probe count, drives the extruder in incremental steps and checks the sensor drops below threshold to confirm grip.
4. Post-unload extruder validation — forward gear spin checks for residual extruder grip.
5. Filament recovery (`MMU_RECOVER`) — two-phase proportional grip test correctly distinguishes loaded vs. bowden-only state, and the −0.9 presence heuristic recovers cases with no in-path switch detection.

### To be validated

1. Further field testing of post-load validation reliability under high-compression scenarios where the PSF may remain above threshold even after successful entry.
2. Recovery reliability under varied buffer spring tensions and bowden path conditions.
3. Behaviour of the adaptive probe budgeting on toolheads where only a single probe step fits (typical of short bowden-to-nozzle geometries with moderate `toolchange_retract`).

### Screenshots

#### Bowden tube calibration results
**Extruder endstop vs. proportional sensor acting as virtual endstop. Variance is ~2 mm.**
<img width="3900" height="1536" alt="image" src="https://github.com/user-attachments/assets/f26426ef-6980-4869-92db-8fbf277a025a" />

**Run-to-run variance ~1 mm**
<img width="2880" height="1934" alt="image" src="https://github.com/user-attachments/assets/98ee3ada-29cd-4b0f-ae59-7bd8b4306b78" />

#### Loading process including load validation
![image](https://github.com/user-attachments/assets/e0703439-3eb6-4e55-b64a-c01c1a7a8e44)

#### Deliberately triggered post-load validation error by holding the sensor in a compressed state
<img width="2346" height="1580" alt="image" src="https://github.com/user-attachments/assets/6912a413-3311-4e65-b083-5a45d0493187" />

#### Recovery when filament in bowden but not loaded
<img width="2326" height="766" alt="image" src="https://github.com/user-attachments/assets/59e2ceff-14b4-4aba-a938-ebc99d216b12" />

#### Recovery when filament in bowden and loaded at the extruder
<img width="2386" height="798" alt="image" src="https://github.com/user-attachments/assets/f2bedfa9-0ed4-4ecf-8dd2-00d82060b858" />
<img width="2386" height="798" alt="image" src="https://github.com/user-attachments/assets/f64cfd99-5254-43fe-be18-638355b3abcc" />

#### Filament unload verification at the extruder — currently just warns if not released
<img width="2304" height="1328" alt="image" src="https://github.com/user-attachments/assets/ec31c451-a771-45d6-ac0c-071ac5711dfa" />

### Reliability considerations

1. Losing the toolhead/extruder sensor means we rely on the buffer spring being stiff enough to overcome natural bowden tube friction.
2. Without a sensor inside the toolhead we are never strictly certain a load has reached the nozzle — we infer it from PSF readings. The post-load validation step mitigates this by confirming extruder grip through incremental movement, but field testing is needed under varied bowden path conditions.
3. Recovery accuracy depends on the buffer having sufficient range for the retract test to produce a measurable sensor shift. Short buffer ranges or very long/loose bowden paths may reduce detection reliability.
