### PR TITLE
fix(mmu): skip unload of already-loaded gate on print start check (v4)

### DIFF
--- a/config/macros/mmu_software.cfg
+++ b/config/macros/mmu_software.cfg
@@ -196,6 +196,8 @@ gcode:
     {% set vars = printer['gcode_macro _MMU_SOFTWARE_VARS'] %}
     {% set check_gates = vars.check_gates|lower == 'true' %}
     {% set using_bypass = printer.mmu.tool == -2 %}
+    {% set selected_tool = printer.mmu.tool %}
+    {% set filament_loaded = printer.mmu.filament_pos == 10 %}
 
     {% if printer.mmu.enabled %}
         {% set slicer_tool_map = printer.mmu.slicer_tool_map %}
@@ -204,13 +206,17 @@ gcode:
         {% if not using_bypass %}
             # Future: Could do extra checks like filament material type/color checking here
             #         to ensure what's loaded on MMU matches the slicer expectations
-            {% if check_gates and tools|length > 0 %}
+            # Skip check for single-tool print whose initial tool is already loaded (avoids a needless home)
+            {% set skip_gate_check = tools|length <= 1 and initial_tool is not none and selected_tool == initial_tool and filament_loaded %}
+            {% if check_gates and tools|length > 0 and not skip_gate_check %}
                 # Pre-check gates option if multi-color print. Will pause if tools missing
                 MMU_LOG MSG="Checking all required gates have filament loaded..."
                 {% if not printer.mmu.is_homed %}
                     MMU_HOME
                 {% endif %}
                 MMU_CHECK_GATE TOOLS={tools|join(",")}
+            {% elif check_gates and skip_gate_check %}
+                MMU_LOG MSG="Skipping gate check: initial tool T{initial_tool} already loaded"
             {% endif %}
         {% endif %}
     {% endif %}

--- a/extras/mmu/commands/mmu_check_gate.py
+++ b/extras/mmu/commands/mmu_check_gate.py
@@ -126,6 +126,16 @@ class MmuCheckGateCommand(BaseCommand):
                             else:
                                 raise MmuError("Current gate is invalid")
 
+                            # An already loaded gate is proven present - mark available and skip rather than unload to re-verify
+                            if filament_pos == FILAMENT_POS_LOADED and mmu.gate_selected >= 0 and any(g == mmu.gate_selected for g, _t in gates_tools):
+                                mmu.gate_maps.set_gate_status(mmu.gate_selected, max(mmu.gate_status[mmu.gate_selected], GATE_AVAILABLE))
+                                mmu.log_info("Gate %d already loaded - marked available, skipping check" % mmu.gate_selected)
+                                gates_tools = [[g, t] for g, t in gates_tools if g != mmu.gate_selected]
+                                if not gates_tools:
+                                    if not quiet:
+                                        mmu.log_info(mmu._mmu_visual_to_string(), color=True)
+                                    return
+
                             # Force initial eject
                             if filament_pos != FILAMENT_POS_UNLOADED:
                                 mmu.log_info("Unloading current tool prior to checking gates")


### PR DESCRIPTION
v4 forward-port of #969.

On print start with the correct filament already loaded, `MMU_CHECK_GATE` ejects
it before verifying the gate, then it gets reloaded.

- `commands/mmu_check_gate.py`: mark an already-loaded gate `AVAILABLE` and skip
  it instead of unloading to re-verify; return early if it was the only gate.
- `config/macros/mmu_software.cfg`: skip `MMU_CHECK_GATE` for a single-tool print
  whose initial tool is already loaded.

Isolated core of #899 (credit @ModularPrintingSystem).
