### PR TITLE
V4 kconfig Installer updates - generic & EMU specific

### DIFF
--- a/config/base/mmu.cfg
+++ b/config/base/mmu.cfg
@@ -464,7 +464,7 @@ toolhead_residual_filament: [[PARAM_TOOLHEAD_RESIDUAL_FILAMENT]]		# Reduction in
 # Similarly a value >+5mm also suggests the four settings above are not correct. Also see 'retract' setting in
 # 'mmu_macro_vars.cfg' for final in-print ooze tuning.
 #
-toolhead_ooze_reduction: 0		# Reduction in extruder loading length to prevent ooze (represents filament remaining)
+toolhead_ooze_reduction: [[PARAM_TOOLHEAD_OOZE_REDUCTION]]		# Reduction in extruder loading length to prevent ooze (represents filament remaining)
 
 
 

--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -666,6 +666,39 @@ effect_gate_empty_sel:     mmu_ready_orange2,       (0.1, 0.04, 0)
 
 
 [% endif %]
+[% if MMU_HAS_FANS %]
+# ┌───────────────────────────────────┐
+# │ ███████╗ █████╗ ███╗   ██╗███████╗│
+# │ ██╔════╝██╔══██╗████╗  ██║██╔════╝│
+# │ █████╗  ███████║██╔██╗ ██║███████╗│
+# │ ██╔══╝  ██╔══██║██║╚██╗██║╚════██║│
+# │ ██║     ██║  ██║██║ ╚████║███████║│
+# │ ╚═╝     ╚═╝  ╚═╝╚═╝  ╚═══╝╚══════╝│
+# └───────────────────────────────────┘
+#
+# FAN SUPPORT: Define cooling fans for MMU units
+#
+[% if not MMU_HAS_PER_GATE_MCU %]
+[% if PIN_FAN != "" %]
+[fan_generic _mmu_fan]
+pin: [[PIN_FAN]]
+max_power: [[PARAM_FAN_MAX_POWER]]
+kick_start_time: [[PARAM_FAN_KICK_START_TIME]]
+
+[% endif %]
+[% else %]
+[% for i in range(0, PARAM_NUM_GATES|int) %]
+[% if (PIN_FAN_|d)[i] != "" %]
+[fan_generic _[[UNIT_NAME]]_gate[[i]]_fan]
+pin: [[ (PIN_FAN_|d)[i] ]]
+max_power: [[PARAM_FAN_MAX_POWER]]
+kick_start_time: [[PARAM_FAN_KICK_START_TIME]]
+
+[% endif %]
+[% endfor %]
+[% endif %]
+
+[% endif %]
 [% if MMU_HAS_SYNC_FEEDBACK_BUFFER and not MMU_SHARED_SYNC_FEEDBACK_BUFFER %]
 # ┌───────────────────────────────────────────────────┐
 # │ ██████╗ ██╗   ██╗███████╗███████╗███████╗██████╗  │
@@ -698,8 +731,10 @@ effect_gate_empty_sel:     mmu_ready_orange2,       (0.1, 0.04, 0)
 buffer_range: [[PARAM_BUFFER_RANGE]]		# Travel in "buffer" between compression/tension or one sensor and end (see above)
 buffer_maxrange: [[PARAM_BUFFER_MAXRANGE]]		# Absolute maximum end-to-end travel (mm) provided by buffer (see above)
 
+[% if not MMU_HAS_SENSOR_BUFFER_PROPORTIONAL %]
 tension_pin:     [[PIN_BUFFER_TENSION]]
 compression_pin: [[PIN_BUFFER_COMPRESSION]]
+[% endif %]
 
 # If the buffer is sprung and reliably rests in one position it can be set here. This aids filament detection
 # logic. If 'none' (default) no assumption will be made about resting position.

--- a/installer/Kconfig
+++ b/installer/Kconfig
@@ -222,6 +222,7 @@ if MULTI_UNIT_ENTRY_POINT
   source "Kconfig.options"          # Main software options
   source "Kconfig.tip_shaping"
   source "Kconfig.purging"
+  source "Kconfig.fans"             # Fan configuration
   source "Kconfig.speeds"           # Access to extruder speeds
   source "macro_vars/Kconfig"       # Variables for all macros
 
