### PR TITLE
v4 ported - Blobifier beta feature release

### DIFF
--- a/config/addons/blobifier_beta.cfg
+++ b/config/addons/blobifier_beta.cfg
@@ -1,0 +1,1248 @@
+# Include servo / stepper hardware definition separately to allow for automatic upgrade
+[include blobifier_hw.cfg]
+
+##########################################################################################
+
+# Sample config to be used in conjunction with Blobifier Purge Tray, Bucket & Nozzle 
+# Scrubber mod. Created by Dendrowen (dendrowen on Discord). The Macro is based on a 
+# version, and Nozzle Scrubber is made by Hernsl (hernsl#8860 on Discord). The device is 
+# designed around a Voron V2.4 300mm, but should work for 250mm and 350mm too. This 
+# version only supports the assembly on the rear-left of the bed. If you decide to change 
+# that, please consider contributing to the project by creating a pull request with the 
+# needed changes.
+
+# IMPORTANT: The rear-left part of your bed becomes unusable by this mod because the 
+#            toolhead needs to lower down to 0. Be sure not to use the left-rear 130x35mm.
+
+# The goals of this combination of devices is to dispose of purged filament during a 
+# multicolored print without the need of a purge block and without the flurries of
+# filament poops consuming your entire 3D printer room. The Blobifier achieves that by
+# purging onto a retractable tray which causes the filament to turn into a tiny blob 
+# rather then a large spiral. This keeps the waste relatively small. The bucket should be
+# able to account for up to 200 filament swaps (for the 300mm V2).
+
+# The Blobifier uses some room at the back-left side of your printer, depending on your
+# printer limits and positions. (usually max_pos.y - toolhead_y and brush_start + 
+# brush_width + toolhead_x). If you do place objects within this region, Blobifier will
+# skip purging automatically. It does this by extending the EXCLUDE_OBJECT_* macro's, so
+# make sure you have exclude objects enabled in your slicer.
+
+# If your using Blobifier in conjunction with the filament cutter on the stealthburner
+# toolhead, you can place the pin at max_pos.y - 7 (e.g., max pos y is 307, place it at
+# 300). The pin will then poke through the cavity in your toolhead. (Be careful with 
+# manually moving the toolhead. I have broken many filament cutter pins)
+
+# It is advised to use the start_gcode from Happy Hare. Then you will be able to fully 
+# and efficiently use this mod. Check the Happy Hare document at gcode_preprocessing.md 
+# in the Happy Hare github for more details.
+
+###################################### DISCLAIMER ########################################
+
+# You, and you alone, are responsible for the correct execution of these macros and 
+# gcodes. Any damage that may occur to your machine remains your responsibility. 
+# Especially when executing this macro for the first few times, keep an eye on your 
+# printer and the 
+# emergency stop.
+
+##########################################################################################
+
+##########################################################################################
+# Main macro. Call this from the purge_macro setting in 'mmu_parameters.cfg'. Previously
+# it was suggested to hook in via the post_load macro, but that method is now deprecated
+# and can lead to synchroniztion/servo movement issues.
+#
+# purge_macro : `BLOBIFIER`
+#
+# Notes on parameters:
+# PURGE_LENGTH=[float] (optional) The length to purge. If omitted (default) it will check
+#                      the purge_volumes matrix or variable_purge_length. This can be used
+#                      to override and for testing.
+#
+[gcode_macro BLOBIFIER]
+
+# ========================================================================================
+# ==================== HOOKS & EXTENSIONS ================================================
+# ========================================================================================
+# User extension macros. Set these to the name of a gcode macro to have it called at
+# specific points during the blobifier sequence. Leave empty to disable.
+
+# Called at the very start, after state save. Call any custom park routines here, 
+# for example to park on a gantry mounted nozzle leak stop
+variable_user_pre_blobifier_extension: ""       
+# Set this to the name of the macro that handles nozzle cleaning after purging 
+# BUT BEFORE LIFTING Z. The macro is responsible for its own safe descend checks and 
+# Z movement. BLOBIFIER_CLEAN is the stock macro for a bed-mounted brush. 
+# Leave empty for gantry mounted brush
+variable_clean_macro: "BLOBIFIER_CLEAN"
+# Called after purging is done and clean macro above is executed but BEFORE RESTORING Z. 
+# If using a gantry mounted nozzle leak stop, use this hook for your custom macro 
+# to park the nozzle on the leak stop before restoring z. If not, leave empty.
+variable_user_post_purge_extension: ""
+# Called AFTER RESTORING Z. Use this hook for nozzle cleaning on a gantry mounted brush 
+# after Z is restored and before print resumes. If not, leave empty.   
+variable_user_post_blobifier_extension: ""      
+
+# ========================================================================================
+# ==================== HARDWARE & GENERAL ================================================
+# ========================================================================================
+# Blobifier tray actuator type: "servo" or "stepper"
+# Set to "stepper" if using a manual_stepper driven tray instead of a servo.
+# Make sure the matching hardware section is enabled in blobifier_hw.cfg
+variable_blobifier_type: "servo"
+
+# Klipper firmware variant: "klipper" or "kalico"
+# Kalico uses integer STOP_ON_ENDSTOP values while
+# mainline Klipper uses string values. Set this to match your firmware.
+# Relevant only for stepper blobifier.
+variable_firmware: "klipper"
+
+# ATTENTION: MUST CALIBRATE
+variable_toolhead_x: 70                 # From the nozzle to the left of your toolhead
+variable_toolhead_y: 50                 # From the nozzle to the front of your toolhead
+
+# Travel speeds (mm/min)
+variable_travel_spd_xy:     10000          # Travel speed along x and y-axis
+variable_travel_spd_z:       1000          # Travel speed along z axis
+
+# Blobifier sends the toolhead to the maximum y position during purge operations and
+# minimum x position during shake operations. This can cause issues when skew correction
+# is set up. If you have skew correction enabled and get 'move out of range' errors
+# regarding blobifier while skew is enabled, try increasing this value. Keep the
+# adjustments small though! (0.1mm - 0.5mm) and increase it until it works.
+variable_skew_correction: 0.1
+
+# Offset subtracted from the Y max position to position the toolhead during purging.
+# To calibrate, move the toolhead to the rearmost of your printer (Max Y) and observe 
+# whether it is centred over the blobifier tray. If the toolhead is towards the rear increase
+# this value. If towards the front, decrease. 
+# Value must be greater than or equal to zero, with zero allowing the toolhead to go to Max Y.
+variable_y_offset: 0
+
+# This macro will prevent a gcode movement downward while 'blobbing' if there might be a
+# print in the way (e.g. You print something large and need the area where Blobifier does
+# its... 'business'). However, at low heights (or at print start) this might not be
+# desireable. You can force a 'safe descend' with this variable. Keep in mind that the
+# height of the print is an estimation based on previous heights and certain assumptions
+# so it might be wise to include a safety margin of 0.2mm
+variable_force_safe_descend_height_until: 1.0
+
+# ========================================================================================
+# ==================== TRAY POSITIONS ====================================================
+# ========================================================================================
+# Location of where to purge. The tray is 15mm in length, so if you assemble it against
+# the side of the bed (default), 7mm is a good location (approx. half way on the tray)
+variable_purge_x: 7
+
+
+# ATTENTION: MUST CALIBRATE
+# Height of the tray. If it's below your bed, give this a negative number equal to the
+# difference. If it's above your bed, give it a positive number. You can find this number
+# by homing, optional QGL or equivalent, nozzle bed probing, and moving you toolhead above 
+# the tray, and lowering it with the paper method.
+variable_tray_top: 0.7 # Must calibrate based on your setup. Default value may not apply
+
+# --- Servo tray ---
+variable_tray_angle_out: 0
+variable_tray_angle_in: 180
+# Increase this value if the servo doesn't have enough time to fully retract or extend.
+# Approx. 500ms is sufficient for the MG90S servo to extend / retract fully.
+variable_dwell_time: 500
+
+# --- Stepper tray ---
+# Positions in mm for the manual_stepper.
+# tray_pos_out: extended position, tray_pos_in: retracted/home position
+variable_tray_pos_out: 21
+variable_tray_pos_in: 0
+variable_tray_stepper_speed: 110           # Speed (mm/s) for stepper tray movements
+
+# ========================================================================================
+# ==================== BRUSH / NOZZLE CLEANING ===========================================
+# ========================================================================================
+# These parameters define the size of the brush. Update as necessary. A visual reference
+# is provided below.
+#
+#                  ←   brush_width   →
+#                   _________________
+#                  |                 |  ↑                Y position is acquired from your
+#  brush_start (x) |                 | brush_depth       stepper_y position_max. Adjust
+#                  |_________________|  ↓                your brush physically in Y so
+#                          (y)                           that the nozzle scrubs within the
+#                      brush_front                       brush.
+# __________________________________________________________
+#                     PRINTER FRONT
+#
+
+# ATTENTION: MUST CALIBRATE 
+# Brush section is applicable if using bed mounted brush.
+# If using gantry mounted brush / nozzle stop you need to set the variable_brush_start to 
+# the position of your nozzle stop.
+
+# Start X location of the brush. Indicative defaults for 250, 300 and 350mm are provided below.
+# Uncomment as necessary
+#variable_brush_start:          34  # For 250mm build
+variable_brush_start:           67  # For 300mm build
+#variable_brush_start:          84  # for 350mm build
+
+variable_brush_width: 35 # in MM on X axis
+
+# Adjust this so that your nozzle scrubs within the brush. Be careful not to go too low!
+# Start out with a high value (like, 6) and go down from there.
+# Set this to None if you have a gantry mounted brush and do not want move Z axis for brushing.
+variable_brush_top:             6		   # Z position for the brush top
+
+variable_clearance_z:           2          # Z clearance above brush when traveling
+variable_wipe_qty:              2          # Number of complete wipe passes
+variable_wipe_spd_xy:       10000          # Nozzle wipe speed in mm/min
+
+# Offset subtracted from the y max to perform brushing.
+variable_brush_y_offset: 0
+
+# The acceleration to use when wiping. If set to 0, uses the current acceleration.
+variable_brush_accel: 0
+
+# ========================================================================================
+# ==================== PURGE LENGTH TUNING ===============================================
+# ========================================================================================
+# The absolute minimum to purge in mm, even if you don't changed tools. This is to prime the
+# nozzle before printing. Set this to match roughly 2x your hotend meltzone length
+variable_purge_length_minimum: 54
+
+# The maximum amount of filament (in mm) to purge in a single blob. Blobifier will
+# automatically purge multiple blobs if the purge amount exceeds this.
+variable_purge_length_maximum: 150
+
+# Default purge length to fall back on when neither the tool map purge_volumes or
+# parameter PURGE_LENGTH is set.
+variable_purge_length: 290
+
+# Multiply down the slicer emmited values by this % value below. 
+# It is strongly recommended to set an appropriate purge multiplier in your slicer instead
+# of adjusting the value below. 
+variable_purge_length_modifier: 1.0
+
+# Fixed length of filament to add after the purge volume calculation. Happy Hare already
+# shares info on the extra amount of filament to purge based on known residual filament,
+# tip cutting fragment and initial retraction setting. However this setting can add a fixed
+# amount on top on that if necessary.
+# It is strongly recommended to leave this value at 0 and tune your slicer purge volume 
+# and nozzle volume.
+# If you would like to use this value still:
+#   INCREASE: When the dark to light swaps are good, but light to dark aren't.
+#   DECREASE: When the light to dark swaps are good, but dark to light aren't. Don't
+#     forget to increase the purge_length_modifier
+variable_purge_length_addition: 0
+
+# Whether to add extruder_filament_remaining to the purge length calculation.
+# If your slicer purge matrix already accounts for residual filament in the nozzle,
+# set this to 0 to avoid over-purging. Typically this is set as the nozzle volume in 
+# your slicer extruder settings.
+variable_include_extruder_residual: 0
+
+# ========================================================================================
+# ==================== BLOB TUNING =======================================================
+# ========================================================================================
+# The following section defines how the purging sequence is executed. This is where you
+# tune the purging to create pretty blobs. Refer to the visual reference for a better
+# understanding. The visual is populated with example values. Below are some guides
+# provided to help with tuning.
+#
+#                          \_____________/
+#                             |___|___|
+#                                \_/            ______________  < End of third iteration.
+#                                / \                                  HEIGHT:   3 x iteration_z_raise - (2 + 1) x iteration_z_change  (3 x 5 - 2 x 1.2 = 11.4)
+#                               |   |                                 EXTRUDED: 3 x max_iteration_length                              (3 x 50 = 150)
+#                              /     \          ______________  < End of second iteration.
+#                             |       \                               HEIGHT:   2 x iteration_z_raise - 1 x iteration_z_change        (2 x 5 - 1 x 1.2 = 8.8)
+#                            /         |                              EXTRUDED: 2 x max_iteration_length                              (2 x 50 = 100)
+#                           |           \       ______________  < End of first iteration.
+#                          /             \                            HEIGHT:   1 x iteration_z_raise                                 (1 x 5 = 5)
+#                         |               |                           EXTRUDED: 1 x max_iteration_length                              (1 x 50 = 50)
+#___________               \             /      ______________  < Start height of the nozzle. default value: 1.5mm
+#           |_______________\___________/_      ______________  < Bottom of the tray
+#           |_____________________________|
+#           |
+#
+########################### BLOB TUNING ##############################
+# +-------------------------------------+----------------------------+
+# |  Filament sticks to the nozzle at   | Incr. purge start          |
+# |    initial purge (first few mm)     |                            |
+# +-------------------------------------+----------------------------+
+# |  Filament scoots out from under     | Incr. temperature          |
+# |  the nozzle at the first iteration  | Decr. z_raise              |
+# |                                     | Incr. purge_length_maximum |
+# +-------------------------------------+----------------------------+
+# |  Filament scoots out from under the | Decr. purge_spd            |
+# |  the nozzle at later iterations     | Decr. z_raise_exp          |
+# |                                     | Decr. z_raise              |
+# |                                     | Incr. purge_length_maximum |
+# +-------------------------------------+----------------------------+
+# |  Filament sticks to the nozzle at   | Incr. z_raise_exp          |
+# |         later iterations            |     (Not above 1)          |
+# +-------------------------------------+----------------------------+
+#
+variable_purge_spd: 290                 # Speed, in mm/min, of the purge.
+variable_purge_temp_min: 200            # Minimum nozzle purge temperature.
+
+# The height to raise the nozzle above the tray before purging. This allows any built up
+# pressure to escape before the purge.
+variable_purge_start: 0.2
+
+# The amount to raise Z
+variable_z_raise: 9.8
+
+# As the nozzle gets higher and the blob wider, the Z raise needs to be reduced, this
+# follows the following formula:
+#            (extruded_amount/max_purge_length)^z_raise_exp * z_raise
+# 1 is linear, below 1 will cause z to raise less quickly over time, above 1 will make it
+# raise quicker over time. 0.85 is a good starting point and you should not have it above 1
+variable_z_raise_exp: 0.90
+
+# Lift the nozzle slightly after creating the blob to release pressure on the tray.
+variable_eject_hop: 6.0
+
+# Dwell time (ms) after purging and before cleaning to relieve pressure from the nozzle.
+variable_pressure_release_time: 500
+
+# Amount of filament (mm) extruded per pulse within a blob. Each pulse is one Z-raise
+# increment. Set this value close to the meltzone volume / 2 to ensure
+# a meaningful flush has taken place before retraction
+variable_purge_pulse_size: 10
+
+# ========================================================================================
+# ==================== RETRACTION TUNING =================================================
+# ========================================================================================
+# Total retract distance (mm) between blobs. Retracting filament into the cold zone
+# between blobs reduces required purge volume as it helps scrape the nozzle walls clean.
+# Larger values pull filament further from the melt zone and into the heatbreak.
+# Set this to be less than your hotend's heatbreak length. If you observe clogs or extruder 
+# skipping, reduce. Minimum is 2mm.
+variable_retract_between_blobs: 6
+
+# Extruder move step size (mm) per retract/de-retract move between blobs. The total retract is split
+# into multiple extruder stepper moves of this size to allow sync feedback to keep up with the motion.
+# The final steps ramp down in speed to ease through the cold zone transition.
+# Leave this at 2mm retraction step unless theres a good reason to change!
+variable_retract_step: 2
+
+# Periodic retract/de-retract during purging to improve color transition. 
+# This pulse occurs every few extrusion cycles within a blob.
+variable_pulse_retract_length: 4          # Length (mm) of the periodic retract. Increase value to improve filament agitation during purge. Do not exceed 5-10mm
+variable_pulse_retract_speed: 2400        # Retract speed (mm/min). Go as fast as your extruder will reliably allow.
+variable_pulse_deretract_speed: 800       # De-retract speed (mm/min) — slower to allow re-melting
+
+# How often (mm of extrusion) the periodic mid-pulse retract fires during purging.
+# Set this to be greater than or equal to your meltzone length.
+variable_purge_retract_interval: 20
+
+# ========================================================================================
+# ==================== FAN CONTROL =======================================================
+# ========================================================================================
+# Set the part cooling fan speed during purging and during the blob depositing process.
+# Low fan speeds during purging help ensure the pellets are well formed and reduces
+# the probability of the pellets coming unstuck from tray due to material shrinkage.
+# Setting the blob depositing fan speed to high (100%) helps freeze the blob, unstick
+# the blob from the nozzle and shrink it a little allowing for a cleaner blob depositing.
+variable_part_cooling_fan:  0.3             # Fan speed during purging (-1 unchanged, 0 off, 0.1-1.0 %)
+variable_part_cooling_fan_blob_deposit: 1   # Fan speed during blob deposit (-1 unchanged, 0 off, 0.1-1.0 %)
+
+# Define the part fan name if you are using a fan other than [fan]
+# Applies to [fan_generic] or other fan definitions
+# Example: if using auxiliary fan control in Orcaslicer, set to "fan_generic fan0"
+variable_fan_name: "fan"
+
+# ========================================================================================
+# ==================== BUCKET ============================================================
+# ========================================================================================
+# Maximum number of blobs that fit in the bucket. Pauses the print if it exceeds this
+# number. A tray for a 350 printer can hold approx. 700 blobs.
+variable_max_blobs: 400
+
+# Enable the bucket shaker. You need to have the shaker.stl installed
+variable_enable_shaker: 1
+
+# Shaker position offset in X (relative to zero)
+# Allows negative positions. Add skew_correction separately if needed.
+variable_shaker_pos_x: 0
+
+# The number of back-and-forth motions of one shake
+variable_bucket_shakes: 20
+
+# During shaking acceleration can often be higher because you don't need to keep print
+# quality in mind. Higher acceleration helps better with dispersing the blobs.
+variable_shake_accel: 8000
+
+# The frequency at which to shake the bucket. A decimal value ranging from 0 to 1, where 0
+# is never, and 1 is every time. This way the shaking occurs more often as the bucket
+# fills up. Sensible values range from 0.75 to 0.95
+variable_bucket_shake_frequency: 0.95
+
+# Height of the shaker arm. If your hotend hits your tray during shaking, increase.
+variable_shaker_arm_z: 2
+
+gcode:
+
+  # ======================================================================================
+  # ==================== RECORD STATE (INCL. FANS, SPEEDS, ETC...) =======================
+  # ======================================================================================
+
+  # General state
+  SAVE_GCODE_STATE NAME=BLOBIFIER_state
+
+  # User pre-blobifier extension hook
+  {% if user_pre_blobifier_extension %}
+    {user_pre_blobifier_extension}
+  {% endif %}
+
+  # ======================================================================================
+  # ==================== CHECK HOMING STATUS =============================================
+  # ======================================================================================
+  
+  {% if "xyz" not in printer.toolhead.homed_axes %}
+    RESPOND MSG="BLOBIFIER: Not homed! Home xyz before blobbing"
+  {% elif printer.quad_gantry_level and printer.quad_gantry_level.applied == False %}
+    RESPOND MSG="BLOBIFIER: QGL not applied! run quad_gantry_level before blobbing"
+  {% else %}
+    
+
+    # Always backup part cooling fan speed
+    {% set fan = fan_name|string %}
+    # Save the part cooling fan speed to be enabled again later
+    {% set backup_fan_speed = (printer[fan].speed if printer[fan] is defined else printer.fan.speed) %}
+    
+    # Part cooling fan set for purging
+    {% if part_cooling_fan >= 0 %}
+      # Set part cooling fan speed
+      M106 S{part_cooling_fan * 255}
+    {% endif %}
+
+    # Set feedrate to 100% for correct speed purging
+    {% set backup_feedrate = printer.gcode_move.speed_factor %}
+    M220 S100
+    
+    # Backup and zero Pressure Advance during blobbing
+    {% set backup_pa = printer.extruder.pressure_advance|default(0.0)|float %}
+    RESPOND MSG={"'BLOBIFIER: Setting PA to zero (was %.4f)'" % (backup_pa)}
+    SET_PRESSURE_ADVANCE ADVANCE=0
+
+
+    # ======================================================================================
+    # ==================== DEFINE BASIC VARIABLES ==========================================
+    # ======================================================================================
+    
+    {% set sequence_vars = printer['gcode_macro _MMU_SEQUENCE_VARS'] %}
+    {% set park_vars = printer['gcode_macro _MMU_PARK'] %}
+    {% set filament_diameter = printer.configfile.config.extruder.filament_diameter|float %}
+    {% set filament_cross_section = (filament_diameter/2) ** 2 * 3.1415 %}
+    {% set from_tool = printer.mmu.last_tool %}
+    {% set to_tool = printer.mmu.tool %}
+    {% set bl_count = printer['gcode_macro _BLOBIFIER_COUNT'] %}
+    {% set pos = printer.gcode_move.gcode_position %}
+    {% set safe = printer['gcode_macro _BLOBIFIER_SAFE_DESCEND'] %}
+    {% set ignore_safe = safe.print_height < force_safe_descend_height_until %}
+    {% set restore_z = [printer['gcode_macro BLOBIFIER_PARK'].restore_z,pos.z]|max %}
+    {% set pos_max = printer.toolhead.axis_maximum %}
+    {% set position_y = pos_max.y - skew_correction - y_offset %}
+
+    # Get purge volumes from the slicer (if set up right. see 
+    # https://github.com/moggieuk/Happy-Hare/wiki/Gcode-Preprocessing)
+    {% set pv = printer.mmu.slicer_tool_map.purge_volumes %}
+    
+    # ======================================================================================
+    # ==================== DETERMINE PURGE LENGTH ==========================================
+    # ======================================================================================
+
+    {% if params.PURGE_LENGTH %} # =============== PARAM PURGE LENGTH ======================
+      {action_respond_info("BLOBIFIER: param PURGE_LENGTH provided")}
+      {% set purge_len = params.PURGE_LENGTH|float %}
+    {% elif from_tool == to_tool and to_tool >= 0 %} # ==== TOOL DIDN'T CHANGE =============
+      {action_respond_info("BLOBIFIER: Tool didn't change (T%s > T%s), %s" % (from_tool, to_tool, "priming" if purge_length_minimum else "skipping"))}
+      {% set purge_len = 0 %}
+
+    {% elif pv %} # ============== FETCH FROM HAPPY HARE (LIKELY FROM SLICER) ==============
+      {% if from_tool < 0 and to_tool >= 0%}
+        {action_respond_info("BLOBIFIER: from tool unknown. Finding largest value for T? > T%d" % to_tool)}
+        {% set purge_vol = pv|map(attribute=to_tool)|max %}
+      {% elif to_tool < 0 %}
+        {action_respond_info("BLOBIFIER: tool(s) unknown. Finding largest value")}
+        {% set purge_vol = pv|map('max')|max %}
+      {% else %}
+        {% set purge_vol = pv[from_tool][to_tool]|float * purge_length_modifier %}
+        {action_respond_info("BLOBIFIER: Swapped T%s > T%s" % (from_tool, to_tool))}
+      {% endif %}
+      {% set purge_len = purge_vol / filament_cross_section %}
+      {% set residual = printer.mmu.extruder_filament_remaining if include_extruder_residual else 0 %}
+      {% set purge_len = purge_len + residual + purge_length_addition %}
+
+    {% else %} # ========================= USE CONFIG VARIABLE =============================
+      {action_respond_info("BLOBIFIER: No toolmap or PURGE_LENGTH. Using default")}
+      {% set residual = printer.mmu.extruder_filament_remaining if include_extruder_residual else 0 %}
+      {% set purge_len = purge_length|float + residual %}
+    {% endif %}
+
+    # ==================================== APPLY PURGE MINIMUM =============================
+    {% set purge_len = [purge_len,purge_length_minimum]|max|round(0, 'ceil')|int %}
+    # Add retracted length after minimum — this is mechanical overhead, not purge volume
+    {% set purge_len = purge_len + park_vars.retracted_length %}
+    {action_respond_info("BLOBIFIER: Purging %dmm of filament" % (purge_len))}
+
+    # ======================================================================================
+    # ==================== PURGING SEQUENCE ================================================
+    # ======================================================================================
+
+    # Set to absolute positioning.
+    G90
+
+    # Check for purge length and purge if necessary.
+    {% if purge_len|float > 0 %}
+
+      # ====================================================================================
+      # ==================== POSITIONING ===================================================
+      # ====================================================================================
+      
+      # Retract the tray so it is not in the way
+      BLOBIFIER_SERVO POS=in
+
+      # Move to the assembly, first a bit more to the right (brush_start) to avoid a 
+      # potential filametrix pin if it's not already on the same Y coordinate.
+      {% if printer.toolhead.position.y != position_y %}
+        G1 X{[brush_start - 20, 30]|max} Y{position_y} F{travel_spd_xy}
+      {% endif %}
+
+      # ====================================================================================
+      # ==================== BUCKET SHAKE ==================================================
+      # ====================================================================================
+      
+      {% if enable_shaker and (safe.shake or ignore_safe) %}
+        {% if (bl_count.current_blobs + 1) >= bl_count.next_shake %}
+          BLOBIFIER_SHAKE_BUCKET SHAKES={bucket_shakes}
+          _BLOBIFIER_CALCULATE_NEXT_SHAKE
+        {% endif %}
+      {% endif %}
+      
+      # ====================================================================================
+      # ==================== POSITIONING ON TRAY ===========================================
+      # ====================================================================================
+      {% if safe.tray or ignore_safe %}
+        G1 Z{tray_top + purge_start} F{travel_spd_z}
+      {% endif %}
+
+      # Move over to the tray after z change (For cases when the tool is lower than the tray)
+      G1 X{purge_x} F{travel_spd_xy}
+
+      # Extend the tray
+      BLOBIFIER_SERVO POS=out
+
+      # ====================================================================================
+      # ==================== HEAT HOTEND ===================================================
+      # ====================================================================================
+      
+      {% if printer.extruder.temperature < purge_temp_min %}
+        {% if printer.extruder.target < purge_temp_min %}
+          M109 S{purge_temp_min}
+        {% else %}
+          TEMPERATURE_WAIT SENSOR=extruder MINIMUM={purge_temp_min}
+        {% endif %}
+      {% endif %}
+
+      # ====================================================================================
+      # ==================== START ITERATING ===============================================
+      # ====================================================================================
+      
+      # Calculate total number of iterations based on the purge length and the max_iteration 
+      # length.
+      {% set blobs = (purge_len / purge_length_maximum)|round(0, 'ceil')|int %}
+      {% set purge_per_blob = purge_len|float / blobs %}
+      {% set retracts_per_blob = (purge_per_blob / purge_retract_interval)|round(0, 'ceil')|int %}
+      {% set purge_per_retract = (purge_per_blob / retracts_per_blob)|int %}
+      {% set pulses_per_retract = (purge_per_blob / retracts_per_blob / purge_pulse_size)|round(0, 'ceil')|int %}
+      {% set pulses_per_blob = (purge_per_blob / purge_pulse_size)|round(0, 'ceil')|int %}
+      {% set purge_per_pulse = purge_per_blob / pulses_per_blob %}
+      {% set pulse_time_constant = purge_per_pulse * 0.95 / purge_spd / (purge_per_pulse * 0.95 / purge_spd + purge_per_pulse * 0.05 / 50) %}
+      {% set pulse_duration = purge_per_pulse / purge_spd %}
+
+      # Repeat the process until purge_len is reached
+      {% for blob in range(blobs) %}
+        RESPOND MSG={"'BLOBIFIER: Blob %d of %d (%.1fmm)'" % (blob + 1, blobs, purge_per_blob)}
+
+        {% if safe.tray or ignore_safe %}
+          G1 Z{tray_top + purge_start} F{travel_spd_z}
+        {% endif %}
+
+        # relative positioning
+        G91 
+        # relative extrusion
+        M83
+        
+        # Un-retract other than the first purge, to re-prime nozzle.
+        # When multiple steps are used, feed fast through cold zone then slow into the
+        # melt zone to allow re-melting.
+        {% if not loop.first %}
+          M400
+          {% set steps = (retract_between_blobs / retract_step)|round(0, 'ceil')|int %}
+          {% set fast_speed = sequence_vars.retract_speed * 60 %}
+          {% set slow_speed = (sequence_vars.retract_speed * 60 * 0.5)|int %}
+          {% for step in range(steps) %}
+            {% if steps == 1 %}
+              __BLOBIFIER_EXTRUDER_MOVE E={retract_step} EXTRUDER_SPEED={fast_speed}
+            {% elif loop.revindex <= 2 %}
+              __BLOBIFIER_EXTRUDER_MOVE E={retract_step} EXTRUDER_SPEED={slow_speed}
+            {% else %}
+              __BLOBIFIER_EXTRUDER_MOVE E={retract_step} EXTRUDER_SPEED={fast_speed}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+
+        # Purge filament in a pulsating motion to purge the filament quicker and better
+        {% for pulse in range(pulses_per_blob) %}
+          # Calculations to determine z-speed
+          {% set purged_this_blob = pulse * purge_per_pulse %}
+          {% set z_last_pos = purge_start + ((purged_this_blob)/purge_length_maximum)**z_raise_exp * z_raise %}
+          {% set z_pos = purge_start + ((purged_this_blob + purge_per_pulse)/purge_length_maximum)**z_raise_exp * z_raise %}
+          {% set z_up = z_pos - z_last_pos %}
+          {% set speed = z_up / pulse_duration %}
+
+          # Purge quickly
+          __BLOBIFIER_EXTRUDER_MOVE EXTRUDER_SPEED={speed} E={purge_per_pulse * 0.95} NEW_Z={z_up * pulse_time_constant}
+          # Purge a tiny bit slowly
+          __BLOBIFIER_EXTRUDER_MOVE EXTRUDER_SPEED={speed} E={purge_per_pulse * 0.05} NEW_Z={z_up * (1 - pulse_time_constant)}
+
+          # Retract and de-retract filament periodically for thorough color transition
+          {% if pulse % pulses_per_retract == 0 and pulse > 0 %}
+            __BLOBIFIER_EXTRUDER_MOVE E=-{pulse_retract_length} EXTRUDER_SPEED={pulse_retract_speed}
+            __BLOBIFIER_EXTRUDER_MOVE E={pulse_retract_length}  EXTRUDER_SPEED={pulse_deretract_speed}
+          {% endif %}
+
+        {% endfor %}
+        
+        # ==================================================================================
+        # ==================== DEPOSIT BLOB ================================================
+        # ==================================================================================
+        
+        # Perform retraction
+        {% if loop.last %}
+          # This is the last blob - retract to match what Happy Hare is expecting
+          __BLOBIFIER_EXTRUDER_MOVE E=-{park_vars.retracted_length} EXTRUDER_SPEED={sequence_vars.retract_speed * 60}
+        {% else %}
+          # Retract between blobs in steps to allow sync feedback to track the motion.
+          # Speed ramps down on the final step to ease through the cold zone transition.
+          {% set steps = (retract_between_blobs / retract_step)|round(0, 'ceil')|int %}
+          {% set fast_speed = sequence_vars.retract_speed * 60 %}
+          {% set slow_speed = (sequence_vars.retract_speed * 60 * 0.5)|int %}
+          {% for step in range(steps) %}
+            {% if steps == 1 or not loop.last %}
+              __BLOBIFIER_EXTRUDER_MOVE E=-{retract_step} EXTRUDER_SPEED={fast_speed}
+            {% else %}
+              __BLOBIFIER_EXTRUDER_MOVE E=-{retract_step} EXTRUDER_SPEED={slow_speed}
+            {% endif %}
+          {% endfor %}
+          # Quick push-pull to help solidify the tip before the next blob
+          # (only when using multi-step retracts with larger retract distances)
+          {% if steps > 1 %}
+            __BLOBIFIER_EXTRUDER_MOVE E={pulse_retract_length}  EXTRUDER_SPEED={pulse_deretract_speed}
+            __BLOBIFIER_EXTRUDER_MOVE E=-{pulse_retract_length} EXTRUDER_SPEED={pulse_retract_speed}
+          {% endif %}
+        {% endif %}
+
+
+        {% if safe.tray or ignore_safe %}
+          # Set blob depositing fan speed
+          {% if part_cooling_fan_blob_deposit >= 0 %}
+            M106 S{(part_cooling_fan_blob_deposit * 255)|int}
+          {% endif %}
+          
+          # Raise z a bit to relieve pressure on the blob preventing it to go sideways
+          G1 Z{eject_hop} F{travel_spd_z}
+          # Retract the tray
+          BLOBIFIER_SERVO POS=in
+          # Move the toolhead down to purge_start height lowering the blob below the tray
+          G90 # absolute positioning
+          G1 Z{tray_top} F{travel_spd_z}
+
+          # Adjust tension and centre sensor before pressure release to settle sync
+          # feedback and avoid accidentally triggering FlowGuard runout
+          {% if printer.mmu.sync_feedback_enabled %}
+            MMU_SYNC_FEEDBACK ADJUST_TENSION=1
+          {% endif %}
+
+          # Dwell to release pressure before cutting the blob off
+          M400
+          G4 P{pressure_release_time}
+          
+          # Extend the tray to 'cut off' the blob and prepare for the next blob
+          BLOBIFIER_SERVO POS=out
+          BLOBIFIER_SERVO POS=in
+          BLOBIFIER_SERVO POS=out
+          # Keep track of the # of blobs
+          _BLOBIFIER_COUNT
+          
+          # Set purging fan speed
+          {% if part_cooling_fan < 0 %} 
+            # If part cooling fan is unchanged and equal to print speed fan
+            M106 S{(backup_fan_speed * 255)|int}
+          {% elif part_cooling_fan >= 0 %}
+            # If specific part cooling fan speed is set
+            M106 S{(part_cooling_fan * 255)|int}
+          {% endif %}
+          
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+
+    {% if safe.tray or ignore_safe %}
+      G1 Z{tray_top + 1} F{travel_spd_z}
+    {% endif %}
+    # Call the configured clean macro (handles its own safe descend checks)
+    {clean_macro}
+
+    # User post-purge extension hook (before restoring Z)
+    {% if user_post_purge_extension %}
+      {user_post_purge_extension}
+    {% endif %}
+
+    # ======================================================================================
+    # ==================== RESTORE STATE ===================================================
+    # ======================================================================================
+
+    G90 # absolute positioning
+    G1 Z{restore_z} F{travel_spd_z}
+    
+    # Reset part cooling fan unconditionally
+    M106 S{(backup_fan_speed * 255)|int}
+    
+    # Restore feedrate
+    M220 S{(backup_feedrate * 100)|int}
+    
+    # Restore Pressure Advance
+    RESPOND MSG={"'BLOBIFIER: Restoring PA to %.4f'" % (backup_pa)}
+    SET_PRESSURE_ADVANCE ADVANCE={backup_pa}
+  {% endif %}
+
+  # Retract the tray
+  BLOBIFIER_SERVO POS=in
+
+  # Disable stepper motor after purge is complete to save power and reduce heat
+  {% if printer['gcode_macro BLOBIFIER'].blobifier_type == "stepper" %}
+    MANUAL_STEPPER STEPPER=stepper_blobifier ENABLE=0 SYNC=1
+  {% endif %}
+
+  RESTORE_GCODE_STATE NAME=BLOBIFIER_state
+  
+  # User post-blobifier extension hook (after restoring Z and state)
+  {% if user_post_blobifier_extension %}
+    {user_post_blobifier_extension}
+  {% endif %}
+
+
+##########################################################################################
+# Extrusion helper that allows for check of "runout/clog" indicator
+#
+[gcode_macro __BLOBIFIER_EXTRUDER_MOVE]
+description: Extruder move (optional Z) with clog/runout guard
+# Parameters:
+#   EXTRUDER_SPEED in mm/min
+#   E             in mm
+#   NEW_Z         in mm
+gcode:
+    {% set extruder_speed = params.EXTRUDER_SPEED|float %}
+    {% set E = params.E|float %}
+    {% set new_z = params.NEW_Z|default(None) %}
+
+    {% set clog_runout_detected = printer.mmu.clog_runout_detected|default(false)|lower == 'true' %}
+
+    {% if not clog_runout_detected %}
+        {% if new_z is not none %}
+            G1 Z{new_z} E{E} F{extruder_speed}
+        {% else %}
+            G1 E{E} F{extruder_speed}
+        {% endif %}
+    {% endif %}
+
+##########################################################################################
+# Default nozzle cleaning macro for bed-mounted brush.
+# This macro is called via variable_clean_macro and can be swapped out for custom
+# cleaning routines (gantry-mounted brush, nozzle stop, etc.)
+# The clean macro is responsible for its own safe descend checks.
+#
+[gcode_macro BLOBIFIER_CLEAN]
+gcode:
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+  {% set safe = printer['gcode_macro _BLOBIFIER_SAFE_DESCEND'] %}
+  {% set ignore_safe = safe.print_height < bl.force_safe_descend_height_until %}
+
+  {% if safe.brush or ignore_safe %}
+    {% set pos_max = printer.toolhead.axis_maximum %}
+    {% set position_y = pos_max.y - bl.skew_correction - bl.brush_y_offset %}
+    {% set original_accel = printer.toolhead.max_accel %}
+    {% set original_minimum_cruise_ratio = printer.toolhead.minimum_cruise_ratio %}
+    {% set pos = printer.gcode_move.gcode_position %}
+    {% set min_z = (bl.brush_top or 0) + bl.clearance_z %}
+
+    SAVE_GCODE_STATE NAME=BLOBIFIER_CLEAN_state
+
+    G90
+
+    {% if bl.brush_accel > 0 %}
+      SET_VELOCITY_LIMIT ACCEL={bl.brush_accel} MINIMUM_CRUISE_RATIO=0.1
+    {% endif %}
+
+    # Ensure we have our clearance...we don't want any bed scraping here!
+    {% if pos.z < min_z %}
+      G1 Z{min_z} F{bl.travel_spd_z}
+    {% endif %}
+    G1 X{bl.brush_start} F{bl.travel_spd_xy}
+    G1 Y{position_y}
+
+    {% if bl.brush_top is not none %}
+      # Ensure clearance above the brush
+      G1 Z{bl.brush_top + bl.clearance_z} F{bl.travel_spd_z}
+
+      # Move nozzle down into brush.
+      G1 Z{bl.brush_top} F{bl.travel_spd_z}
+    {% endif %}
+
+    SET_VELOCITY_LIMIT ACCEL={original_accel} MINIMUM_CRUISE_RATIO={original_minimum_cruise_ratio}
+
+    # Perform wipe
+    {% for wipes in range(1, (bl.wipe_qty + 1)) %}
+       G1 X{bl.brush_start + bl.brush_width} F{bl.wipe_spd_xy}
+       G1 X{bl.brush_start} F{bl.wipe_spd_xy}
+    {% endfor %}
+
+    # Move away from the brush, but not onto the tray or in front of the filametrix cutter pin
+    G1 X{[bl.brush_start - 20, 30]|max} F{bl.travel_spd_xy}
+
+    RESTORE_GCODE_STATE NAME=BLOBIFIER_CLEAN_state
+  {% else %}
+    # Not safe to descend to brush — just move X clear of the tray
+    G1 X{bl.brush_start} F{bl.travel_spd_xy}
+  {% endif %}
+
+
+
+##########################################################################################
+# Park the nozzle on the tray to prevent oozing during filament swaps. Place this 
+# extension in the post_form_tip extension in mmu_macro_vars.cfg:
+#   variable_user_post_form_tip_extension: "BLOBIFIER_PARK"
+#
+[gcode_macro BLOBIFIER_PARK]
+variable_restore_z: 0
+gcode:
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+  {% set pos = printer.gcode_move.gcode_position %}
+  {% set safe = printer['gcode_macro _BLOBIFIER_SAFE_DESCEND'] %}
+  {% set pos_max = printer.toolhead.axis_maximum %}
+  {% set position_y = pos_max.y - bl.skew_correction - bl.y_offset %}
+
+  SET_GCODE_VARIABLE MACRO=BLOBIFIER_PARK VARIABLE=restore_z VALUE={pos.z}
+
+  SAVE_GCODE_STATE NAME=blobifier_park_state
+
+  {% if "xyz" in printer.toolhead.homed_axes and printer.quad_gantry_level and printer.quad_gantry_level.applied %}
+    G90
+
+    # Home stepper tray if in stepper mode and stepper is disabled
+    {% if bl.blobifier_type == "stepper" and not printer.stepper_enable.steppers['manual_stepper stepper_blobifier'] %}
+      _BLOBIFIER_HOME_STEPPER
+    {% endif %}
+
+    # Retract the tray
+    BLOBIFIER_SERVO POS=in
+
+    G1 X{[bl.brush_start - 20, 30]|max} Y{position_y} F{bl.travel_spd_xy}
+    {% if safe.tray or ignore_safe %}
+      G1 Z{bl.tray_top} F{bl.travel_spd_z}
+    {% endif %}
+    G1 X{bl.purge_x} F{bl.travel_spd_xy}
+
+    # Extend the tray
+    BLOBIFIER_SERVO POS=out
+
+  {% else %}
+    RESPOND MSG="Please home (and QGL) before parking"
+  {% endif %}
+
+  RESTORE_GCODE_STATE NAME=blobifier_park_state
+
+##########################################################################################
+# Home the stepper-based blobifier tray. This enables the stepper, sets an assumed
+# position, then homes to the endstop. Called automatically before stepper moves if
+# the stepper is not yet homed. Only relevant when blobifier_type is "stepper".
+#
+[gcode_macro _BLOBIFIER_HOME_STEPPER]
+gcode:
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+  RESPOND MSG="BLOBIFIER: Homing stepper tray"
+  MANUAL_STEPPER STEPPER=stepper_blobifier ENABLE=1 SET_POSITION=30 SYNC=1
+  {% if bl.firmware == "kalico" %}
+    MANUAL_STEPPER STEPPER=stepper_blobifier MOVE=0 SPEED=20 STOP_ON_ENDSTOP=2
+  {% else %}
+    MANUAL_STEPPER STEPPER=stepper_blobifier MOVE=0 SPEED=20 STOP_ON_ENDSTOP=try_home
+  {% endif %}
+
+##########################################################################################
+# Retract or extend the tray
+# POS=[in|out] Retract or extend the tray
+# Works with both servo and stepper blobifier types based on variable_blobifier_type
+#
+[gcode_macro BLOBIFIER_SERVO]
+gcode:
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+  {% set pos = params.POS %}
+
+  {% if bl.blobifier_type == "stepper" %}
+    # === STEPPER MODE ===
+    # If stepper is disabled, it needs homing before any move
+    {% if not printer.stepper_enable.steppers['manual_stepper stepper_blobifier'] %}
+      _BLOBIFIER_HOME_STEPPER
+    {% endif %}
+    {% if pos == "in" %}
+      MANUAL_STEPPER STEPPER=stepper_blobifier MOVE={bl.tray_pos_in} SPEED={bl.tray_stepper_speed} SYNC=1
+    {% elif pos == "out" %}
+      MANUAL_STEPPER STEPPER=stepper_blobifier MOVE={bl.tray_pos_out} SPEED={bl.tray_stepper_speed} SYNC=1
+    {% else %}
+      {action_respond_info("BLOBIFIER: provide POS=[in|out]")}
+    {% endif %}
+  {% else %}
+    # === SERVO MODE ===
+    {% if pos == "in" %}
+      SET_SERVO SERVO=blobifier ANGLE={bl.tray_angle_in}
+      G4 P{bl.dwell_time}
+    {% elif pos == "out" %}
+      SET_SERVO SERVO=blobifier ANGLE={bl.tray_angle_out}
+      G4 P{bl.dwell_time}
+    {% else %}
+      {action_respond_info("BLOBIFIER: provide POS=[in|out]")}
+    {% endif %}
+    SET_SERVO SERVO=blobifier WIDTH=0
+  {% endif %}
+
+##########################################################################################
+# Define exclude objects for those who haven't already
+#
+[exclude_object]
+
+##########################################################################################
+# Overwrite the existing EXCLUDE_OBJECT_DEFINE to also check for safe descend.
+#
+[gcode_macro EXCLUDE_OBJECT_DEFINE]
+rename_existing: _EXCLUDE_OBJECT_DEFINE
+gcode:
+  # only reset on the first object at the beginning of a print
+  {% if printer.exclude_object.objects|length < 1 %}
+    _BLOBIFIER_RESET_SAFE_DESCEND
+  {% endif %}
+  _EXCLUDE_OBJECT_DEFINE {rawparams}
+  _BLOBIFIER_SAFE_DESCEND
+  UPDATE_DELAYED_GCODE ID=BLOBIFIER_SHOW_SAFE_DESCEND DURATION=1
+  
+[delayed_gcode BLOBIFIER_SHOW_SAFE_DESCEND]
+gcode:
+  {% set safe = printer['gcode_macro _BLOBIFIER_SAFE_DESCEND'] %}
+  {action_respond_info(
+    "BLOBIFIER: Safe descend possible:\n - tray:  %s\n - brush: %s\n - shake: %s" % 
+    (
+      "yes" if safe.tray else "no",
+      "yes" if safe.brush else "no",
+      "yes" if safe.shake else "no"
+    )
+  )}
+
+##########################################################################################
+# Use the EXCLUDE_OBJECT_START gcode macro to record the current height
+#
+[gcode_macro EXCLUDE_OBJECT_START]
+rename_existing: _EXCLUDE_OBJECT_START
+gcode:
+  _EXCLUDE_OBJECT_START {rawparams}
+  {% if printer['gcode_macro _BLOBIFIER_SAFE_DESCEND'].first_layer %}
+    SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=first_layer VALUE=False
+    SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=print_height VALUE={printer['gcode_macro _BLOBIFIER_SAFE_DESCEND'].print_layer_height}
+  {% else %}
+    {% set pos = printer.gcode_move.gcode_position %}
+    {% set last_height = printer['gcode_macro _BLOBIFIER_SAFE_DESCEND'].print_previous_height|float %}
+    {% if pos.z > last_height %}
+      {% set last_layer = (pos.z - last_height)|round(2) %}
+      {% set print_height = (pos.z + last_layer)|round(2) %}
+      SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=print_previous_height VALUE={pos.z}
+      SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=print_height VALUE={print_height}
+    {% endif %}
+  {% endif %}
+
+##########################################################################################
+# Reset the safe descend variables.
+#
+[gcode_macro _BLOBIFIER_RESET_SAFE_DESCEND]
+gcode:
+  SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=tray VALUE=True
+  SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=brush VALUE=True
+  SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=shake VALUE=True
+  SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=first_layer VALUE=True
+  SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=print_height VALUE=0
+  SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=print_previous_height VALUE=0
+
+##########################################################################################
+# Determine if it is safe to drop the toolhead (e.g. not hit a print)
+#
+[gcode_macro _BLOBIFIER_SAFE_DESCEND]
+variable_tray: True # Assume it is safe
+variable_brush: True
+variable_shake: True
+variable_first_layer: True
+variable_print_height: 0
+variable_print_previous_height: 0
+variable_print_layer_height: 0.3
+gcode:
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+  {% set pos_max = printer.toolhead.axis_maximum %}
+  {% set position_y = pos_max.y - bl.skew_correction - bl.y_offset %}
+  {% set brush_position_y = pos_max.y - bl.skew_correction - bl.brush_y_offset %}
+  {% set tray = [bl.purge_x + bl.toolhead_x, position_y - bl.toolhead_y] %}
+  {% set brush = [bl.brush_start + bl.brush_width + bl.toolhead_x, brush_position_y - bl.toolhead_y] %}
+  {% set shake = [bl.purge_x + bl.toolhead_x, position_y - bl.toolhead_y - 4] %}
+  {% set objects = printer.exclude_object.objects | map(attribute='polygon') %}
+
+  {% for polygon in objects %}
+    {% for point in polygon %}
+      {% if point[0] < tray[0] and point[1] > tray[1] %}
+        SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=tray VALUE=False
+      {% endif %}
+      {% if bl.brush_top is not none and point[0] < brush[0] and point[1] > brush[1] %}
+        SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=brush VALUE=False
+      {% endif %}
+      {% if point[0] < shake[0] and point[1] > shake[1] %}
+        SET_GCODE_VARIABLE MACRO=_BLOBIFIER_SAFE_DESCEND VARIABLE=shake VALUE=False
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
+
+##########################################################################################
+# Increment the blob count with 1 and check if the bucket is full. Pause 
+# the printer if it is.
+#
+[gcode_macro _BLOBIFIER_COUNT]
+# Don't change these variables
+variable_current_blobs: 0
+variable_last_shake: 0
+variable_next_shake: 0
+gcode:
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+  {% set count = printer['gcode_macro _BLOBIFIER_COUNT'] %}
+  {% if current_blobs >= bl.max_blobs %}
+    {action_respond_info("BLOBIFIER: Empty purge bucket!")}
+    M117 Empty purge bucket!
+    MMU_PAUSE MSG="Empty purge bucket!"
+  {% else %}
+    SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=current_blobs VALUE={current_blobs + 1}
+    _BLOBIFIER_SAVE_STATE
+    {action_respond_info(
+      "BLOBIFIER: Blobs in bucket: %s/%s. Next shake @ %s" 
+      % (current_blobs + 1, bl.max_blobs, next_shake)
+    )}
+  {% endif %}
+
+##########################################################################################
+# Reset the blob count to 0
+#
+[gcode_macro _BLOBIFIER_COUNT_RESET]
+gcode:
+  SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=current_blobs VALUE=0
+  SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=last_shake VALUE=0
+  _BLOBIFIER_SAVE_STATE
+  
+  _BLOBIFIER_CALCULATE_NEXT_SHAKE
+
+##########################################################################################
+# Shake the blob bucket to disperse the blobs
+#
+[gcode_macro BLOBIFIER_SHAKE_BUCKET]
+gcode:
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+  {% set count = printer['gcode_macro _BLOBIFIER_COUNT'] %}
+  {% set original_accel = printer.toolhead.max_accel %}
+  {% set original_minimum_cruise_ratio = printer.toolhead.minimum_cruise_ratio %}
+  {% set position_x = bl.shaker_pos_x|default(0)|float + bl.skew_correction %}
+
+  {% if "xyz" not in printer.toolhead.homed_axes %}
+    {action_raise_error("BLOBIFIER: Not homed. Home xyz first")}
+  {% endif %}
+  
+  SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=last_shake VALUE={count.current_blobs}
+  _BLOBIFIER_SAVE_STATE
+  SAVE_GCODE_STATE NAME=shake_bucket
+  
+  M400
+  M117 (^_^)
+
+  G90
+  {% set shakes = params.SHAKES|default(10)|int %}
+  {% set pos_max = printer.toolhead.axis_maximum %}
+  {% set position_y = pos_max.y - bl.skew_correction - bl.y_offset %}
+  
+  # move to save y if not already there
+  {% if printer.toolhead.position.y != position_y %}
+    G1 X{bl.brush_start} Y{position_y} F{bl.travel_spd_xy}
+  {% endif %}
+
+  # Retract the tray
+  BLOBIFIER_SERVO POS=in
+
+  # move up a bit to prevent oozing on base
+  G1 Z{bl.shaker_arm_z} F{bl.travel_spd_z}
+  # slide into the slot
+  G1 X{position_x} F{bl.travel_spd_xy}
+
+  M400
+  M117 (+(+_+)+)
+
+  SET_VELOCITY_LIMIT ACCEL={bl.shake_accel} MINIMUM_CRUISE_RATIO=0.1
+  
+  # Shake away!
+  {% for shake in range(1, shakes) %}
+     G1 Y{position_y - 4}
+     G1 Y{position_y}
+  {% endfor %}
+
+  SET_VELOCITY_LIMIT ACCEL={original_accel} MINIMUM_CRUISE_RATIO={original_minimum_cruise_ratio}
+  # move out of slot
+  G1 X{bl.purge_x}
+
+  M400
+  M117 (X_x)
+
+  RESTORE_GCODE_STATE NAME=shake_bucket  
+
+##########################################################################################
+# Calculate when the bucket should be shaken. 
+#
+[gcode_macro _BLOBIFIER_CALCULATE_NEXT_SHAKE]
+gcode:
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+  {% set count = printer['gcode_macro _BLOBIFIER_COUNT'] %}
+
+  {% set remaining_blobs = bl.max_blobs - count.last_shake %}
+  {% set next_shake = (1 - bl.bucket_shake_frequency) * remaining_blobs + count.last_shake %}
+  _BLOBIFIER_SAVE_STATE
+  _BLOBIFIER_SET_NEXT_SHAKE VALUE={next_shake|int}
+
+##########################################################################################
+# Set when the bucket should be shaken next
+# VALUE=[int] At what amount of blobs should it be shaken
+#
+[gcode_macro _BLOBIFIER_SET_NEXT_SHAKE]
+gcode:
+  {% if params.VALUE %}
+    {% set next_shake = params.VALUE %}
+    SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=next_shake VALUE={next_shake}
+    _BLOBIFIER_SAVE_STATE
+  {% else %}
+    {action_respond_info("BLOBIFIER: Provide parameter VALUE=")}
+  {% endif %}
+
+##########################################################################################
+# Some sanity checks
+#
+[delayed_gcode BLOBIFIER_INIT]
+initial_duration: 5.0
+gcode:
+  _BLOBIFIER_INIT
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+  {% if bl.blobifier_type == "stepper" %}
+    # Home and test stepper tray
+    _BLOBIFIER_HOME_STEPPER
+    BLOBIFIER_SERVO POS=out
+    BLOBIFIER_SERVO POS=in
+    # Disable stepper after init test
+    MANUAL_STEPPER STEPPER=stepper_blobifier ENABLE=0 SYNC=1
+  {% else %}
+    # Extend and retract the servo tray to test
+    BLOBIFIER_SERVO POS=out
+    BLOBIFIER_SERVO POS=in
+  {% endif %}
+
+[gcode_macro _BLOBIFIER_INIT]
+gcode:
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+  {% set axis_min = printer.toolhead.axis_minimum %}
+  {% set axis_max = printer.toolhead.axis_maximum %}
+
+  # Valid part cooling fan setting
+  {% if bl.part_cooling_fan != -1 and (bl.part_cooling_fan < 0 or bl.part_cooling_fan > 1) %}
+    {action_emergency_stop("BLOBIFIER: Value %f is invalid for variable part_cooling_fan. Either -1 or a value from 0 .. 1 is valid." % (bl.part_cooling_fan))}
+  {% endif %}
+
+  # Valid bucket shake frequency
+  {% if bl.bucket_shake_frequency < 0 or bl.bucket_shake_frequency > 1 %}
+    {action_emergency_stop("BLOBIFIER: Value %f is invalid for variable bucket_shake_frequency. Change it to a value between 0 .. 1" % (bl.bucket_shake_frequency))}
+  {% endif %}  
+
+  # Check if position is on 'next'
+  {% if printer.mmu %}
+    {% if printer['gcode_macro _MMU_SEQUENCE_VARS'].restore_xy_pos != 'next' %}
+      {action_respond_info("BLOBIFIER: If not using a wipe tower, consider setting restore_xy_pos: 'next' in mmu_macro_vars.cfg")}
+    {% endif %}
+  {% endif %}
+
+  # Check the z_raise variable for normal values
+  {% if bl.z_raise < 3 %}
+    {action_respond_info("BLOBIFIER: variable_z_raise: %f is very low. This is the value z raises in total on a single blob. Make sure the value is correct before continuing." % (bl.z_raise))}
+  {% endif %}
+
+  # Z raise exponent
+  {% if bl.z_raise_exp > 1 or bl.z_raise_exp < 0.5 %}
+    {action_respond_info("BLOBIFIER: variable_z_raise_exp has value: %f. This value is out of spec (0.5 ... 1.0)." % (bl.z_raise_exp))}
+  {% endif %}
+
+  # cap user defined accels at printer max_accel if greater
+  {% if bl.shake_accel >  printer.configfile.config.printer.max_accel|int %}
+     {action_respond_info("BLOBIFIER: variable_shake_accel has value: %d which is higher than your printer limit of %d. Reduce this if your printer skips steps." % (bl.shake_accel,printer.configfile.config.printer.max_accel|int))}
+  {% endif %}
+  {% if bl.brush_accel >  printer.configfile.config.printer.max_accel|int %}
+     {action_respond_info("BLOBIFIER: variable_brush_accel has value: %d which is higher than your printer limit of %d. Reduce this if your printer skips steps." % (bl.brush_accel,printer.configfile.config.printer.max_accel|int))}
+  {% endif %}
+
+  # Check brush_top variable
+  _BLOBIFIER_VALIDATE_FLOAT_VARIABLE NAME=brush_top MIN={axis_min.z} MAX={axis_max.z} ALLOW_NONE=1
+
+[gcode_macro _BLOBIFIER_VALIDATE_FLOAT_VARIABLE]
+gcode:
+  {% set name = params.NAME %}
+  {% set min_value = params.MIN|default(None)|float(None) %}
+  {% set max_value = params.MAX|default(None)|float(None) %}
+  {% set allow_none = params.ALLOW_NONE|default(0)|int %}
+  {% set bl = printer['gcode_macro BLOBIFIER'] %}
+
+  {% set value = bl[name]|float(None) %}
+
+  # Save the normalized value back to the variable
+  SET_GCODE_VARIABLE MACRO=BLOBIFIER VARIABLE={name} VALUE={value}
+
+  {% if not allow_none and value is none %}
+    {action_emergency_stop("BLOBIFIER: %s is not set. Please provide a value." % (name))}
+  {% endif %}
+
+  # If number is less than min, then we should just emergency stop now
+  {% if value is number and min_value is not none and value < min_value %}
+    {action_emergency_stop("BLOBIFIER: %s has value: %.2f which is below min of %.2f. Adjust %s!" % (name, value, min_value, name))}
+
+  # If number is greater than max, then we should just emergency stop now
+  {% elif value is number and max_value is not none and value > max_value %}
+    {action_emergency_stop("BLOBIFIER: %s has value: %.2f which is above max of %.2f. Adjust %s!" % (name, value, max_value, name))}
+  {% endif %}
+
+[delayed_gcode BLOBIFIER_LOAD_STATE]
+initial_duration: 2.0 # Give it some time to boot up
+gcode:
+  {% set sv = printer.save_variables.variables.blobifier %}
+
+  {% if sv %}
+    # Restore state
+    SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=last_shake VALUE={sv.last_shake}
+    SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=current_blobs VALUE={sv.current_blobs}
+  {% endif %}
+  _BLOBIFIER_CALCULATE_NEXT_SHAKE
+
+[gcode_macro _BLOBIFIER_SAVE_STATE]
+gcode:
+  {% set count = printer['gcode_macro _BLOBIFIER_COUNT'] %}
+  {% set sv = {'current_blobs': count.current_blobs, 'last_shake': count.last_shake} %}
+  SAVE_VARIABLE VARIABLE=blobifier VALUE="{sv}"

