### PR TITLE
Remove sync feedback callout

### DIFF
--- a/config/macros/blobifier.cfg
+++ b/config/macros/blobifier.cfg
@@ -287,11 +287,6 @@ gcode:
       {% endfor %}
     {% endif %}
 
-    # Adjust tension and centre sensor to ensure we don't accidentally trigger FlowGuard runout when print resumes
-    {% if printer.mmu.sync_feedback_enabled and printer.mmu.filament == 'Loaded' %}
-        MMU_SYNC_FEEDBACK ADJUST_TENSION=1
-    {% endif %}
-
     {% if safe.tray or ignore_safe %}
       G1 Z{bl.tray_top + 1} F{bl.travel_spd_z}
     {% endif %}

--- a/config/macros/mmu_purge.cfg
+++ b/config/macros/mmu_purge.cfg
@@ -79,11 +79,6 @@ gcode:
         G1 E-{retracted_length} F{retract_speed|abs * 60}
     {% endif %}
 
-    # Adjust tension and centre sensor to ensure we don't accidentally trigger FlowGuard runout when print resumes
-    {% if not extruder_only and printer.mmu.sync_feedback_enabled and printer.mmu.filament == 'Loaded' %}
-        MMU_SYNC_FEEDBACK ADJUST_TENSION=1
-    {% endif %}
-
     MMU_LOG MSG="Purging complete"
 
 


### PR DESCRIPTION
Remove callout to MMU_SYNC_FEEDBACK ADJUST_TENSION=1 to adjust tension as HH 4.0 now does this as part of streamlined sync operations