@@ -258,6 +259,7 @@ if !MULTI_UNIT_ENTRY_POINT
     source "Kconfig.options"        # Main software options
     source "Kconfig.tip_shaping"
     source "Kconfig.purging"
+    source "Kconfig.fans"           # Fan configuration
     source "macro_vars/Kconfig"     # Variables for all macros
   endif
   source "Kconfig.raw"              # Raw access to appropriate parameters

--- a/installer/Kconfig
+++ b/installer/Kconfig
@@ -222,7 +222,6 @@ if MULTI_UNIT_ENTRY_POINT
   source "Kconfig.options"          # Main software options
   source "Kconfig.tip_shaping"
   source "Kconfig.purging"
-  source "Kconfig.fans"             # Fan configuration
   source "Kconfig.speeds"           # Access to extruder speeds
   source "macro_vars/Kconfig"       # Variables for all macros
 
@@ -259,7 +258,6 @@ if !MULTI_UNIT_ENTRY_POINT
     source "Kconfig.options"        # Main software options
     source "Kconfig.tip_shaping"
     source "Kconfig.purging"
-    source "Kconfig.fans"           # Fan configuration
     source "macro_vars/Kconfig"     # Variables for all macros
   endif
   source "Kconfig.raw"              # Raw access to appropriate parameters

--- a/installer/Kconfig.endstops
+++ b/installer/Kconfig.endstops
@@ -191,7 +191,7 @@ menu "Endstops for Bowden movement"
 
     config CHOICE_EXTRUDER_HOMING_ENDSTOP_COMPRESSION
       bool "Filament compression"
-      depends on MMU_HAS_SENSOR_BUFFER_COMPRESSION
+      depends on MMU_HAS_SENSOR_BUFFER_COMPRESSION || MMU_HAS_SENSOR_BUFFER_PROPORTIONAL
       help
         If you have a "sync-feedback" sensor (often called a "buffer")
         with compression switch configured. E.g like Belay or TurtleNeck

--- a/installer/Kconfig.extruder
+++ b/installer/Kconfig.extruder
@@ -7,4 +7,4 @@ config PARAM_EXTRUDER_NAME
   help
     Name of extruder attached to this MMU unit. Typically
     this is 'extruder' but you can connect different
-    mmu units to different extuders
+    mmu units to different extruders

--- a/installer/Kconfig.fans
+++ b/installer/Kconfig.fans
@@ -1,0 +1,68 @@
+# Defines fan configuration for MMU units
+#
+# Responsible for defining/setting:
+#   MMU_HAS_FANS
+#   PIN_FAN (single MCU)
+#   PIN_FAN_X (per-gate MCU)
+#   PARAM_FAN_MAX_POWER
+#   PARAM_FAN_KICK_START_TIME
+
+# Hidden feature : set in boards to enable
+config MMU_SUPPORTS_FANS
+  bool
+  default n
+  help
+    Set by board-specific configurations when fans are available
+
+config MMU_HAS_FANS
+  bool "Has MMU cooling fans?"
+  depends on MMU_SUPPORTS_FANS
+  default n
+  help
+    Enable this if you have cooling fans installed in your MMU unit(s).
+    Fans will be defined as hidden [fan_generic] sections in the generated config.
+
+if MMU_HAS_FANS
+  menu "Fan configuration"
+    config PARAM_FAN_MAX_POWER
+      float "Fan maximum power"
+      default 1.0
+      range 0.1 1.0
+      help
+        Maximum power setting for the fan (0.1 to 1.0).
+        1.0 = 100% power
+
+    config PARAM_FAN_KICK_START_TIME
+      float "Fan kick start time"
+      default 0.5
+      range 0 3.0
+      help
+        Time in seconds to run fan at full power before resetting to target speed.
+  endmenu
+
+  if !MMU_HAS_PER_GATE_MCU
+    menu "Fan pin"
+      config PIN_FAN
+        string
+        prompt "Fan pin"
+        help
+          Pin for cooling fan.
+          Leave blank if you don't have a fan installed.
+          Empty pins will be ignored in the generated configuration.
+    endmenu
+
+  endif
+
+  if MMU_HAS_PER_GATE_MCU
+    menu "Fan pins"
+      @repeat var=i min=0 max=11@
+        config PIN_FAN_$(i)
+          string
+          prompt "Fan $(i) pin" if PARAM_NUM_GATES > $(i)
+          # ningpj kconfig doesn't like help in this block for some reason !!!
+          # help 
+          #   Leave blank if this gate does not have a fan installed.         
+      @endrepeat@
+    endmenu
+  endif
+endif