--- a/config/addons/blobifier_hw.cfg
+++ b/config/addons/blobifier_hw.cfg
@@ -1,14 +1,26 @@
 
 ##########################################################################################
+# BLOBIFIER HARDWARE CONFIGURATION
+# Choose ONE of the two tray actuator options below:
+#   1. Servo-based (default) - uncomment the [mmu_servo blobifier] section
+#   2. Stepper-based         - uncomment the [manual_stepper stepper_blobifier] section
+#
+# IMPORTANT: Also set variable_blobifier_type in the [gcode_macro BLOBIFIER] section
+# to match your hardware: "servo" or "stepper"
+##########################################################################################
+
+
+##########################################################################################
+# OPTION 1: Servo-based tray actuator (DEFAULT)
 # The servo hardware configuration. Change the values to your needs.
-# 
+#
 [mmu_servo blobifier]
 # Pin for the servo.
 pin: PG14
-# Adjust this value until a 'BLOBIFIER_SERVO POS=out' extends the tray fully without a 
+# Adjust this value until a 'BLOBIFIER_SERVO POS=out' extends the tray fully without a
 # buzzing sound
 minimum_pulse_width: 0.00053
-# Adjust this value until a 'BLOBIFIER_SERVO POS=in' retracts the tray fully without a 
+# Adjust this value until a 'BLOBIFIER_SERVO POS=in' retracts the tray fully without a
 # buzzing sound
 maximum_pulse_width: 0.0023
 # Leave this value at 180
