### PR TITLE
Stepper Blobifier support

### DIFF
--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -67,6 +67,17 @@ variable_purge_temp_min: 200            # Minimum nozzle purge temperature.
 variable_toolhead_x: 70                 # From the nozzle to the left of your toolhead
 variable_toolhead_y: 50                 # From the nozzle to the front of your toolhead
 
+# Blobifier tray actuator type: "servo" or "stepper"
+# Set to "stepper" if using a manual_stepper driven tray instead of a servo.
+# Make sure the matching hardware section is enabled in blobifier_hw.cfg
+variable_blobifier_type: "servo"
+
+# Klipper firmware variant: "klipper" or "kalico"
+# Kalico uses integer STOP_ON_ENDSTOP values while
+# mainline Klipper uses string values. Set this to match your firmware.
+# Relevant only for stepper blobifier.
+variable_firmware: "klipper"
+
 # This macro will prevent a gcode movement downward while 'blobbing' if there might be a
 # print in the way (e.g. You print something large and need the area where Blobifier does
 # its... 'business'). However, at low heights (or at print start) this might not be
@@ -144,12 +155,21 @@ variable_purge_x: 10
 # lowering it with the paper method. 
 variable_tray_top: 0.7
 
-# Servo angles for tray positions
+# Servo Blobifier:
+# Servo angles for tray positions (used when blobifier_type is "servo")
 variable_tray_angle_out: 0
 variable_tray_angle_in: 180
-
 # Increase this value if the servo doesn't have enough time to fully retract or extend
 variable_dwell_time: 200
+
+# Stepper Blobifier:
+# Stepper positions for tray (used when blobifier_type is "stepper")
+# These are positions in mm for the manual_stepper.
+# tray_pos_out: extended position, tray_pos_in: retracted/home position
+variable_tray_pos_out: 21
+variable_tray_pos_in: 0
+# Speed (mm/s) for stepper tray movements
+variable_tray_stepper_speed: 110
 
 # ========================================================================================
 # ==================== BLOB TUNING =======================================================
@@ -563,9 +583,9 @@ gcode:
     
     # Adjust tension and centre sensor to ensure we don't accidentally trigger FlowGuard runout when print resumes
     {% if printer.mmu.sync_feedback_enabled %}
-        MMU_SYNC_FEEDBACK ADJUST_TENSION=1  
+        MMU_SYNC_FEEDBACK ADJUST_TENSION=1
     {% endif %}
-    
+
     {% if safe.tray or ignore_safe %}
       G1 Z{tray_top + 1} F{travel_spd_z}
     {% endif %}
@@ -595,8 +615,13 @@ gcode:
 
   # Retract the tray
   BLOBIFIER_SERVO POS=in
-  
-  RESTORE_GCODE_STATE NAME=BLOBIFIER_state 
+
+  # Disable stepper motor after purge is complete to save power and reduce heat
+  {% if printer['gcode_macro BLOBIFIER'].blobifier_type == "stepper" %}
+    MANUAL_STEPPER STEPPER=stepper_blobifier ENABLE=0 SYNC=1
+  {% endif %}
+
+  RESTORE_GCODE_STATE NAME=BLOBIFIER_state
 
 ##########################################################################################
 # Extrusion helper that allows for check of "runout/clog" indicator
@@ -690,9 +715,14 @@ gcode:
   SET_GCODE_VARIABLE MACRO=BLOBIFIER_PARK VARIABLE=restore_z VALUE={pos.z}
 
   SAVE_GCODE_STATE NAME=blobifier_park_state
-  
+
   {% if "xyz" in printer.toolhead.homed_axes and printer.quad_gantry_level and printer.quad_gantry_level.applied %}
     G90
+
+    # Home stepper tray if in stepper mode and stepper is disabled
+    {% if bl.blobifier_type == "stepper" and not printer.stepper_enable.steppers['manual_stepper stepper_blobifier'] %}
+      _BLOBIFIER_HOME_STEPPER
+    {% endif %}
 
     # Retract the tray
     BLOBIFIER_SERVO POS=in
@@ -713,23 +743,57 @@ gcode:
   RESTORE_GCODE_STATE NAME=blobifier_park_state
 
 ##########################################################################################
