### PR TITLE
Improve mmu_cut_tip safety moves to avoid static depressor pin

### DIFF
--- a/config/macros/mmu_cut_tip.cfg
+++ b/config/macros/mmu_cut_tip.cfg
@@ -33,7 +33,7 @@
 #   SET_GCODE_VARIABLE MACRO=_MMU_CUT_TIP VARIABLE=output_park_pos VALUE=..
 #
 [gcode_macro _MMU_CUT_TIP]
-description: Cut filament by pressing the cutter on a pin with toolhead movement
+description: Cut filament by pressing the cutter on a pin with a horizontal movement
 
 # -------------------------- Internal Don't Touch -------------------------
 variable_output_park_pos: 0 # Dynamically set in this macro
@@ -98,7 +98,7 @@ gcode:
 
     # Step 3 - Pushback of the tip residual into the hotend to avoid future catching (ideally past the PTFE/metal boundary)
     {% set effective_pushback_length = [pushback_length, retract_length - printer.mmu.extruder_filament_remaining - park_vars.retracted_length]|min %}
-    {% if effective_pushback_length > 0 %}
+    {% if effective_pushback_length > 0 %} 
         MMU_LOG MSG="Pushing filament fragment back {effective_pushback_length|round(1)}mm after cut"
         G1 E{effective_pushback_length} F{extruder_move_speed * 60}
         G4 P{pushback_dwell_time}
@@ -185,7 +185,9 @@ gcode:
     {% set x = [axis_minimum.x, [axis_maximum.x, pos.x]|min]|max %}
     {% set y = [axis_minimum.y, [axis_maximum.y, pos.y]|min]|max %}
 
-    MMU_LOG MSG="Warning: Klipper reported out of range gcode position (x:{pos.x}, y:{pos.y})! Adjusted to (x:{x}, y:{y}) to prevent move failure" ERROR=1
+    {% if x != pos.x or y != pos.y %}
+        MMU_LOG MSG="Warning: Klipper reported out of range gcode position (x:{pos.x}, y:{pos.y})! Adjusted to (x:{x}, y:{y}) to prevent move failure" ERROR=1
+    {% endif %}
     G1 X{x} Y{y} F{travel_speed * 60}
 
 
@@ -203,18 +205,18 @@ gcode:
     {% set travel_speed = vars['travel_speed']|float %}
     {% set cutting_axis = vars['cutting_axis'] %}
 
-    {% if ((printer.gcode_move.gcode_position.x - pin_park_x_loc)|abs < safe_margin_x) or ((printer.gcode_move.gcode_position.y - pin_park_y_loc)|abs < safe_margin_y) %}
-        # Make a safe but slower travel move
-        {% if cutting_axis == "x" %}
-            G1 X{pin_park_x_loc} F{travel_speed * 60}
-            G1 Y{pin_park_y_loc} F{travel_speed * 60}
-        {% else %}
-            G1 Y{pin_park_y_loc} F{travel_speed * 60}
-            G1 X{pin_park_x_loc} F{travel_speed * 60}
-        {% endif %}
-    {% else %}
-        G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed * 60}
-    {% endif %}
+    {% if vars.gantry_servo_enabled|default(false)|lower == 'false' %}  # by pass safety moves if servo depressor pin is enabled
+       {% if printer.gcode_move.gcode_position.x < pin_park_x_loc + safe_margin_x %}  # trigger extra safety moves if within depressor safety zone
+          {% set move_y = [pin_park_y_loc + safe_margin_y, printer.toolhead.axis_maximum.y]|min if printer.gcode_move.gcode_position.y > pin_park_y_loc else pin_park_y_loc %}
+          {% set move_x = pin_park_x_loc + safe_margin_x if move_y != pin_park_y_loc else pin_park_x_loc %} 
+          G1 X{move_x} Y{move_y} F{travel_speed * 60}          # 1st safety move  
+          G1 X{move_x} Y{pin_park_y_loc} F{travel_speed * 60}  # 2nd safety move
+       {% else %}
+          G1 X{pin_park_x_loc + safe_margin_x} Y{pin_park_y_loc} F{travel_speed * 60}  # move to penultimate position if in the clear
+       {% endif %}
+    {% endif %}   
+
+    G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed * 60} # move to final position 
 
 
 ###########################################################################
@@ -235,14 +237,14 @@ gcode:
             {% set pin_loc_compressed_x = pin_loc %}
             {% set pin_loc_compressed_y = pin_park_y_loc %}
         {% else %}
