### PR TITLE
EMU installer updates

### DIFF
--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -611,7 +611,7 @@ logo_leds:   [[parts[0].strip()]]
 [% for part in parts[1:] %]
              [[part.strip()]]
 [% endfor %]
-frame_rate: 24
+frame_rate: 15
 
 # Default effects for LED segments when not providing action status
 #    off              - LED's off

--- a/installer/Kconfig.calibration
+++ b/installer/Kconfig.calibration
@@ -16,14 +16,15 @@
 menu "Calibration/Autotuning"
   config BOOL_AUTOCAL_BOWDEN_LENGTH
     bool "Auto calibrate bowden length"
-    default y if MMU_HAS_SYNC_FEEDBACK_BUFFER && MMU_HAS_SENSOR_BUFFER_COMPRESSION
+    default y
+    #default y if MMU_HAS_SYNC_FEEDBACK_BUFFER && MMU_HAS_SENSOR_BUFFER_COMPRESSION && MMU_HAS_SENSOR_BUFFER_PROPORTIONAL
     help
       Automated bowden length calibration.
       The calibrated bowden length will be established on first load. It can also be set
       manually or reset with MMU_CALIBRATE_BOWDEN. Best results require the use of
       sync-feedback-compression or extruder sensor but gear-touch or encoder will also work.
       Note that 'extruder_homing_endstop' cannot be 'none'
-  config PARAM_AUTOCAL_BOWDEN_LENGTH
+  config PARAM_AUTOCAL_BOWDEN_LENGTH 
     int
     default 1 if BOOL_AUTOCAL_BOWDEN_LENGTH
     default 0
@@ -55,10 +56,11 @@ menu "Calibration/Autotuning"
 
   config BOOL_AUTOTUNE_ROTATION_DISTANCE
     bool "Autotune rotation distance"
-    default y if MMU_HAS_SYNC_FEEDBACK_BUFFER && \
-        ((MMU_HAS_SENSOR_BUFFER_COMPRESSION && \
-          MMU_HAS_SENSOR_BUFFER_TENSION) || \
-         MMU_HAS_SENSOR_BUFFER_PROPORTIONAL)
+    default n
+    #default y if MMU_HAS_SYNC_FEEDBACK_BUFFER && \
+    #    ((MMU_HAS_SENSOR_BUFFER_COMPRESSION && \
+    #      MMU_HAS_SENSOR_BUFFER_TENSION) || \
+    #     MMU_HAS_SENSOR_BUFFER_PROPORTIONAL)
     help
       Automated gate calibration/tuning.
       Requires sync-feedback sensor (aka "buffer") with both compression and tension switches

--- a/installer/boards/per_gate/Kconfig.ebb
+++ b/installer/boards/per_gate/Kconfig.ebb
@@ -6,7 +6,7 @@ if BOARD_TYPE_EBB_1_0
     default "EBB v1"
 
   choice CHOICE_MMU_CONNECTION_TYPE
-    default CHOICE_MMU_CONNECTION_TYPE_SERIAL
+    default CHOICE_MMU_CONNECTION_TYPE_CANBUS
   endchoice
   choice CHOICE_MMU_SERIAL_CONNECTION
     default $(mmu_serial_config,1,stm32)

--- a/installer/boards/per_gate/Kconfig.slb
+++ b/installer/boards/per_gate/Kconfig.slb
@@ -6,7 +6,7 @@ if BOARD_TYPE_SLB_1_0
     default "SLB v1"
 
   choice CHOICE_MMU_CONNECTION_TYPE
-    default CHOICE_MMU_CONNECTION_TYPE_SERIAL
+    default CHOICE_MMU_CONNECTION_TYPE_CANBUS
   endchoice
   choice CHOICE_MMU_SERIAL_CONNECTION
     default $(mmu_serial_config,1,stm32)
@@ -20,32 +20,32 @@ if BOARD_TYPE_SLB_1_0
   if !MMU_HAS_PER_GATE_MCU
 
     config PIN_GEAR_UART 