--- a/installer/Kconfig.leds
+++ b/installer/Kconfig.leds
@@ -77,8 +77,33 @@ if MMU_HAS_LEDS
       string "Logo leds       "
       default ""
 
+    #config PIN_NEOPIXEL
+    #  prompt "Led Neopixel pin"
+
     config PIN_NEOPIXEL
-      prompt "Led Neopixel pin"
+      string
+      prompt "Neopixel pin          " if MMU_HAS_LEDS && !MMU_HAS_PER_GATE_MCU
+
+    menu "Neopixel per-gate pins    " 
+      depends on MMU_HAS_LEDS && MMU_HAS_PER_GATE_MCU
+
+      @repeat var=i min=0 max=11@
+        config PIN_NEOPIXEL_$(i)
+          string
+          prompt "Neopixel gate $(i) pin" if PARAM_NUM_GATES > $(i)
+      @endrepeat@
+    endmenu
+
+    menu "Neopixel box pins         " 
+      depends on MMU_HAS_LEDS && MMU_HAS_PER_GATE_MCU
+
+      @repeat var=i min=0 max=11@
+        config PIN_NEOPIXEL_BOX_$(i)
+          string
+          prompt "Neopixel box gate $(i) pin" if PARAM_NUM_GATES > $(i)
+      @endrepeat@
+    endmenu
   endmenu
+
 endif
 

--- a/installer/Kconfig.mmu_additions
+++ b/installer/Kconfig.mmu_additions
@@ -17,6 +17,7 @@ menu "MMU Features/Additions"
   source "Kconfig.eject_buttons"
   source "Kconfig.encoder"
   source "Kconfig.filament_buffer"
+  source "Kconfig.fans"
   comment "_"
   source "sensors/Kconfig"
 endmenu

--- a/installer/Kconfig.pins
+++ b/installer/Kconfig.pins
@@ -314,13 +314,23 @@ menu "Pins / TMC"
     string
     prompt "Neopixel pin          " if MMU_HAS_LEDS && !MMU_HAS_PER_GATE_MCU
 
-  menu "Neopixel per-gate pins"
+  menu "Neopixel per-gate pins    " 
     depends on MMU_HAS_LEDS && MMU_HAS_PER_GATE_MCU
 
     @repeat var=i min=0 max=11@
       config PIN_NEOPIXEL_$(i)
         string
         prompt "Neopixel gate $(i) pin" if PARAM_NUM_GATES > $(i)
+    @endrepeat@
+  endmenu
+
+  menu "Neopixel box pins         " 
+    depends on MMU_HAS_LEDS && MMU_HAS_PER_GATE_MCU
+
+    @repeat var=i min=0 max=11@
+      config PIN_NEOPIXEL_BOX_$(i)
+        string
+        prompt "Neopixel box gate $(i) pin" if PARAM_NUM_GATES > $(i)
     @endrepeat@
   endmenu
 

--- a/installer/Kconfig.purging
+++ b/installer/Kconfig.purging
@@ -147,6 +147,11 @@ menu "Purging"
           are optionally caught by a collection bucket.
     endif
 
+    config CHOICE_PURGE_MACRO_SLICER
+      bool "Slicer managed"
+      help
+        Purging is controlled and managed by the slicer rather than Happy-Hare.
+
     config CHOICE_PURGE_MACRO_OTHER
       bool "Other / manually entered"
       help
@@ -163,6 +168,7 @@ menu "Purging"
     string
     default "_MMU_PURGE"      if CHOICE_PURGE_MACRO_PURGE
     default "BLOBIFIER"       if CHOICE_PURGE_MACRO_BLOBIFIER
+    default ""                if CHOICE_PURGE_MACRO_SLICER
     default PURGE_MACRO_OTHER if CHOICE_PURGE_MACRO_OTHER
     default ""
 