@@ -16,9 +28,65 @@ maximum_servo_angle: 180
 
 
 ##########################################################################################
-# The bucket hardware configuration. Change the pin to whatever pin you've connected the 
+# OPTION 2: Stepper-based tray actuator
+# Uncomment the sections below and comment out the servo section above to use a stepper
+# motor driven blobifier tray instead of a servo.
+#
+#[manual_stepper stepper_blobifier]
+#step_pin: PD4                            # Update your pins
+#dir_pin: !PD3
+#enable_pin: !PD6
+#endstop_pin: ^!PC15
+#microsteps: 4
+#gear_ratio: 1:1
+#rotation_distance: 62.83
+#position_min: 0 # Not supported in Kalico. Leave disabled
+#position_max: 21 # Not supported in Kalico. Leave disabled.
+#homing_speed: 20 # Unused in the macros. Just for completeness
+#velocity: 150
+#accel: 1000
+#
+# Uncomment ONE of the TMC driver sections below to match your hardware.
+# Only one driver section should be active at a time.
+#
+# --- TMC2240 (SPI) ---
+#[tmc2240 manual_stepper stepper_blobifier]
+#cs_pin: PD5                            # Update your pins
+#spi_software_sclk_pin: PG8
+#spi_software_mosi_pin: PG6
+#spi_software_miso_pin: PG7
+#driver_SLOPE_CONTROL: 2
+#run_current: 0.6
+#hold_current: 0.2
+#interpolate: true
+#stealthchop_threshold: 99999999
+#
+# --- TMC2209 (UART) ---
+#[tmc2209 manual_stepper stepper_blobifier]
+#uart_pin: PD5                          # Update to your UART pin
+#run_current: 0.6
+#hold_current: 0.1
+#interpolate: true
+#stealthchop_threshold: 99999999
+#sense_resistor: 0.110
+#
+# --- TMC5160 (SPI) ---
+#[tmc5160 manual_stepper stepper_blobifier]
+#cs_pin: PD5                            # Update your pins
+#spi_software_sclk_pin: PG8
+#spi_software_mosi_pin: PG6
+#spi_software_miso_pin: PG7
+#run_current: 0.6
+#hold_current: 0.2
+#interpolate: true
+#stealthchop_threshold: 99999999
+#sense_resistor: 0.075
+
+
+##########################################################################################
+# The bucket hardware configuration. Change the pin to whatever pin you've connected the
 # switch to.