-# Retract or extend the tray 
-# POS=[in|out] Retractor extend the tray
+# Home the stepper-based blobifier tray. This enables the stepper, sets an assumed
+# position, then homes to the endstop. Called automatically before stepper moves if
+# the stepper is not yet homed. Only relevant when blobifier_type is "stepper".
+#
+[gcode_macro _BLOBIFIER_HOME_STEPPER]
+gcode:
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+  RESPOND MSG="BLOBIFIER: Homing stepper tray"
+  MANUAL_STEPPER STEPPER=stepper_blobifier ENABLE=1 SET_POSITION=30 SYNC=1
+  {% if bl.firmware == "kalico" %}
+    MANUAL_STEPPER STEPPER=stepper_blobifier MOVE=0 SPEED=50 STOP_ON_ENDSTOP=2
+  {% else %}
+    MANUAL_STEPPER STEPPER=stepper_blobifier MOVE=0 SPEED=50 STOP_ON_ENDSTOP=try_home
+  {% endif %}
+
+##########################################################################################
+# Retract or extend the tray
+# POS=[in|out] Retract or extend the tray
+# Works with both servo and stepper blobifier types based on variable_blobifier_type
 #
 [gcode_macro BLOBIFIER_SERVO]
 gcode:
   {% set bl = printer['gcode_macro BLOBIFIER'] %}
   {% set pos = params.POS %}
-  {% if pos == "in" %}
-    SET_SERVO SERVO=blobifier ANGLE={bl.tray_angle_in}
-    G4 P{bl.dwell_time}
-  {% elif pos == "out" %}
-    SET_SERVO SERVO=blobifier ANGLE={bl.tray_angle_out}
-    G4 P{bl.dwell_time}
+
+  {% if bl.blobifier_type == "stepper" %}
+    # === STEPPER MODE ===
+    # If stepper is disabled, it needs homing before any move
+    {% if not printer.stepper_enable.steppers['manual_stepper stepper_blobifier'] %}
+      _BLOBIFIER_HOME_STEPPER
+    {% endif %}
+    {% if pos == "in" %}
+      MANUAL_STEPPER STEPPER=stepper_blobifier MOVE={bl.tray_pos_in} SPEED={bl.tray_stepper_speed} SYNC=1
+    {% elif pos == "out" %}
+      MANUAL_STEPPER STEPPER=stepper_blobifier MOVE={bl.tray_pos_out} SPEED={bl.tray_stepper_speed} SYNC=1
+    {% else %}
+      {action_respond_info("BLOBIFIER: provide POS=[in|out]")}
+    {% endif %}
   {% else %}
-    {action_respond_info("BLOBIFIER: provide POS=[in|out]")}
+    # === SERVO MODE ===
+    {% if pos == "in" %}
+      SET_SERVO SERVO=blobifier ANGLE={bl.tray_angle_in}
+      G4 P{bl.dwell_time}
+    {% elif pos == "out" %}
+      SET_SERVO SERVO=blobifier ANGLE={bl.tray_angle_out}
+      G4 P{bl.dwell_time}
+    {% else %}
+      {action_respond_info("BLOBIFIER: provide POS=[in|out]")}
+    {% endif %}
+    SET_SERVO SERVO=blobifier WIDTH=0
   {% endif %}
-  SET_SERVO SERVO=blobifier WIDTH=0
 
 ##########################################################################################
 # Define exclude objects for those who haven't already
@@ -960,9 +1024,19 @@ gcode:
 initial_duration: 5.0
 gcode:
   _BLOBIFIER_INIT
-  # Extend and retract the tray to test
-  BLOBIFIER_SERVO POS=out
-  BLOBIFIER_SERVO POS=in
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+  {% if bl.blobifier_type == "stepper" %}
+    # Home and test stepper tray
+    _BLOBIFIER_HOME_STEPPER
+    BLOBIFIER_SERVO POS=out
+    BLOBIFIER_SERVO POS=in
+    # Disable stepper after init test
+    MANUAL_STEPPER STEPPER=stepper_blobifier ENABLE=0 SYNC=1
+  {% else %}
+    # Extend and retract the servo tray to test
+    BLOBIFIER_SERVO POS=out
+    BLOBIFIER_SERVO POS=in
+  {% endif %}
 
 [gcode_macro _BLOBIFIER_INIT]
 gcode:

--- a/config/addons/blobifier.cfg
+++ b/config/addons/blobifier.cfg
@@ -753,9 +753,9 @@ gcode:
   RESPOND MSG="BLOBIFIER: Homing stepper tray"
   MANUAL_STEPPER STEPPER=stepper_blobifier ENABLE=1 SET_POSITION=30 SYNC=1
   {% if bl.firmware == "kalico" %}
-    MANUAL_STEPPER STEPPER=stepper_blobifier MOVE=0 SPEED=50 STOP_ON_ENDSTOP=2
+    MANUAL_STEPPER STEPPER=stepper_blobifier MOVE=0 SPEED=20 STOP_ON_ENDSTOP=2
   {% else %}
-    MANUAL_STEPPER STEPPER=stepper_blobifier MOVE=0 SPEED=50 STOP_ON_ENDSTOP=try_home
+    MANUAL_STEPPER STEPPER=stepper_blobifier MOVE=0 SPEED=20 STOP_ON_ENDSTOP=try_home
   {% endif %}
 
 ##########################################################################################