-      default "$(MCU_NAME):PA15"
+      default "$(MCU_NAME):PB6"
     config PIN_GEAR_STEP
-      default "$(MCU_NAME):PD0" 
+      default "$(MCU_NAME):PB5" 
     config PIN_GEAR_DIR
-      default "$(MCU_NAME):PD1" 
+      default "$(MCU_NAME):PB4" 
     config PIN_GEAR_ENABLE
-      default "!$(MCU_NAME):PD2" 
+      default "!$(MCU_NAME):PB7" 
     config PIN_GEAR_DIAG
       default ""
 
     config PIN_ENTRY_SENSOR_0
-      default "^(MCU_NAME):PB7" 
+      default "^(MCU_NAME):PA1" 
 
     config PIN_EXIT_SENSOR_0
-      default "^(MCU_NAME):PB5"
+      default "^(MCU_NAME):PA0"
 
     config PIN_EJECT_BUTTON_0
-      default "^$(MCU_NAME):PB6"
+      default "^$(MCU_NAME):PB2"
 
     config PIN_NEOPIXEL
-      default "$(MCU_NAME):PD3" 
+      default "$(MCU_NAME):PA2" 
 
     config PIN_BUFFER_TENSION
-      default "^$(MCU_NAME):PB8"
+      default "^$(MCU_NAME):PB1"
     config PIN_BUFFER_COMPRESSION
-      default "^$(MCU_NAME):PB9"
+      default "^$(MCU_NAME):PB0"
 
     if OPTION_PSF_BUFFER
       config PIN_BUFFER_ANALOG
@@ -61,13 +61,13 @@ if BOARD_TYPE_SLB_1_0
   if MMU_HAS_PER_GATE_MCU
 
     config PIN_GEAR_UART 
-      default "$(MCU_NAME)_gate0:PA15"
+      default "$(MCU_NAME)_gate0:PB6"
     config PIN_GEAR_STEP
-      default "$(MCU_NAME)_gate0:PD0" 
+      default "$(MCU_NAME)_gate0:PB5" 
     config PIN_GEAR_DIR
-      default "$(MCU_NAME)_gate0:PD1" 
+      default "$(MCU_NAME)_gate0:PB4" 
     config PIN_GEAR_ENABLE
-      default "!$(MCU_NAME)_gate0:PD2" 
+      default "!$(MCU_NAME)_gate0:PB7" 
     config PIN_GEAR_DIAG
       default ""
 
@@ -75,13 +75,13 @@ if BOARD_TYPE_SLB_1_0
     if PARAM_NUM_GATES > $(gate)
 
       config PIN_GEAR_UART_$(gate)
-        default "$(MCU_NAME)_gate$(gate):PA15"
+        default "$(MCU_NAME)_gate$(gate):PB6"
       config PIN_GEAR_STEP_$(gate)
-        default "$(MCU_NAME)_gate$(gate):PD0" 
+        default "$(MCU_NAME)_gate$(gate):PB5" 
       config PIN_GEAR_DIR_$(gate)
-        default "$(MCU_NAME)_gate$(gate):PD1" 
+        default "$(MCU_NAME)_gate$(gate):PB4" 
       config PIN_GEAR_ENABLE_$(gate)
-        default "!$(MCU_NAME)_gate$(gate):PD2" 
+        default "!$(MCU_NAME)_gate$(gate):PB7" 
       config PIN_GEAR_DIAG_$(gate)
         default ""
 
@@ -92,25 +92,25 @@ if BOARD_TYPE_SLB_1_0
     if PARAM_NUM_GATES > $(gate)
 
       config PIN_ENTRY_SENSOR_$(gate)
-        default "^$(MCU_NAME)_gate$(gate):PB7"
+        default "^$(MCU_NAME)_gate$(gate):PA1"
 
       config PIN_EXIT_SENSOR_$(gate)
-        default "^$(MCU_NAME)_gate$(gate):PB5"
+        default "^$(MCU_NAME)_gate$(gate):PA0"
 
       config PIN_EJECT_BUTTON_$(gate)