-# 
+#
 [gcode_button bucket]
 pin: ^PG15 # The pullup ( ^ ) is important here.
 press_gcode:


### PR DESCRIPTION
# Blobifier beta

## Overview
This update is a stepping stone towards more a modular blobifier, that is able to operate with both bed mounted brushes, gantry brushes and gantry mounted nozzle leak stops and brush. 

It also brings finer purge process control by exposing some of the hard coded variables aiming to better match the tuning of the purge process to the melt zone length.

In addition, the configuration file has been reorganized into better labeled sections for easier navigation and tuning.

## Features
### Stepper blobifier support
Enable the use of the new stepper blobifier, aiming to mitigate servo dying from heat issues. https://github.com/Carrot-collective/Blobifier/tree/main/User%20mods/Stepper%20Blobifier

### User Extension Hooks
Three new hooks allow custom gcode macros to be called during stages of the blobifier sequence:

- `variable_user_pre_blobifier_extension` — Called at the very start, after state save.
- `variable_user_post_purge_extension` — Called after purging but before Z is restored.
- `variable_user_post_blobifier_extension` — Called after Z is restored and state is returned.

### Modular Clean Macro (`variable_clean_macro`)
The nozzle cleaning step is now performed through a configurable macro name (default: `BLOBIFIER_CLEAN`). This allows users to swap in their own cleaning routine — gantry-mounted brush, nozzle stop, or any custom macro — without modifying the main blobifier gcode. The clean macro is now responsible for its own safe-descend checks.

