### PR TITLE
v4 ported - Disable steppers in type B MMUs with filament always gripped when switching lanes

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -6774,7 +6774,7 @@ class Mmu:
             self.handle_mmu_error(str(ee))
         finally:
             # Disable type-B lane stepper after select (re-enabled on next move)
-            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped and self.gate_selected >= 0:
+            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
                 self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
 
     cmd_MMU_SELECT_BYPASS_help = "Select the filament bypass"
@@ -7096,7 +7096,7 @@ class Mmu:
             self.handle_mmu_error("Filament eject for gate %d failed: %s" % (gate, str(ee)))
         finally:
             # Disable type-B lane stepper after eject command (re-enabled on next move)
-            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped and self.gate_selected >= 0:
+            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
                 self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
 
     # Common logic for MMU_UNLOAD and MMU_EJECT

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -6774,7 +6774,7 @@ class Mmu:
             self.handle_mmu_error(str(ee))
         finally:
             # Disable type-B lane stepper after select (re-enabled on next move)
-            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped and self.gate_selected >= 0:
                 self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
 
     cmd_MMU_SELECT_BYPASS_help = "Select the filament bypass"
@@ -7096,7 +7096,7 @@ class Mmu:
             self.handle_mmu_error("Filament eject for gate %d failed: %s" % (gate, str(ee)))
         finally:
             # Disable type-B lane stepper after eject command (re-enabled on next move)
-            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped and self.gate_selected >= 0:
                 self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
 
     # Common logic for MMU_UNLOAD and MMU_EJECT

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -1342,6 +1342,10 @@ class Mmu:
             self.reset_sync_gear_to_extruder(False) # Intention is not to sync unless we have to
             self.mmu_toolhead.quiesce()
 
+            # Disable all type-B lane steppers at startup (re-enabled on next select_gear_stepper)
+            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                self.mmu_toolhead.disable_all_lane_steppers()
+
             # Sync with spoolman. Delay as long as possible to maximize the chance it is contactable after startup/reboot
             self._spoolman_sync()
 
@@ -9033,6 +9037,10 @@ class Mmu:
 
                             if not quiet:
                                 self.log_info(self._mmu_visual_to_string())
+
+                            # Disable type-B lane stepper after check (re-enabled on next select_gear_stepper)
+                            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped and self.filament_pos == self.FILAMENT_POS_UNLOADED:
+                                self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
 
         except MmuError as ee:
             self.handle_mmu_error(str(ee))

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -2400,6 +2400,10 @@ class Mmu:
             elif not self.selector.buzz_motor(motor):
                 raise gcmd.error("Motor '%s' not known" % motor)
 