@@ -173,6 +179,7 @@ menu "Purging"
 
   config BOOL_FORCE_PURGE_STANDALONE
     bool "Happy Hare controlled in-print purge"
+    def_bool n if CHOICE_PURGE_MACRO_SLICER
     def_bool y
     help
       You can choose whether you want the slicer or Happy Hare (recommended) to control filament purging.

--- a/installer/Kconfig.tip_shaping
+++ b/installer/Kconfig.tip_shaping
@@ -57,6 +57,7 @@ menu "Tip Forming / Cutting"
 
   choice CHOICE_FORM_TIP_MACRO
     bool "Select standalone tip shaping option"
+    default CHOICE_FORM_TIP_MACRO_CUT_TIP if MMU_HAS_TOOLHEAD_CUTTER
     default CHOICE_FORM_TIP_MACRO_FORM_TIP
     help
       How to perform standalone tip shaping (forming or cutting)
@@ -65,7 +66,7 @@ menu "Tip Forming / Cutting"
       bool "Tip shaping using filament movement"
       help
         Uses repeated retract/extrude operations to shape filament
-        tip into a torpedeo shape without strings.
+        tip into a torpedo shape without strings.
         Needs careful tuning.
 
     config CHOICE_FORM_TIP_MACRO_CUT_TIP
@@ -74,6 +75,11 @@ menu "Tip Forming / Cutting"
       help
         If toolhead contains a filament cutter with activation
         via toolhead movement.
+
+    config CHOICE_FORM_TIP_MACRO_SLICER
+      bool "Slicer controlled tip forming"
+      help
+        Tip forming is controlled and managed by the slicer rather than Happy Hare.
 
     config CHOICE_FORM_TIP_MACRO_OTHER
       bool "Other / manually entered macro"
@@ -91,6 +97,7 @@ menu "Tip Forming / Cutting"
     string
     default "_MMU_FORM_TIP" if CHOICE_FORM_TIP_MACRO_FORM_TIP
     default "_MMU_CUT_TIP" if CHOICE_FORM_TIP_MACRO_CUT_TIP
+    default ""                if CHOICE_FORM_TIP_MACRO_SLICER
     default FORM_TIP_MACRO_OTHER if CHOICE_FORM_TIP_MACRO_OTHER
     default ""
 
@@ -119,6 +126,7 @@ menu "Tip Forming / Cutting"
 
   config BOOL_FORCE_FORM_TIP_STANDALONE
     bool "Happy Hare controlled in-print tip forming/cutting"
+    def_bool n if CHOICE_FORM_TIP_MACRO_SLICER
     def_bool y
     help
       You can choose whether you want the slicer or Happy Hare (recommended) to control tip forming.

--- a/installer/Kconfig.toolhead
+++ b/installer/Kconfig.toolhead
@@ -13,6 +13,7 @@
 #   PARAM_TOOLHEAD_SENSOR_TO_NOZZLE
 #   PARAM_TOOLHEAD_ENTRY_TO_EXTRUDER
 #   PARAM_TOOLHEAD_RESIDUAL_FILAMENT
+#   PARAM_TOOLHEAD_OOZE_REDUCTION
 
 config MMU_HAS_SENSOR_TOOLHEAD
   def_bool n
@@ -116,7 +117,7 @@ menu "Toolhead sensors/settings"
     depends on MMU_HAS_SENSOR_TOOLHEAD
 
   config PARAM_TOOLHEAD_ENTRY_TO_EXTRUDER
-    float "Extruer sensor to entry    "
+    float "Extruder sensor to entry    "
     help
       Distance (mm) from extruder "entry" sensor to extruder gears
     depends on MMU_HAS_SENSOR_EXTRUDER
@@ -129,16 +130,17 @@ menu "Toolhead sensors/settings"
       in the calculation of purge volume.
       Note that this value can also be measured with 'MMU_CALIBRATE_TOOLHEAD' command (see Happy Hare wiki)
 
