### PR TITLE
v4 ported - Fix MMU_CALIBRATE_PSENSOR sensor saturation grinding

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -2866,6 +2866,9 @@ class Mmu:
             return (avg)
 
         def _seek_limit(msg, steps, step_size, prev_val, ramp, log_label):
+            PLATEAU_EPSILON = 0.005
+            PLATEAU_COUNT = 2
+            plateau_steps = 0
             self.log_always(msg)
             for i in range(steps):
                 _ = self.trace_filament_move(msg, step_size, motor="gear", speed=MOVE_SPEED, wait=True)
@@ -2874,16 +2877,24 @@ class Mmu:
                 delta = val - prev_val
 
                 if ramp is None:
-                    if delta == 0:
+                    if abs(delta) < PLATEAU_EPSILON:
                         self.log_always("No sensor change. Retrying")
                         continue
                     ramp = (delta > 0)
 
                 if (ramp and val >= prev_val) or (not ramp and val <= prev_val):
+                    # Check for saturation — value has plateaued
+                    if abs(delta) < PLATEAU_EPSILON:
+                        plateau_steps += 1
+                        if plateau_steps >= PLATEAU_COUNT:
+                            self.log_always("Sensor saturated at %.4f — limit found" % val)
+                            return val, ramp, True
+                    else:
+                        plateau_steps = 0
                     prev_val = val
                     self.log_always("Seeking ... ADC %s limit: %.4f" % (log_label, val))
                 else:
-                    # Limit found
+                    # Limit found — value reversed direction
                     return prev_val, ramp, True
 
             # Ran out of steps without detecting a clear limit


### PR DESCRIPTION
Adds plateau detection to `_seek_limit()` in `MMU_CALIBRATE_PSENSOR`. Previously, when the sensor hit its physical limit (e.g. ADC saturated at 1.0), the seek loop continued stepping for the entire remaining move distance because the stop condition only checked for a value reversal — which never comes when the sensor is saturated.

Now, if the value changes by less than 0.005 for 2 consecutive steps, the limit is treated as found and the seek stops immediately. This is in addition to the existing value reversal logic.