+            # Disable type-B lane stepper after buzz test (re-enabled on next move)
+            if motor in ("gear", "gears") and self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
+
     cmd_MMU_SYNC_GEAR_MOTOR_help = "Sync the MMU gear motor to the extruder stepper"
     cmd_MMU_SYNC_GEAR_MOTOR_param_help = (
         "MMU_SYNC_GEAR_MOTOR: %s\n" % cmd_MMU_SYNC_GEAR_MOTOR_help
@@ -2575,6 +2579,9 @@ class Mmu:
                     self._unload_tool()
                     self.calibration_manager.calibrate_encoder(length, repeats, speed, min_speed, max_speed, accel, save)
                     _,_,_,_ = self.trace_filament_move("Parking filament", -advance)
+                    # Disable type-B lane stepper after calibration (re-enabled on next move)
+                    if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                        self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
         except MmuError as ee:
             self.handle_mmu_error(str(ee))
         finally:
@@ -2922,6 +2929,10 @@ class Mmu:
                     msg = "Backing off tension limit"
                     self.log_always(msg)
                     _ = self.trace_filament_move(msg, (steps * STEP_SIZE / 2.0), motor="gear", speed=MOVE_SPEED, wait=True)
+
+                    # Disable type-B lane stepper after calibration (re-enabled on next move)
+                    if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                        self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
 
             if (found_c_limit and found_t_limit):
                 msg =  "Calibration Results:\n"
@@ -4378,6 +4389,9 @@ class Mmu:
                         self.trace_filament_move("Final parking", -self.gate_preload_parking_distance)
                         self._set_gate_status(self.gate_selected, self.GATE_AVAILABLE)
                         self._check_pending_spool_id(self.gate_selected) # Have spool_id ready?
+                        # Disable type-B lane stepper after preload (re-enabled on next move)
+                        if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                            self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
                         self.log_always("Filament detected and loaded in gate %d" % self.gate_selected)
                         return
         else:
@@ -4397,6 +4411,9 @@ class Mmu:
 
         if self.sensor_manager.check_gate_sensor(self.SENSOR_PRE_GATE_PREFIX, self.gate_selected):
             self._set_gate_status(self.gate_selected, self.GATE_UNKNOWN)
+            # Disable type-B lane stepper after failed preload (re-enabled on next move)
+            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
             self.log_warning("Filament detected by pre-gate %d sensor but did not complete preload" % self.gate_selected)
         else:
             self._set_gate_status(self.gate_selected, self.GATE_EMPTY)
@@ -4431,6 +4448,9 @@ class Mmu:
 
         self._set_filament_pos_state(self.FILAMENT_POS_UNLOADED, silent=True) # Should already be in this position
         self._set_gate_status(gate, self.GATE_EMPTY)
+        # Disable type-B lane stepper after eject (re-enabled on next move)
+        if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+            self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
         self.log_always("The filament in gate %d can be removed" % gate)
 
     # Load filament into gate. This is considered the starting position for the rest of the filament loading
@@ -4523,6 +4543,9 @@ class Mmu:
                     self._set_filament_pos_state(self.FILAMENT_POS_HOMED_GATE)
                     self.trace_filament_move("Final parking", -self.gate_parking_distance)
                     self._set_filament_pos_state(self.FILAMENT_POS_UNLOADED)
+                    # Disable type-B lane stepper after unload (re-enabled on next move)
+                    if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                        self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
                     return actual, self.gate_unload_buffer
 
         if self.gate_homing_endstop == self.SENSOR_ENCODER:
@@ -4539,6 +4562,9 @@ class Mmu:
                     if measured > self.encoder_min: # We expect 0, but relax the test a little (allow one pulse)
                         self.log_warning("Warning: Possible encoder malfunction (free-spinning) during final filament parking")
                     self._set_filament_pos_state(self.FILAMENT_POS_UNLOADED)
+                    # Disable type-B lane stepper after unload (re-enabled on next move)
+                    if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                        self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
                     return actual, self.gate_unload_buffer
                 msg = "did not clear the encoder after moving %.1fmm" % homing_max
 
@@ -4549,6 +4575,9 @@ class Mmu:
                 self._set_filament_pos_state(self.FILAMENT_POS_HOMED_GATE)
                 self.trace_filament_move("Final parking", -self.gate_parking_distance)
                 self._set_filament_pos_state(self.FILAMENT_POS_UNLOADED)
+                # Disable type-B lane stepper after unload (re-enabled on next move)
+                if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                    self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
                 return actual, self.gate_unload_buffer
             msg = "did not home to sensor '%s' after moving %1.fmm" % (self.gate_homing_endstop, homing_max)
 
@@ -5380,10 +5409,6 @@ class Mmu:
                             self.wrap_gcode_command(self.post_unload_macro, exception=True, wait=True)
                     else:
                         self.wrap_gcode_command(self.post_unload_macro, exception=True, wait=True)
-
-            # Disable type-B lane stepper after unload (re-enabled on next select_gear_stepper)
-            if not extruder_only and self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
-                self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
 
         except MmuError as ee:
             self._track_gate_statistics('unload_failures', self.gate_selected)
@@ -7061,6 +7086,10 @@ class Mmu:
                                 # Lazy movement means we have side effect of changed tool/gate
                                 self._ensure_ttg_match()
                                 self._initialize_encoder() # Encoder 0000
+
+                    # Disable type-B lane stepper after eject command (re-enabled on next move)
+                    if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                        self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
 
                     self._persist_swap_statistics()
 

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -2579,12 +2579,12 @@ class Mmu:
                     self._unload_tool()
                     self.calibration_manager.calibrate_encoder(length, repeats, speed, min_speed, max_speed, accel, save)
                     _,_,_,_ = self.trace_filament_move("Parking filament", -advance)
-                    # Disable type-B lane stepper after calibration (re-enabled on next move)
-                    if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
-                        self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
         except MmuError as ee:
             self.handle_mmu_error(str(ee))
         finally:
+            # Disable type-B lane stepper after calibration (re-enabled on next move)
+            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
             self.calibrating = False
 
     # Calibrated bowden length is always from chosen gate homing point to the entruder gears
@@ -2930,10 +2930,6 @@ class Mmu:
                     self.log_always(msg)
                     _ = self.trace_filament_move(msg, (steps * STEP_SIZE / 2.0), motor="gear", speed=MOVE_SPEED, wait=True)
 
-                    # Disable type-B lane stepper after calibration (re-enabled on next move)
-                    if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
-                        self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
-
             if (found_c_limit and found_t_limit):
                 msg =  "Calibration Results:\n"
                 msg += "As wired, recommended settings (in mmu_hardware.cfg) are:\n"
@@ -2953,6 +2949,9 @@ class Mmu:
         except MmuError as ee:
             self.handle_mmu_error(str(ee))
         finally:
+            # Disable type-B lane stepper after calibration (re-enabled on next move)
+            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
             self.calibrating = False
 
 
@@ -4417,6 +4416,9 @@ class Mmu:
             self.log_warning("Filament detected by pre-gate %d sensor but did not complete preload" % self.gate_selected)
         else:
             self._set_gate_status(self.gate_selected, self.GATE_EMPTY)
+            # Disable type-B lane stepper before raising (re-enabled on next move)
+            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
             raise MmuError("Filament not detected")
 
     # Eject final clear of gate. Important for MMU's where filament is always gripped (e.g. most type-B)
@@ -6768,11 +6770,12 @@ class Mmu:
                 msg = self._mmu_visual_to_string()
                 msg += "\n%s" % self._state_to_string()
                 self.log_info(msg, color=True)
-                # Disable type-B lane stepper after select (re-enabled on next move)
-                if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
-                    self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
         except MmuError as ee:
             self.handle_mmu_error(str(ee))
+        finally:
+            # Disable type-B lane stepper after select (re-enabled on next move)
+            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
 
     cmd_MMU_SELECT_BYPASS_help = "Select the filament bypass"
     def cmd_MMU_SELECT_BYPASS(self, gcmd):
@@ -7087,14 +7090,14 @@ class Mmu:
                                 self._ensure_ttg_match()
                                 self._initialize_encoder() # Encoder 0000
 
-                    # Disable type-B lane stepper after eject command (re-enabled on next move)
-                    if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
-                        self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
-
                     self._persist_swap_statistics()
 
         except MmuError as ee:
             self.handle_mmu_error("Filament eject for gate %d failed: %s" % (gate, str(ee)))
+        finally:
+            # Disable type-B lane stepper after eject command (re-enabled on next move)
+            if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
 
     # Common logic for MMU_UNLOAD and MMU_EJECT
     def _mmu_unload_eject(self, gcmd):

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -5377,6 +5377,10 @@ class Mmu:
                     else:
                         self.wrap_gcode_command(self.post_unload_macro, exception=True, wait=True)
 
+            # Disable type-B lane stepper after unload (re-enabled on next select_gear_stepper)
+            if not extruder_only and self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
+
         except MmuError as ee:
             self._track_gate_statistics('unload_failures', self.gate_selected)
             raise MmuError("Unload sequence failed because:\n%s" % (str(ee)))

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -6743,6 +6743,9 @@ class Mmu:
                 msg = self._mmu_visual_to_string()
                 msg += "\n%s" % self._state_to_string()
                 self.log_info(msg, color=True)
+                # Disable type-B lane stepper after select (re-enabled on next move)
+                if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                    self.mmu_toolhead.disable_lane_stepper(self.gate_selected)
         except MmuError as ee:
             self.handle_mmu_error(str(ee))
 

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -9044,6 +9044,9 @@ class Mmu:
                                             self.log_always(msg)
                                     finally:
                                         self._initialize_encoder() # Encoder 0000
+                                        # Disable type-B lane stepper after each gate check (re-enabled on next select_gate)
+                                        if self.mmu_machine.multigear and self.mmu_machine.filament_always_gripped:
+                                            self.mmu_toolhead.disable_lane_stepper(gate)
 
                             # If not printing select original tool and load filament if necessary
                             # We don't do this when printing because this is expected to preceed loading initial tool

--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -603,11 +603,36 @@ class MmuToolHead(toolhead.ToolHead, object):
         if not self.mmu_machine.multigear: return
         with self._resync_lock:
             if gate == 0:
+                self._enable_lane_stepper_for_gate(gate)
                 self._reconfigure_rail_no_lock([GEAR_STEPPER_CONFIG])
             elif gate > 0:
+                self._enable_lane_stepper_for_gate(gate)
                 self._reconfigure_rail_no_lock(["%s_%d" % (GEAR_STEPPER_CONFIG, gate)])
             else:
                 self._reconfigure_rail_no_lock(None)
+
+
+    # Disable the gear stepper driver for the specified gate.
+    # Called on type-B MMUs (multigear + filament_always_gripped) after a successful
+    # unload to de-energize the lane stepper driver while transitioning to the next gate.
+    def disable_lane_stepper(self, gate):
+        if not self.mmu_machine.multigear or not self.mmu_machine.filament_always_gripped or gate < 0:
+            return
+        stepper_name = GEAR_STEPPER_CONFIG if gate == 0 else "%s_%d" % (GEAR_STEPPER_CONFIG, gate)
+        se = self.printer.lookup_object('stepper_enable').lookup_enable(stepper_name)
+        se.motor_disable(self.get_last_move_time())
+        self.mmu.log_trace("Type-B lane stepper '%s' disabled after unload" % stepper_name)
+
+	# Re-enable the gear stepper driver for the specified gate before activation.
+    # Called on type-B MMUs (multigear + filament_always_gripped) prior to selecting
+    # a new lane, ensuring the stepper is energized before the load sequence begins.
+    def _enable_lane_stepper_for_gate(self, gate):
+        if not self.mmu_machine.filament_always_gripped or gate < 0:
+            return  # multigear is already confirmed by the caller (select_gear_stepper)
+        stepper_name = GEAR_STEPPER_CONFIG if gate == 0 else "%s_%d" % (GEAR_STEPPER_CONFIG, gate)
+        se = self.printer.lookup_object('stepper_enable').lookup_enable(stepper_name)
+        se.motor_enable(self.get_last_move_time())
+        self.mmu.log_trace("Type-B lane stepper '%s' enabled before lane activation" % stepper_name)
 
     def _reconfigure_rail_no_lock(self, selected):
         m_th = self.mmu_toolhead

--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -603,36 +603,40 @@ class MmuToolHead(toolhead.ToolHead, object):
         if not self.mmu_machine.multigear: return
         with self._resync_lock:
             if gate == 0:
-                self._enable_lane_stepper_for_gate(gate)
+                if self.mmu_machine.filament_always_gripped:
+                    self._enable_lane_stepper(gate)
                 self._reconfigure_rail_no_lock([GEAR_STEPPER_CONFIG])
             elif gate > 0:
-                self._enable_lane_stepper_for_gate(gate)
+                if self.mmu_machine.filament_always_gripped:
+                    self._enable_lane_stepper(gate)
                 self._reconfigure_rail_no_lock(["%s_%d" % (GEAR_STEPPER_CONFIG, gate)])
             else:
                 self._reconfigure_rail_no_lock(None)
 
+    # Electrically disable/enable individual or all gear stepper drivers on type-B
+    # MMUs. Callers are responsible for guarding with multigear + filament_always_gripped.
+    # all_gear_rail_steppers only contains MMU gear rail steppers (rails[1]), never
+    # printer axis or extruder steppers.
 
-    # Disable the gear stepper driver for the specified gate.
-    # Called on type-B MMUs (multigear + filament_always_gripped) after a successful
-    # unload to de-energize the lane stepper driver while transitioning to the next gate.
     def disable_lane_stepper(self, gate):
-        if not self.mmu_machine.multigear or not self.mmu_machine.filament_always_gripped or gate < 0:
-            return
         stepper_name = GEAR_STEPPER_CONFIG if gate == 0 else "%s_%d" % (GEAR_STEPPER_CONFIG, gate)
         se = self.printer.lookup_object('stepper_enable').lookup_enable(stepper_name)
         se.motor_disable(self.get_last_move_time())
-        self.mmu.log_trace("Type-B lane stepper '%s' disabled after unload" % stepper_name)
+        self.mmu.log_trace("Type-B lane stepper '%s' disabled" % stepper_name)
 
-	# Re-enable the gear stepper driver for the specified gate before activation.
-    # Called on type-B MMUs (multigear + filament_always_gripped) prior to selecting
-    # a new lane, ensuring the stepper is energized before the load sequence begins.
-    def _enable_lane_stepper_for_gate(self, gate):
-        if not self.mmu_machine.filament_always_gripped or gate < 0:
-            return  # multigear is already confirmed by the caller (select_gear_stepper)
+    def disable_all_lane_steppers(self):
+        stepper_enable = self.printer.lookup_object('stepper_enable')
+        last_move_time = self.get_last_move_time()
+        for s in self.all_gear_rail_steppers:
+            se = stepper_enable.lookup_enable(s.get_name())
+            se.motor_disable(last_move_time)
+        self.mmu.log_trace("All type-B lane steppers disabled")
+
+    def _enable_lane_stepper(self, gate):
         stepper_name = GEAR_STEPPER_CONFIG if gate == 0 else "%s_%d" % (GEAR_STEPPER_CONFIG, gate)
         se = self.printer.lookup_object('stepper_enable').lookup_enable(stepper_name)
         se.motor_enable(self.get_last_move_time())
-        self.mmu.log_trace("Type-B lane stepper '%s' enabled before lane activation" % stepper_name)
+        self.mmu.log_trace("Type-B lane stepper '%s' enabled" % stepper_name)
 
     def _reconfigure_rail_no_lock(self, selected):
         m_th = self.mmu_toolhead

--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -603,20 +603,17 @@ class MmuToolHead(toolhead.ToolHead, object):
         if not self.mmu_machine.multigear: return
         with self._resync_lock:
             if gate == 0:
-                if self.mmu_machine.filament_always_gripped:
-                    self._enable_lane_stepper(gate)
                 self._reconfigure_rail_no_lock([GEAR_STEPPER_CONFIG])
             elif gate > 0:
-                if self.mmu_machine.filament_always_gripped:
-                    self._enable_lane_stepper(gate)
                 self._reconfigure_rail_no_lock(["%s_%d" % (GEAR_STEPPER_CONFIG, gate)])
             else:
                 self._reconfigure_rail_no_lock(None)
 
-    # Electrically disable/enable individual or all gear stepper drivers on type-B
-    # MMUs. Callers are responsible for guarding with multigear + filament_always_gripped.
-    # all_gear_rail_steppers only contains MMU gear rail steppers (rails[1]), never
-    # printer axis or extruder steppers.
+    # Electrically disable individual or all gear stepper drivers on type-B MMUs.
+    # Callers are responsible for guarding with multigear + filament_always_gripped.
+    # Klipper auto-enables steppers on the next queued move so no explicit re-enable
+    # is needed. all_gear_rail_steppers only contains MMU gear rail steppers (rails[1]),
+    # never printer axis or extruder steppers.
 
     def disable_lane_stepper(self, gate):
         stepper_name = GEAR_STEPPER_CONFIG if gate == 0 else "%s_%d" % (GEAR_STEPPER_CONFIG, gate)
@@ -631,12 +628,6 @@ class MmuToolHead(toolhead.ToolHead, object):
             se = stepper_enable.lookup_enable(s.get_name())
             se.motor_disable(last_move_time)
         self.mmu.log_trace("All type-B lane steppers disabled")
-
-    def _enable_lane_stepper(self, gate):
-        stepper_name = GEAR_STEPPER_CONFIG if gate == 0 else "%s_%d" % (GEAR_STEPPER_CONFIG, gate)
-        se = self.printer.lookup_object('stepper_enable').lookup_enable(stepper_name)
-        se.motor_enable(self.get_last_move_time())
-        self.mmu.log_trace("Type-B lane stepper '%s' enabled" % stepper_name)
 
     def _reconfigure_rail_no_lock(self, selected):
         m_th = self.mmu_toolhead

--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -616,6 +616,8 @@ class MmuToolHead(toolhead.ToolHead, object):
     # never printer axis or extruder steppers.
 
     def disable_lane_stepper(self, gate):
+        if gate < 0:
+            return
         stepper_name = GEAR_STEPPER_CONFIG if gate == 0 else "%s_%d" % (GEAR_STEPPER_CONFIG, gate)
         se = self.printer.lookup_object('stepper_enable').lookup_enable(stepper_name)
         se.motor_disable(self.get_last_move_time())


### PR DESCRIPTION
PR to address stepper driver power consumption on Type B designs where the inactive lanes are not needed to remain energised if the lane is not actively operating.