### PR TITLE
V4 Fix proportional sensor unload test

### DIFF
--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1449,8 +1449,8 @@ class MmuFilamentMovement:
         self.move_filament(
             "Proportional unload validation: extruder forward spin",
             probe_distance,
-            speed=self.p.extruder_load_speed,
-            motor="extruder",
+            speed=u.p.virtual_sensor_homing_speed,
+            motor="gear",
             wait=True,
         )
         self.movequeue_dwell(0.2) # Let ADC sensor catch up


### PR DESCRIPTION

test activated extruder rather than gear to check if the filament had exited the extruder. Changed to "gear" and reduced speed to a sane level (virtual_sensor_homing_speed) for users with fast extruder_load_speed's (e.g. 100mm/s) to prevent filament tip from getting caught in extruder gears