### PR TITLE
fix(mmu): skip unload of already-loaded gate on print start check

### DIFF
--- a/config/base/mmu_software.cfg
+++ b/config/base/mmu_software.cfg
@@ -196,6 +196,8 @@ gcode:
     {% set vars = printer['gcode_macro _MMU_SOFTWARE_VARS'] %}
     {% set check_gates = vars.check_gates|lower == 'true' %}
     {% set using_bypass = printer.mmu.tool == -2 %}
+    {% set selected_tool = printer.mmu.tool %}
+    {% set filament_loaded = printer.mmu.filament_pos == 10 %}
 
     {% if printer.mmu.enabled %}
         {% set slicer_tool_map = printer.mmu.slicer_tool_map %}
@@ -204,13 +206,17 @@ gcode:
         {% if not using_bypass %}
             # Future: Could do extra checks like filament material type/color checking here
             #         to ensure what's loaded on MMU matches the slicer expectations
-            {% if check_gates and tools|length > 0 %}
+            # Skip check for single-tool print whose initial tool is already loaded (avoids a needless home)
+            {% set skip_gate_check = tools|length <= 1 and initial_tool is not none and selected_tool == initial_tool and filament_loaded %}
+            {% if check_gates and tools|length > 0 and not skip_gate_check %}
                 # Pre-check gates option if multi-color print. Will pause if tools missing
                 MMU_LOG MSG="Checking all required gates have filament loaded..."
                 {% if not printer.mmu.is_homed %}
                     MMU_HOME
                 {% endif %}
                 MMU_CHECK_GATE TOOLS={tools|join(",")}
+            {% elif check_gates and skip_gate_check %}
+                MMU_LOG MSG="Skipping gate check: initial tool T{initial_tool} already loaded"
             {% endif %}
         {% endif %}
     {% endif %}

--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -8957,6 +8957,16 @@ class Mmu:
                             else:
                                 raise MmuError("Current gate is invalid")
 
+                            # An already loaded gate is proven present - mark available and skip rather than unload to re-verify
+                            if filament_pos == self.FILAMENT_POS_LOADED and self.gate_selected >= 0 and any(g == self.gate_selected for g, _t in gates_tools):
+                                self._set_gate_status(self.gate_selected, max(self.gate_status[self.gate_selected], self.GATE_AVAILABLE))
+                                self.log_info("Gate %d already loaded - marked available, skipping check" % self.gate_selected)
+                                gates_tools = [[g, t] for g, t in gates_tools if g != self.gate_selected]
+                                if not gates_tools:
+                                    if not quiet:
+                                        self.log_info(self._mmu_visual_to_string())
+                                    return
+
                             # Force initial eject
                             if filament_pos != self.FILAMENT_POS_UNLOADED:
                                 self.log_info("Unloading current tool prior to checking gates")


### PR DESCRIPTION
On print start with the correct filament already loaded, HH unloads it,
re-checks the gate, then reloads it. `MMU_CHECK_GATE` always ejects first,
setting `filament_pos = UNLOADED`, which defeats the "already loaded"
short-circuit in `MMU_CHANGE_TOOL`.

- `mmu.py`: an already-loaded gate is proven present — mark it `AVAILABLE` and
  skip it instead of unloading to re-verify; return early if it was the only
  gate. Other gates still unload to free the selector, so multi-color also stops
  re-checking the loaded gate.
- `mmu_software.cfg`: skip `MMU_CHECK_GATE` entirely for a single-tool print
  whose initial tool is already loaded.

Isolated core of #899 (credit @ModularPrintingSystem), without the
recover/purge/install changes.


v4 port: #970.
