### PR TITLE
update SuperSlicer filament color handling the same as PrusaSlicer 

### DIFF
--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -879,7 +879,7 @@ METADATA_END_PURGING = "CP TOOLCHANGE END"
 # PS/SS uses "extruder_colour", Orca uses "filament_colour" but extruder_colour can exist with empty or single color
 COLORS_REGEX = {
     'PrusaSlicer' : r"^;\s*(?:extruder|filament)_colour\s*=\s*(#.*;*.*)$", #if extruder colour is not set, check filament colour
-    'SuperSlicer' : r"^;\s*extruder_colour\s*=\s*(#.*;*.*)$",
+    'SuperSlicer' : r"^;\s*(?:extruder|filament)_colour\s*=\s*(#.*;*.*)$", #if extruder colour is not set, check filament colour
     'OrcaSlicer'  : r"^;\s*filament_colour\s*=\s*(#.*;*.*)$",
     'BambuStudio' : r"^;\s*filament_colour\s*=\s*(#.*;*.*)$",
 }


### PR DESCRIPTION
allow fallback to 'filament_colour' value if 'extruder_colour' is not set