### PR TITLE
[Feature] Add pushback_push_only variable to control whether to only extrude th…

### DIFF
--- a/config/base/mmu_cut_tip.cfg
+++ b/config/base/mmu_cut_tip.cfg
@@ -50,6 +50,7 @@ gcode:
     {% set rip_length = vars['rip_length']|float %}
     {% set pushback_length = vars['pushback_length']|float %}
     {% set pushback_dwell_time = vars['pushback_dwell_time']|int %}
+    {% set pushback_push_only = vars['pushback_push_only']|default(false)|lower == 'true' %}
     {% set extruder_move_speed = vars['extruder_move_speed']|float %}
     {% set travel_speed = vars['travel_speed']|float %}
     {% set restore_position = vars['restore_position']|default(true)|lower == 'true' %}
@@ -102,7 +103,9 @@ gcode:
         MMU_LOG MSG="Pushing filament fragment back {effective_pushback_length|round(1)}mm after cut"
         G1 E{effective_pushback_length} F{extruder_move_speed * 60}
         G4 P{pushback_dwell_time}
-        G1 E-{effective_pushback_length} F{extruder_move_speed * 60}
+        {% if not pushback_push_only %}
+            G1 E-{effective_pushback_length} F{extruder_move_speed * 60}
+        {% endif %}
     {% endif %}
 
     # Final eject is for testing

--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -325,6 +325,7 @@ variable_rip_speed              : 3		; Speed mm/s
 # Cannot be larger than 'retract_length' - `toolhead_ooze_reduction`
 variable_pushback_length        : 15.0		; TUNE ME: PTFE tube length + 3mm is good starting point
 variable_pushback_dwell_time    : 0		; Time in ms to dwell after the pushback
+variable_pushback_push_only     : False ; True = Only extrude the pushback length after the cut, False = Extrude then retract the pushback length
 
 # Speed related settings for tip cutting
 # Note that if the cut speed is too fast, the steppers can lose steps.


### PR DESCRIPTION
Add pushback_push_only variable to control whether to only extrude the pushback length after the cut, or to extrude then retract it. This is useful when the cutter is before the extruder.

Allows extrude only on pushback. See https://github.com/moggieuk/Happy-Hare/issues/954