### PR TITLE
v4 not relevant - Fix wrong-gate unload during cross-gate MMU_EJECT

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -7032,12 +7032,17 @@ class Mmu:
                 with self._wrap_suspend_filament_monitoring(): # Don't want runout accidently triggering during filament eject
 
                     current_gate = self.gate_selected
-                    if gate != current_gate:
-                        self.select_gate(gate)
 
                     try:
+                        # Unload BEFORE switching to the eject target gate so the unload sequence
+                        # (and its bowden sensor checks) references the gate the filament is
+                        # currently loaded from, not the eject destination. Pre-switching pointed
+                        # the sensor validation at an empty gate and, on a multigear MMU, drove
+                        # the wrong gate's gear stepper through the bowden unload.
                         self._mmu_unload_eject(gcmd)
                         if can_eject_from_gate:
+                            if gate != self.gate_selected:
+                                self.select_gate(gate)
                             self.log_always("Ejecting filament out of %s" % ("current gate" if gate == current_gate else "gate %d" % gate))
                             self._eject_from_gate()
 


### PR DESCRIPTION
`cmd_MMU_EJECT` calls `select_gate(target)` before running the unload, so the unload of the currently loaded tool runs with `gate_selected` already pointing at the eject destination instead of the gate the filament is actually on.

For example: T0 loaded on gate 0, user runs `MMU_EJECT GATE=2`.
- The bowden sensor check evaluates gate 2's sensors (correctly Empty) and trips a spurious `Possible sensor malfunction - mmu_gear_2, ...` warning.
- On a multigear MMU, the bowden retract drives gate 2's empty gear stepper for the full bowden length with the unload reporting success while leaving gate 0 still physically loaded.

This PR aims to fix this by moving `select_gate(gate)` to immediately before `_eject_from_gate`, so the unload runs on the actually loaded gate. 