-            {% set pin_loc_compressed_x = pin_park_x_loc %}
+            {% set pin_loc_compressed_x = pin_park_x_loc %}   
             {% set pin_loc_compressed_y = pin_loc %}
         {% endif %}
     {% else %}
         # New config
         {% set pin_loc_compressed_x, pin_loc_compressed_y = vars.pin_loc_compressed_xy|map('float') %}
     {% endif %}
-
+        
     {% set cut_fast_move_fraction = vars['cut_fast_move_fraction']|float %}
     {% set cut_fast_move_speed = vars['cut_fast_move_speed']|float %}
     {% set cut_slow_move_speed = vars['cut_slow_move_speed']|float %}
@@ -250,6 +252,8 @@ gcode:
     {% set evacuate_speed = vars['evacuate_speed']|float %}
     {% set rip_length = vars['rip_length']|float %}
     {% set rip_speed = vars['rip_speed']|float %}
+    {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
+    {% set travel_speed = vars['travel_speed']|float %}
 
 
     {% set fast_slow_transition_loc_x = (pin_loc_compressed_x - pin_park_x_loc) * cut_fast_move_fraction + pin_park_x_loc|float %}
@@ -263,6 +267,7 @@ gcode:
     {% endif %}
 
     G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{evacuate_speed * 60} # Evacuate
+    G1 X{pin_park_x_loc + safe_margin_x} F{travel_speed * 60}
 
 
 ###########################################################################

--- a/mmu_cut_tip.cfg
+++ b/mmu_cut_tip.cfg
@@ -1,0 +1,301 @@
+########################################################################################################################
+# Happy Hare MMU Software
+# Supporting macros
+#
+# THIS FILE IS READ ONLY
+#
+# Copyright (C) 2022-2026  moggieuk#6538 (discord)
+#                          moggieuk@hotmail.com
+# This file may be distributed under the terms of the GNU GPLv3 license.
+#
+# Goal: Standalone Tip Cutting for "Filametrix" style toolhead cutters
+#
+# (\_/)
+# ( *,*)
+# (")_(") Happy Hare Ready
+#
+#
+# When using this macro it is important to turn off tip forming in your slicer
+# (read the wiki: Slicer Setup & Toolchange-Movement pages)
+# Then set the following parameters in mmu_parameters.cfg:
+#
+#   form_tip_macro: _MMU_CUT_TIP
+#   force_form_tip_standalone: 1
+#
+# This will ensure this macro is always called either in out of a print
+#
+# NOTE:
+# The park position of the filament is relative to the nozzle and
+# represents where the end of the filament is after cutting. The park position
+# is important and used by Happy Hare both to finish unloading the extruder
+# as well as to calculate how far to advance the filament on the subsequent load.
+# It is set dynamically in gcode with this construct:
+#   SET_GCODE_VARIABLE MACRO=_MMU_CUT_TIP VARIABLE=output_park_pos VALUE=..
+#
+[gcode_macro _MMU_CUT_TIP]
+description: Cut filament by pressing the cutter on a pin with a horizontal movement
+
+# -------------------------- Internal Don't Touch -------------------------
+variable_output_park_pos: 0 # Dynamically set in this macro
+
+gcode:
+    {% set final_eject = params.FINAL_EJECT|default(0)|int %}
+    {% set vars = printer['gcode_macro _MMU_CUT_TIP_VARS'] %}
+    {% set park_vars = printer['gcode_macro _MMU_PARK'] %}
+    {% set pin_loc_x, pin_loc_y = vars.pin_loc_xy|map('float') %}
+    {% set pin_park_dist = vars['pin_park_dist']|float %}
+    {% set retract_length = vars['retract_length']|float %}
+    {% set simple_tip_forming = vars['simple_tip_forming']|default(true)|lower == 'true' %}
+    {% set blade_pos = vars['blade_pos']|float %}
+    {% set rip_length = vars['rip_length']|float %}
+    {% set pushback_length = vars['pushback_length']|float %}
+    {% set pushback_dwell_time = vars['pushback_dwell_time']|int %}
+    {% set extruder_move_speed = vars['extruder_move_speed']|float %}
+    {% set travel_speed = vars['travel_speed']|float %}
+    {% set restore_position = vars['restore_position']|default(true)|lower == 'true' %}
+    {% set extruder_park_pos = blade_pos + rip_length %}
+    {% set cutting_axis = vars['cutting_axis'] %}
+
+    {% if cutting_axis == "x" %}
+        {% set pin_park_x_loc = pin_loc_x + pin_park_dist %}
+        {% set pin_park_y_loc = pin_loc_y %}
+    {% else %}
+        {% set pin_park_y_loc = pin_loc_y + pin_park_dist %}
+        {% set pin_park_x_loc = pin_loc_x %}
+    {% endif %}
+	
+    {% if "xy" not in printer.toolhead.homed_axes %}
+        MMU_LOG MSG="Automatically homing XY"
+        G28 X Y
+        _CUT_TIP_MOVE_IN_BOUNDS
+    {% endif %}
+
+    SAVE_GCODE_STATE NAME=_MMU_CUT_TIP_state # Save after possible homing operation to prevent 0,0 being recorded
+
+    G90 # Absolute positioning
+    M83 # Relative extrusion
+    G92 E0
+
+    # Step 1 - Calculate initial retract to save filament waste, repeat to allow some cooling
+    {% set effective_retract_length = retract_length - printer.mmu.extruder_filament_remaining - park_vars.retracted_length %}
+    {% if effective_retract_length > 0 %}
+        MMU_LOG MSG="Retracting filament {effective_retract_length|round(1)}mm prior to cut"
+        G1 E-{effective_retract_length} F{extruder_move_speed * 60}
+        {% if simple_tip_forming %}
+            G1 E{effective_retract_length / 2} F{extruder_move_speed * 60}
+            G1 E-{effective_retract_length / 2} F{extruder_move_speed * 60}
+        {% endif %}
+    {% endif %}
+
+    # Step 2 - Perform the cut
+    _CUT_TIP_ADJUST_CURRENT
+    _CUT_TIP_MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc}
+    _CUT_TIP_GANTRY_SERVO_DOWN
+    _CUT_TIP_DO_CUT_MOTION PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc} RIP_LENGTH={rip_length}
+    _CUT_TIP_GANTRY_SERVO_UP
+    _CUT_TIP_RESTORE_CURRENT
+    _MMU_EVENT EVENT="filament_cut"
+
+    # Step 3 - Pushback of the tip residual into the hotend to avoid future catching (ideally past the PTFE/metal boundary)
+    {% set effective_pushback_length = [pushback_length, retract_length - printer.mmu.extruder_filament_remaining - park_vars.retracted_length]|min %}
+    {% if effective_pushback_length > 0 %} 
+        MMU_LOG MSG="Pushing filament fragment back {effective_pushback_length|round(1)}mm after cut"
+        G1 E{effective_pushback_length} F{extruder_move_speed * 60}
+        G4 P{pushback_dwell_time}
+        G1 E-{effective_pushback_length} F{extruder_move_speed * 60}
+    {% endif %}
+
+    # Final eject is for testing
+    {% if final_eject %}
+        G92 E0
+        G1 E-80 F{extruder_move_speed * 60}
+    {% endif %}
+
+    # Dynamically set the required output variables for Happy Hare
+    SET_GCODE_VARIABLE MACRO=_MMU_CUT_TIP VARIABLE=output_park_pos VALUE={extruder_park_pos}
+
+    # Restore state and optionally position (usually on wipetower)
+    RESTORE_GCODE_STATE NAME=_MMU_CUT_TIP_state MOVE={1 if restore_position else 0} MOVE_SPEED={travel_speed}
+
+###########################################################################
+# Helper macro to alter X/Y stepper current during cut operation
+#
+[gcode_macro _CUT_TIP_ADJUST_CURRENT]
+description: Helper to optionally increase X/Y stepper current prior to cut
+variable_current_map: {} # Internal, don't set
+gcode:
+    {% set vars = printer['gcode_macro _MMU_CUT_TIP_VARS'] %}
+    {% set cut_axis_steppers = (vars['cut_axis_steppers'] | default('')).split(',') | map('trim') | list %}
+    {% set cut_stepper_current = vars['cut_stepper_current'] | default(100) | int %}
+    {% set tmc_types = ["tmc2209", "tmc2130", "tmc2208", "tmc2660", "tmc5160", "tmc2240"] %}
+
+    {% if not current_map %}
+        {% set ns = namespace(run_current={}) %}
+        {% if cut_stepper_current != 100 %}
+            {% for stepper in cut_axis_steppers %}
+                {% for tmc in tmc_types %}
+                    {% set fullname = tmc ~ ' ' ~ stepper %}
+                    {% if printer[fullname] is defined %}
+                        # Save original run_current and reset to new value
+                        {% set cur_rc = printer[fullname].run_current %}
+                        {% if ns.run_current.update({stepper: cur_rc}) %}{% endif %}
+                        {% set new_rc = cur_rc * cut_stepper_current | float / 100 %}
+                        MMU_LOG MSG="Adjusting {stepper} current"
+                        SET_TMC_CURRENT STEPPER={stepper} CURRENT={new_rc}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+        {% endif %}
+
+        SET_GCODE_VARIABLE MACRO=_CUT_TIP_ADJUST_CURRENT VARIABLE=current_map VALUE="{ns.run_current}"
+    {% endif %}
+
+###########################################################################
+# Helper macro to restore X/Y stepper current after cutting action
+#
+[gcode_macro _CUT_TIP_RESTORE_CURRENT]
+description: Helper to restore X/Y stepper current after cutting action
+gcode:
+    {% set current_vars = printer['gcode_macro _CUT_TIP_ADJUST_CURRENT'] %}
+    {% set current_map = current_vars['current_map'] %}
+
+    {% if current_map %}
+        {% for stepper, current in current_map.items() %}
+            MMU_LOG MSG="Restoring {stepper} current"
+            SET_TMC_CURRENT STEPPER={stepper} CURRENT={current}
+        {% endfor %}
+    {% endif %}
+
+    SET_GCODE_VARIABLE MACRO=_CUT_TIP_ADJUST_CURRENT VARIABLE=current_map VALUE="{{}}"
+
+
+###########################################################################
+# Helper macro to ensure toolhead is in bounds after home in case it is
+# used as a restore position point
+#
+[gcode_macro _CUT_TIP_MOVE_IN_BOUNDS]
+description: Helper to move the toolhead to a legal position after homing
+gcode:
+    {% set vars = printer['gcode_macro _MMU_CUT_TIP_VARS'] %}
+    {% set travel_speed = vars['travel_speed']|float %}
+
+    {% set pos = printer.gcode_move.gcode_position %}
+    {% set axis_minimum = printer.toolhead.axis_minimum %}
+    {% set axis_maximum = printer.toolhead.axis_maximum %}
+    {% set x = [axis_minimum.x, [axis_maximum.x, pos.x]|min]|max %}
+    {% set y = [axis_minimum.y, [axis_maximum.y, pos.y]|min]|max %}
+
+    {% if x != pos.x or y != pos.y %}
+        MMU_LOG MSG="Warning: Klipper reported out of range gcode position (x:{pos.x}, y:{pos.y})! Adjusted to (x:{x}, y:{y}) to prevent move failure" ERROR=1
+    {% endif %}
+    G1 X{x} Y{y} F{travel_speed * 60}
+
+
+###########################################################################
+# Helper macro for tip cutting
+#
+[gcode_macro _CUT_TIP_MOVE_TO_CUTTER_PIN]
+description: Helper to move the toolhead to the target pin in either safe or faster way, depending on toolhead clearance
+gcode:
+    {% set pin_park_x_loc = params.PIN_PARK_X_LOC|float %}
+    {% set pin_park_y_loc = params.PIN_PARK_Y_LOC|float %}
+    {% set vars = printer['gcode_macro _MMU_CUT_TIP_VARS'] %}
+
+    {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
+    {% set travel_speed = vars['travel_speed']|float %}
+    {% set cutting_axis = vars['cutting_axis'] %}
+
+    {% if vars.gantry_servo_enabled|default(false)|lower != 'true' %}  # by pass safety moves if servo depressor pin is enabled
+       {% if printer.gcode_move.gcode_position.x < pin_park_x_loc + safe_margin_x %}  # trigger extra safety moves if within depressor safety zone
+          {% set move_y = [pin_park_y_loc + safe_margin_y, printer.toolhead.axis_maximum.y]|min if printer.gcode_move.gcode_position.y > pin_park_y_loc else pin_park_y_loc %}
+          {% set move_x = pin_park_x_loc + safe_margin_x if move_y != pin_park_y_loc else pin_park_x_loc %} 
+          G1 X{move_x} Y{move_y} F{travel_speed * 60}          # 1st safety move  
+          G1 X{move_x} Y{pin_park_y_loc} F{travel_speed * 60}  # 2nd safety move
+       {% else %}
+          G1 X{pin_park_x_loc + safe_margin_x} Y{pin_park_y_loc} F{travel_speed * 60}  # move to penultimate position if in the clear
+       {% endif %}
+    {% endif %}   
+
+    G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_speed * 60} # move to final position 
+
+
+###########################################################################
+# Helper macro for tip cutting
+#
+[gcode_macro _CUT_TIP_DO_CUT_MOTION]
+description: Helper to do a single cut movement
+gcode:
+    {% set pin_park_x_loc = params.PIN_PARK_X_LOC | float %}
+    {% set pin_park_y_loc = params.PIN_PARK_Y_LOC | float %}
+    {% set vars = printer['gcode_macro _MMU_CUT_TIP_VARS'] %}
+    {% set cutting_axis = vars['cutting_axis'] %}
+
+    {% set pin_loc = vars['pin_loc_compressed']|default(-999)|float %}
+    {% if pin_loc != -999 %}
+        # Old one-dimensional pin_loc_compressed config
+        {% if cutting_axis == "x" %}
+            {% set pin_loc_compressed_x = pin_loc %}
+            {% set pin_loc_compressed_y = pin_park_y_loc %}
+        {% else %}
+            {% set pin_loc_compressed_x = pin_park_x_loc %}   
+            {% set pin_loc_compressed_y = pin_loc %}
+        {% endif %}
+    {% else %}
+        # New config
+        {% set pin_loc_compressed_x, pin_loc_compressed_y = vars.pin_loc_compressed_xy|map('float') %}
+    {% endif %}
+        
+    {% set cut_fast_move_fraction = vars['cut_fast_move_fraction']|float %}
+    {% set cut_fast_move_speed = vars['cut_fast_move_speed']|float %}
+    {% set cut_slow_move_speed = vars['cut_slow_move_speed']|float %}
+    {% set cut_dwell_time = vars['cut_dwell_time']|float %}
+    {% set evacuate_speed = vars['evacuate_speed']|float %}
+    {% set rip_length = vars['rip_length']|float %}
+    {% set rip_speed = vars['rip_speed']|float %}
+    {% set safe_margin_x, safe_margin_y = vars.safe_margin_xy|map('float') %}
+    {% set travel_speed = vars['travel_speed']|float %}
+
+
+    {% set fast_slow_transition_loc_x = (pin_loc_compressed_x - pin_park_x_loc) * cut_fast_move_fraction + pin_park_x_loc|float %}
+    {% set fast_slow_transition_loc_y = (pin_loc_compressed_y - pin_park_y_loc) * cut_fast_move_fraction + pin_park_y_loc|float %}
+    G1 X{fast_slow_transition_loc_x} Y{fast_slow_transition_loc_y} F{cut_fast_move_speed * 60} # Fast move to initiate contact of the blade with filament
+    G1 X{pin_loc_compressed_x} Y{pin_loc_compressed_y} F{cut_slow_move_speed * 60} # Do the cut in slow move
+
+    G4 P{cut_dwell_time}
+    {% if rip_length > 0 %}
+        G1 E-{rip_length} F{rip_speed * 60}
+    {% endif %}
+
+    G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{evacuate_speed * 60} # Evacuate
+    G1 X{pin_park_x_loc + safe_margin_x} F{travel_speed * 60}
+
+
+###########################################################################
+# Helper macro for tip cutting
+#
+[gcode_macro _CUT_TIP_GANTRY_SERVO_DOWN]
+description: Operate optional gantry servo operated pin
+gcode:
+    {% set vars = printer['gcode_macro _MMU_CUT_TIP_VARS'] %}
+    {% set gantry_servo_enabled = vars['gantry_servo_enabled']|default(true)|lower == 'true' %}
+    {% set angle = vars['gantry_servo_down_angle']|float %}
+
+    {% if gantry_servo_enabled %}
+        SET_SERVO SERVO=mmu_gantry_servo ANGLE={angle}
+        G4 P500 # Pause to ensure servo is fully down before movement
+    {% endif %}
+
+
+###########################################################################
+# Helper macro for tip cutting
+#
+[gcode_macro _CUT_TIP_GANTRY_SERVO_UP]
+description: Operate optional gantry servo operated pin
+gcode:
+    {% set vars = printer['gcode_macro _MMU_CUT_TIP_VARS'] %}
+    {% set gantry_servo_enabled = vars['gantry_servo_enabled']|default(true)|lower == 'true' %}
+    {% set angle = vars['gantry_servo_up_angle']|float %}
+
+    {% if gantry_servo_enabled %}
+        SET_SERVO SERVO=mmu_gantry_servo ANGLE={angle} DURATION=0.5
+    {% endif %}


### PR DESCRIPTION
Current logic wasnt effective and continued to crash into depressor pin.
Uses `safe_margin_x` & `safe_margin_y` to maneuver around static depressor pin with up to 3 moves, bypassing if servo fitted. Post cut and return to park pos, move inboard by `safe_margin_x`