-# This is for tuning. Don't expose
-#  config PARAM_TOOLHEAD_OOZE_REDUCTION
-#    float "Ooze reduction             "
-#    default 0
-#    help
-#      This is for tuning to fix blobbing. It is expected that this value is NEAR ZERO as it represents a further
-#      reduction in extruder load length to fix blobbing. If using a wipetower and you experience blobs on it,
-#      increase this value (reduce the quantity of filament loaded). If you experience gaps, decrease this value.
-#      If gaps and already at 0 then perhaps the 'toolhead_extruder_to_nozzle' or 'toolhead_residual_filament'
-#      settings are incorrect. Similarly a value >+5mm also suggests the four settings above are not correct.
-#      Recommend starting with 0
+# This is for tuning and can mask other issues with toolhead dimensions
+  config PARAM_TOOLHEAD_OOZE_REDUCTION
+    float "Ooze reduction             "
+    range 0 5
+    default 0
+    help
+      This is for tuning to fix blobbing. It is expected that this value is NEAR ZERO as it represents a further
+      reduction in extruder load length to fix blobbing. If using a wipetower and you experience blobs on it,
+      increase this value (reduce the quantity of filament loaded). If you experience gaps, decrease this value.
+      If gaps and already at 0 then perhaps the 'toolhead_extruder_to_nozzle' or 'toolhead_residual_filament'
+      settings are incorrect. Similarly a value >+5mm also suggests the four settings above are not correct.
+      Recommend starting with 0
 
 endmenu

--- a/installer/boards/per_gate/Kconfig.ebb
+++ b/installer/boards/per_gate/Kconfig.ebb
@@ -5,6 +5,9 @@ if BOARD_TYPE_EBB_1_0
   config PARAM_BOARD_TYPE
     default "EBB v1"
 
+  config MMU_SUPPORTS_FANS
+    default y
+
   choice CHOICE_MMU_CONNECTION_TYPE
     default CHOICE_MMU_CONNECTION_TYPE_CANBUS
   endchoice
@@ -102,6 +105,10 @@ if BOARD_TYPE_EBB_1_0
 
       config PIN_NEOPIXEL_$(gate)
         default "$(MCU_NAME)_gate$(gate):PD3"
+
+      config PIN_FAN_$(gate)
+        string
+        default "$(MCU_NAME)_gate$(gate):PA0"
 
     endif
     @endrepeat@

--- a/installer/boards/per_gate/Kconfig.slb
+++ b/installer/boards/per_gate/Kconfig.slb
@@ -5,6 +5,9 @@ if BOARD_TYPE_SLB_1_0
   config PARAM_BOARD_TYPE
     default "SLB v1"
 
+  config MMU_SUPPORTS_FANS
+    default y
+
   choice CHOICE_MMU_CONNECTION_TYPE
     default CHOICE_MMU_CONNECTION_TYPE_CANBUS
   endchoice
@@ -46,6 +49,10 @@ if BOARD_TYPE_SLB_1_0
     config PIN_NEOPIXEL_BOX
       string
       default "$(MCU_NAME):PA2"
+
+    config PIN_FAN
+      string
+      default "$(MCU_NAME):PA15"
 
     config PIN_BUFFER_TENSION
       default "^$(MCU_NAME):PB1"
@@ -112,6 +119,10 @@ if BOARD_TYPE_SLB_1_0
       config PIN_NEOPIXEL_BOX_$(gate)
         string
         default "$(MCU_NAME)_gate$(gate):PA2"
+
+      config PIN_FAN_$(gate)
+        string
+        default "$(MCU_NAME)_gate$(gate):PA15"
 
     endif
     @endrepeat@


### PR DESCRIPTION
* Dont write type-CTD tension/compression pins settings to config when PSF selected
* Add option to edit neopixel pins in Pins & LED sections. Pins for 2nd chain only visible when defined in mmu kconfig e.g `kconfig.emu`
* Uncommented and refined ooze settings in toolhead to enable users to manage related settings. Capped 0->5mm
* Purge refinements - added option for "Slicer Controlled" to make more intuitive
* Tip Forming/Cutting refinements - added option for "Slicer controlled" to make more intuitive
* Refined extruder Homing to enable `filament_compression` selection when compression & PSF configured
* Added conditional HW block for MMU fans - single & multi-mcu setups. Delete pins to disable config block for specific gate

More EMU work needed - fan macros, custom neo effects, additional env sensor HW block. Pushing for feedback and validation