--- a/config/addons/blobifier_hw.cfg
+++ b/config/addons/blobifier_hw.cfg
@@ -1,14 +1,26 @@
 
 ##########################################################################################
+# BLOBIFIER HARDWARE CONFIGURATION
+# Choose ONE of the two tray actuator options below:
+#   1. Servo-based (default) - uncomment the [mmu_servo blobifier] section
+#   2. Stepper-based         - uncomment the [manual_stepper stepper_blobifier] section
+#
+# IMPORTANT: Also set variable_blobifier_type in the [gcode_macro BLOBIFIER] section
+# to match your hardware: "servo" or "stepper"
+##########################################################################################
+
+
+##########################################################################################
+# OPTION 1: Servo-based tray actuator (DEFAULT)
 # The servo hardware configuration. Change the values to your needs.
-# 
+#
 [mmu_servo blobifier]
 # Pin for the servo.
 pin: PG14
-# Adjust this value until a 'BLOBIFIER_SERVO POS=out' extends the tray fully without a 
+# Adjust this value until a 'BLOBIFIER_SERVO POS=out' extends the tray fully without a
 # buzzing sound
 minimum_pulse_width: 0.00053
-# Adjust this value until a 'BLOBIFIER_SERVO POS=in' retracts the tray fully without a 
+# Adjust this value until a 'BLOBIFIER_SERVO POS=in' retracts the tray fully without a
 # buzzing sound
 maximum_pulse_width: 0.0023
 # Leave this value at 180
@@ -16,9 +28,65 @@ maximum_servo_angle: 180
 
 
 ##########################################################################################
-# The bucket hardware configuration. Change the pin to whatever pin you've connected the 
+# OPTION 2: Stepper-based tray actuator
+# Uncomment the sections below and comment out the servo section above to use a stepper
+# motor driven blobifier tray instead of a servo.
+#
+#[manual_stepper stepper_blobifier]
+#step_pin: PD4                            # Update your pins
+#dir_pin: !PD3
+#enable_pin: !PD6
+#endstop_pin: ^!PC15
+#microsteps: 4
+#gear_ratio: 1:1
+#rotation_distance: 62.83
+#position_min: 0 # Not supported in Kalico. Leave disabled
+#position_max: 21 # Not supported in Kalico. Leave disabled.
+#homing_speed: 30
+#velocity: 150
+#accel: 1000
+#
+# Uncomment ONE of the TMC driver sections below to match your hardware.
+# Only one driver section should be active at a time.
+#
+# --- TMC2240 (SPI) ---
+#[tmc2240 manual_stepper stepper_blobifier]
+#cs_pin: PD5                            # Update your pins
+#spi_software_sclk_pin: PG8
+#spi_software_mosi_pin: PG6
+#spi_software_miso_pin: PG7
+#driver_SLOPE_CONTROL: 2
+#run_current: 0.6
+#hold_current: 0.2
+#interpolate: true
+#stealthchop_threshold: 99999999
+#
+# --- TMC2209 (UART) ---
+#[tmc2209 manual_stepper stepper_blobifier]
+#uart_pin: PD5                          # Update to your UART pin
+#run_current: 0.6
+#hold_current: 0.1
+#interpolate: true
+#stealthchop_threshold: 99999999
+#sense_resistor: 0.110
+#
+# --- TMC5160 (SPI) ---
+#[tmc5160 manual_stepper stepper_blobifier]
+#cs_pin: PD5                            # Update your pins
+#spi_software_sclk_pin: PG8
+#spi_software_mosi_pin: PG6
+#spi_software_miso_pin: PG7
+#run_current: 0.6
+#hold_current: 0.2
+#interpolate: true
+#stealthchop_threshold: 99999999
+#sense_resistor: 0.075
+
+
+##########################################################################################
+# The bucket hardware configuration. Change the pin to whatever pin you've connected the
 # switch to.
-# 
+#
 [gcode_button bucket]
 pin: ^PG15 # The pullup ( ^ ) is important here.
 press_gcode:

--- a/config/addons/blobifier_hw.cfg
+++ b/config/addons/blobifier_hw.cfg
@@ -42,7 +42,7 @@ maximum_servo_angle: 180
 #rotation_distance: 62.83
 #position_min: 0 # Not supported in Kalico. Leave disabled
 #position_max: 21 # Not supported in Kalico. Leave disabled.
-#homing_speed: 30
+#homing_speed: 20 # Unused in the macros. Just for completeness
 #velocity: 150
 #accel: 1000
 #


### PR DESCRIPTION
Enabled support for the stepper version of the blobifier.

Key features:
1. Autohome tray if needed
2. Disable stepper when blobifier process has finished to prevent unnecessary heating of the stepper
3. Global variable (blobifier type) governing whether stepper or servo blobifier is used.
