### PR TITLE
v4 merged - Fix cut tip not respecting safe margin post cut

### DIFF
--- a/config/base/mmu_cut_tip.cfg
+++ b/config/base/mmu_cut_tip.cfg
@@ -185,7 +185,9 @@ gcode:
     {% set x = [axis_minimum.x, [axis_maximum.x, pos.x]|min]|max %}
     {% set y = [axis_minimum.y, [axis_maximum.y, pos.y]|min]|max %}
 
-    MMU_LOG MSG="Warning: Klipper reported out of range gcode position (x:{pos.x}, y:{pos.y})! Adjusted to (x:{x}, y:{y}) to prevent move failure" ERROR=1
+    {% if x != pos.x or y != pos.y %}
+        MMU_LOG MSG="Warning: Klipper reported out of range gcode position (x:{pos.x}, y:{pos.y})! Adjusted to (x:{x}, y:{y}) to prevent move failure" ERROR=1
+    {% endif %}
     G1 X{x} Y{y} F{travel_speed * 60}
 
 

--- a/config/base/mmu_cut_tip.cfg
+++ b/config/base/mmu_cut_tip.cfg
@@ -250,6 +250,8 @@ gcode:
     {% set evacuate_speed = vars['evacuate_speed']|float %}
     {% set rip_length = vars['rip_length']|float %}
     {% set rip_speed = vars['rip_speed']|float %}
+    {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
+    {% set travel_speed = vars['travel_speed']|float %}
 
 
     {% set fast_slow_transition_loc_x = (pin_loc_compressed_x - pin_park_x_loc) * cut_fast_move_fraction + pin_park_x_loc|float %}
@@ -263,6 +265,13 @@ gcode:
     {% endif %}
 
     G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{evacuate_speed * 60} # Evacuate
+
+    # Move clear of pin on non-cutting axis to prevent toolhead collision on subsequent travel moves
+    {% if cutting_axis == "x" %}
+        G1 Y{pin_park_y_loc + safe_margin_y} F{travel_speed * 60}
+    {% else %}
+        G1 X{pin_park_x_loc + safe_margin_x} F{travel_speed * 60}
+    {% endif %}
 
 
 ###########################################################################

--- a/config/base/mmu_cut_tip.cfg
+++ b/config/base/mmu_cut_tip.cfg
@@ -205,18 +205,18 @@ gcode:
     {% set travel_speed = vars['travel_speed']|float %}
     {% set cutting_axis = vars['cutting_axis'] %}
 
-    {% if ((printer.gcode_move.gcode_position.x - pin_park_x_loc)|abs < safe_margin_x) or ((printer.gcode_move.gcode_position.y - pin_park_y_loc)|abs < safe_margin_y) %}
-        # Make a safe but slower travel move
-        {% if cutting_axis == "x" %}
-            G1 X{pin_park_x_loc} F{travel_speed * 60}
-            G1 Y{pin_park_y_loc} F{travel_speed * 60}
-        {% else %}
-            G1 Y{pin_park_y_loc} F{travel_speed * 60}
-            G1 X{pin_park_x_loc} F{travel_speed * 60}
-        {% endif %}
-    {% else %}
-        G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed * 60}
-    {% endif %}
+    {% if vars.gantry_servo_enabled|default(false)|lower == 'false' %}  # by pass safety moves if servo depressor pin is enabled
+       {% if printer.gcode_move.gcode_position.x < pin_park_x_loc + safe_margin_x %}  # trigger extra safety moves if within depressor safety zone
+          {% set move_y = [pin_park_y_loc + safe_margin_y, printer.toolhead.axis_maximum.y]|min if printer.gcode_move.gcode_position.y > pin_park_y_loc else pin_park_y_loc %}
+          {% set move_x = pin_park_x_loc + safe_margin_x if move_y != pin_park_y_loc else pin_park_x_loc %} 
+          G1 X{move_x} Y{move_y} F{travel_speed * 60}          # 1st safety move  
+          G1 X{move_x} Y{pin_park_y_loc} F{travel_speed * 60}  # 2nd safety move
+       {% else %}
+          G1 X{pin_park_x_loc + safe_margin_x} Y{pin_park_y_loc} F{travel_speed * 60}  # move to penultimate position if in the clear
+       {% endif %}
+    {% endif %}   
+
+    G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed * 60} # move to final position 
 
 
 ###########################################################################
@@ -267,13 +267,7 @@ gcode:
     {% endif %}
 
     G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{evacuate_speed * 60} # Evacuate
-
-    # Move clear of pin on non-cutting axis to prevent toolhead collision on subsequent travel moves
-    {% if cutting_axis == "x" %}
-        G1 Y{pin_park_y_loc + safe_margin_y} F{travel_speed * 60}
-    {% else %}
-        G1 X{pin_park_x_loc + safe_margin_x} F{travel_speed * 60}
-    {% endif %}
+    G1 X{pin_park_x_loc + safe_margin_x} F{travel_speed * 60}
 
 
 ###########################################################################


### PR DESCRIPTION
Currently there is the potential for a cutter pin crash after the cut move is complete due to the do cut move macro not travelling away from the cutter pin by the safe margin to clear the cutter.

This PR addresses this by ensuring the toolhead is distanced from the cutter pin by the user configured safe margins in the mmu cut macro variables.

This PR also fixes a spurious Klipper reported out of range gcode position error.