-        default "^$(MCU_NAME)_gate$(gate):PB6"
+        default "^$(MCU_NAME)_gate$(gate):PB2"
 
       config PIN_NEOPIXEL_$(gate)
-        default "$(MCU_NAME)_gate$(gate):PD3" 
+        default "$(MCU_NAME)_gate$(gate):PA2" 
 
     endif
     @endrepeat@
 
     # Buffer. Assumed on gate 0 MCU ---
     config PIN_BUFFER_TENSION
-      default "^$(MCU_NAME)_gate0:PB8"
+      default "^$(MCU_NAME)_gate0:PB1"
     config PIN_BUFFER_COMPRESSION
-      default "^$(MCU_NAME)_gate0:PB9"
+      default "^$(MCU_NAME)_gate0:PB0"
 
     if OPTION_PSF_BUFFER
       config PIN_BUFFER_ANALOG

--- a/installer/mmu_types/Kconfig.emu
+++ b/installer/mmu_types/Kconfig.emu
@@ -3,18 +3,19 @@ config MMU_TYPE_EMU_1_0
   help
     EMU is a modular type-B MMU with each spool being contained in it's own
     (optionally heater) enclosure. It had many features and is an incredible
-    choose for new builds. Highly recommended to use with a analog proportional
+    choice for new builds. Highly recommended to use with a analog proportional
     sync-feedback buffer like PSF.
   imply  MMU_HAS_PER_GATE_MCU # Install must also be run with "-e" for PER_GATE_MCU support
   select VIRTUAL_SELECTOR
   select MMU_HAS_ENVIRONMENT_SENSOR
   select MMU_HAS_PER_GATE_ENV_SENSORS
-  select MMU_HAS_HEATER
   select MMU_HAS_PER_GATE_HEATERS
   select MMU_HAS_LEDS
   select MMU_HAS_EJECT_BUTTONS
   select MMU_HAS_SENSOR_ENTRY
+  select MMU_HAS_SENSOR_EXIT
   select BOOL_VARIABLE_ROTATION_DISTANCES
+  select BOOL_VARIABLE_BOWDEN_LENGTHS
   select BOOL_REQUIRE_BOWDEN_MOVE
   select BOOL_FILAMENT_ALWAYS_GRIPPED
   select BOOL_ENABLE_SYNC_TO_EXTRUDER
@@ -56,7 +57,6 @@ if MMU_TYPE_EMU_1_0
     config MMU_HAS_SENSOR_BUFFER_TENSION
       default y
   endif
-
 endif
 
 
@@ -95,7 +95,6 @@ if MMU_TYPE_EMU_1_0
   config PARAM_GEAR_MICROSTEPS
     default 4
 
-  # "Leds" config
   config PARAM_COLOR_ORDER
     default "GRBW"
 
@@ -127,10 +126,13 @@ if MMU_TYPE_EMU_1_0
   config PARAM_GATE_FINAL_EJECT_DISTANCE
     default 100
 
+  config PARAM_SYNC_GEAR_CURRENT
+    default 52
+
   config PARAM_ENVIRONMENT_SENSORS
     generated_default "$(UNIT_NAME)_env{iter}" "" PARAM_NUM_GATES
 
-  config PARAM_FILAMENT_HEATERS
+  config PARAM_FILAMENT_HEATERS 
     generated_default "$(UNIT_NAME)_heater{iter}" "" PARAM_NUM_GATES
 
   comment "_"


### PR DESCRIPTION
* Update SLB pin settings
* Reduce LED frame rate to 15 to mitigate TTC (all mmu's)
* Set EMU feature BOOL_VARIABLE_BOWDEN_LENGTHS
* Set EMU feature MMU_HAS_SENSOR_EXIT
* Set PARAM_SYNC_GEAR_CURRENT 52
* Default EBB & SLB to CANBUS connection
* Revise calibration defaults for all MMU's (Auto cal bowden on, autotune off)