### BLOBIFIER_CLEAN Now Self-Contained
The `BLOBIFIER_CLEAN` macro now handles its own safe-descend check internally rather than relying on the caller. 

### Configurable Mid-Purge Pulse Retract
The periodic retract/de-retract during purging (pulsatile flushing) is now fully tunable:
- `variable_pulse_retract_length` — Length (mm) of each periodic retract (was hardcoded to 2).
- `variable_pulse_retract_speed` — Retract speed in mm/min (was hardcoded to 1800).
- `variable_pulse_deretract_speed` — De-retract speed in mm/min (was hardcoded to 800).
- `variable_purge_retract_interval` — How often (mm of extrusion) the mid-pulse retract fires (was hardcoded to 40).

Larger melt zone toolheads should aim to retract more and faster to allow improved purging efficiency (eg. 5mm-10mm)

### Multi-Step Retract
Retraction during purging is now split into steps (`variable_retract_step`). The final steps ramp down to half speed to ease through the cold-zone transition.

### Configurable Purge Pulse Size
`variable_purge_pulse_size` controls the amount of filament (mm) extruded per Z-raise increment within a blob. Tune this to be approximately equal to your purge zone length. Previously hardcoded to 5.

### Extruder Residual Filament Toggle
`variable_include_extruder_residual` (default: 1) controls whether `extruder_filament_remaining` is added to the purge length calculation. The slicer purge matrix usually already accounts for residual filament in the nozzle. If so, set to 0 to avoid over-purging.

### Purge Length Calculation
`park_vars.retracted_length` is now added **after** the minimum purge length floor is applied, rather than before. This correctly treats the retracted filament as mechanical overhead rather than purge volume, preventing the minimum purge from being inflated by the retraction distance.

### Default Fan Name
`variable_fan_name` now defaults to `"fan"` instead of being commented out

### Sync Feedback Tension Adjustment Relocated
`MMU_SYNC_FEEDBACK ADJUST_TENSION=1` is now called **inside** the blob loop immediately after pressure release, rather than after the entire purge sequence. This centres the sync feedback sensor before the next blob begins, reducing the risk of accidentally triggering FlowGuard.

## Configuration Reorganization
The variable block has been reorganized into the below sections for improved configuration flow:

1. **Hooks & Extensions** — User extension macros and clean macro selection.
2. **Hardware & General** — Toolhead offsets, travel speeds, skew correction, Y offset.
3. **Tray Positions** — Purge location, tray height, servo/stepper tray settings.
4. **Brush / Nozzle Cleaning** — Brush geometry, wipe parameters, acceleration.
5. **Purge Length Tuning** — Min/max purge, modifier, addition, residual toggle.
6. **Purge Sequence Tuning** — Iteration heights, speeds, pulse size (visual guide retained).
7. **Retraction Tuning** — Between-blob retract, step size, periodic pulse retract parameters.
8. **Fan Control** — Part cooling fan speeds and fan name.

## Notes
- All existing variable names are preserved — no breaking changes to variable names.
- Users with custom cleaning routines should set `variable_clean_macro` to their macro name instead of editing `BLOBIFIER` directly.
- This PR contains the stepper blobifier changes.
