### PR TITLE
Proportional post load validation and unload verification code fixes

### DIFF
--- a/config/base/mmu.cfg
+++ b/config/base/mmu.cfg
@@ -41,8 +41,8 @@
 #
 [mmu_machine]
 
-happy_hare_version: [[HAPPY_HARE_VERSION]]		# Don't mess, used for upgrade detection
-units:              [[MMU_UNITS]]		# Comma separated list of mmu unit config names. E.g unit0, unit1
+happy_hare_version        : [[HAPPY_HARE_VERSION]]		# Don't mess, used for upgrade detection
+units                     : [[MMU_UNITS]]		# Comma separated list of mmu unit config names. E.g unit0, unit1
 
 
 # ┌───────────────────────────────────────────────────────────────────────────────────────────────────────┐
@@ -74,13 +74,13 @@ units:              [[MMU_UNITS]]		# Comma separated list of mmu unit config nam
 # Note: that it is not recommended to keep logging at level greater that 2 (debug) if not debugging an issue because
 # of the additional overhead
 #
-log_level:                 [[PARAM_LOG_LEVEL]]
-log_file_level:            [[PARAM_LOG_FILE_LEVEL]]		# Can also be set to -1 to disable log file completely
-log_statistics:            1		# 1 to log statistics on every toolchange (default), 0 to disable (but still recorded)
-log_visual:                1		# 1 log visual representation of filament, 0 = disable
-log_startup_status:        1		# Whether to log tool to gate status on startup, 1 = summary (default), 0 = disable
-log_m117_messages:         1		# Whether send toolchange message via M117 to screen
-suppress_klipper_warnings: 0		# Whether to push startup klipper warnings to mmu.log rather than display on console
+log_level                 : [[PARAM_LOG_LEVEL]]
+log_file_level            : [[PARAM_LOG_FILE_LEVEL]]		# Can also be set to -1 to disable log file completely
+log_statistics            : 1		# 1 to log statistics on every toolchange (default), 0 to disable (but still recorded)
+log_visual                : 1		# 1 log visual representation of filament, 0 = disable
+log_startup_status        : 1		# Whether to log tool to gate status on startup, 1 = summary (default), 0 = disable
+log_m117_messages         : 1		# Whether send toolchange message via M117 to screen
+suppress_klipper_warnings : 0		# Whether to push startup klipper warnings to mmu.log rather than display on console
 
 
 # Extruder movement speeds -------------------------------------------------------------------------------------------
@@ -93,18 +93,18 @@ suppress_klipper_warnings: 0		# Whether to push startup klipper warnings to mmu.
 #
 # Speeds of extruder movement. The 'sync' speeds will be used when gear and extruder steppers are moving in sync
 #
-extruder_load_speed:        [[PARAM_EXTRUDER_LOAD_SPEED]]		# mm/s speed of load move inside extruder from homing position to meltzone
-extruder_unload_speed:      [[PARAM_EXTRUDER_LOAD_SPEED]]		# mm/s speed of unload moves inside of extruder (move from meltzone is 50% of this)
-extruder_sync_load_speed:   [[PARAM_EXTRUDER_SYNC_LOAD_SPEED]]		# mm/s speed of synchronized extruder load moves
-extruder_sync_unload_speed: [[PARAM_EXTRUDER_SYNC_UNLOAD_SPEED]]		# mm/s speed of synchronized extruder unload moves
-extruder_homing_speed:      [[PARAM_EXTRUDER_HOMING_SPEED]]		# mm/s speed of extruder only homing moves (e.g. to toolhead sensor)
-extruder_accel:             [[PARAM_EXTRUDER_ACCEL]]	# Extruder stepper acceleration
+extruder_load_speed        : [[PARAM_EXTRUDER_LOAD_SPEED]]		# mm/s speed of load move inside extruder from homing position to meltzone
+extruder_unload_speed      : [[PARAM_EXTRUDER_LOAD_SPEED]]		# mm/s speed of unload moves inside of extruder (move from meltzone is 50% of this)
+extruder_sync_load_speed   : [[PARAM_EXTRUDER_SYNC_LOAD_SPEED]]		# mm/s speed of synchronized extruder load moves
+extruder_sync_unload_speed : [[PARAM_EXTRUDER_SYNC_UNLOAD_SPEED]]		# mm/s speed of synchronized extruder unload moves
+extruder_homing_speed      : [[PARAM_EXTRUDER_HOMING_SPEED]]		# mm/s speed of extruder only homing moves (e.g. to toolhead sensor)
+extruder_accel             : [[PARAM_EXTRUDER_ACCEL]]	# Extruder stepper acceleration
 
 # When Happy Hare calls out to a macro for user customization and for parking moves these settings are applied and the previous
 # values automatically restored afterwards. This allows for deterministic movement speed regardless of the starting state.
 #
-macro_toolhead_max_accel:   0		# Default printer toolhead acceleration applied when macros are run. 0 = use printer max
-macro_toolhead_min_cruise_ratio: 0.5	# Default printer cruise ratio applied when macros are run
+macro_toolhead_max_accel        : 0	# Default printer toolhead acceleration applied when macros are run. 0 = use printer max
+macro_toolhead_min_cruise_ratio : 0.5	# Default printer cruise ratio applied when macros are run
 
 
 # Tip forming --------------------------------------------------------------------------------------------------------
@@ -134,10 +134,10 @@ macro_toolhead_min_cruise_ratio: 0.5	# Default printer cruise ratio applied when
 # If opting for slicer tip forming you MUST configure where the slicer leaves the filament in the extruder since
 # there is no way to determine this. This can be ignored if all tip forming is performed by Happy Hare
 #
-force_form_tip_standalone: [[PARAM_FORCE_FORM_TIP_STANDALONE]]
-form_tip_macro:            [[PARAM_FORM_TIP_MACRO]]	# Macro to call to perform the tip forming (or cutting) operation
-extruder_form_tip_current: [[PARAM_EXTRUDER_FORM_TIP_CURRENT]]			# % of extruder current (100%-150%) to use when forming tip (100 to disable)
-slicer_tip_park_pos:       [[PARAM_SLICER_TIP_PARK_POS]]			# Specifies the position of filament in extruder after slicer completes tip forming
+force_form_tip_standalone : [[PARAM_FORCE_FORM_TIP_STANDALONE]]
+form_tip_macro            : [[PARAM_FORM_TIP_MACRO]]	# Macro to call to perform the tip forming (or cutting) operation
+extruder_form_tip_current : [[PARAM_EXTRUDER_FORM_TIP_CURRENT]]			# % of extruder current (100%-150%) to use when forming tip (100 to disable)
+slicer_tip_park_pos       : [[PARAM_SLICER_TIP_PARK_POS]]			# Specifies the position of filament in extruder after slicer completes tip forming
 
 
 # Purging ------------------------------------------------------------------------------------------------------------
@@ -162,9 +162,9 @@ slicer_tip_park_pos:       [[PARAM_SLICER_TIP_PARK_POS]]			# Specifies the posit
 #
 # Often it is useful to increase the extruder current for the often rapid puring movement to ensure high torque and no skipped steps
 #
-force_purge_standalone: [[PARAM_FORCE_PURGE_STANDALONE]]
-purge_macro:            [[PARAM_PURGE_MACRO]]	# Macro to call to perform the standalone purging operation
-extruder_purge_current: [[PARAM_EXTRUDER_PURGE_CURRENT]]		# % of extruder current (100%-150%) to use when purging (100 to disable)
+force_purge_standalone   : [[PARAM_FORCE_PURGE_STANDALONE]]
+purge_macro              : [[PARAM_PURGE_MACRO]]	# Macro to call to perform the standalone purging operation
+extruder_purge_current   : [[PARAM_EXTRUDER_PURGE_CURRENT]]		# % of extruder current (100%-150%) to use when purging (100 to disable)
 
 
 # Filament management ------------------------------------------------------------------------------------------------
@@ -184,10 +184,10 @@ extruder_purge_current: [[PARAM_EXTRUDER_PURGE_CURRENT]]		# % of extruder curren
 #   defaulting to current gate. A custom gate will disable mmu entry runout detection for EndlessSpool because filament
 #   end must completely pass through the gate for selector to move
 #
-endless_spool_enabled:    [[PARAM_ENDLESS_SPOOL_ENABLED]]		# 0 = disable, 1 = enable endless spool
-endless_spool_on_load:    0		# 0 = don't apply endless spool on load, 1 = run endless spool if gate is empty
-endless_spool_eject_gate: -1		# Which gate to eject the filament remains. -1 = current gate
-endless_spool_groups:			# EndlessSpool grouping (if empty, no groups are defined)
+endless_spool_enabled    : [[PARAM_ENDLESS_SPOOL_ENABLED]]		# 0 = disable, 1 = enable endless spool
+endless_spool_on_load    : 0		# 0 = don't apply endless spool on load, 1 = run endless spool if gate is empty
+endless_spool_eject_gate : -1		# Which gate to eject the filament remains. -1 = current gate
+endless_spool_groups     :		# EndlessSpool grouping (if empty, no groups are defined)
 #
 # Spoolman support requires you to correctly enable spoolman with moonraker first. If enabled, the gate SpoolId will
 # be used to load filament details and color from the spoolman database and Happy Hare will activate/deactivate
@@ -203,8 +203,8 @@ endless_spool_groups:			# EndlessSpool grouping (if empty, no groups are defined
 #        push        |     yes    |           yes             |        yes       |        no         |
 #        pull        |     yes    |           yes             |        yes       |        yes        |
 #
-spoolman_support:         [[PARAM_SPOOLMAN_SUPPORT]]		# off = disabled, readonly = enabled, push = local gate map, pull = remote gate map
-pending_spool_id_timeout: 20		# Seconds after which this pending spool_id (set with rfid) is voided
+spoolman_support         : [[PARAM_SPOOLMAN_SUPPORT]]		# off = disabled, readonly = enabled, push = local gate map, pull = remote gate map
+pending_spool_id_timeout : 20		# Seconds after which this pending spool_id (set with rfid) is voided
 #
 # Mainsail/Fluid UI can visualize the color of filaments next to the extruder/tool chooser. The color is dynamic and
 # can be customized to your choice:
@@ -216,7 +216,7 @@ pending_spool_id_timeout: 20		# Seconds after which this pending spool_id (set w
 #
 # Note: Happy Hare will also add the 'spool_id' variable to the Tx macro if spoolman is enabled
 #
-t_macro_color: slicer
+t_macro_color            : slicer
 
 
 # Console ------------------------------------------------------------------------------------------------------------
@@ -244,24 +244,24 @@ t_macro_color: slicer
 #
 # Comma separated list of desired columns
 # Options: pre_unload, form_tip, unload, post_unload, pre_load, load, purge, post_load, total
-console_stat_columns: unload, load, post_load, total
+console_stat_columns        : unload, load, post_load, total
 
 # Comma separated list of rows. The order determines the order in which they're shown.
 # Options: total, total_average, job, job_average, last
-console_stat_rows: total, total_average, job, job_average, last
+console_stat_rows           : total, total_average, job, job_average, last
 
 # How you'd want to see the state of the gates and how they're performing
 #   string     - poor, good, perfect, etc..
 #   percentage - rate of success
 #   emoticon   - fun sad to happy faces (python3 only)
-console_gate_stat:           emoticon
+console_gate_stat           : emoticon
 
 # Always display the full statistics table
-console_always_output_full:  1		# 1 = Show full table, 0 = Only show totals out of print
+console_always_output_full  : 1		# 1 = Show full table, 0 = Only show totals out of print
 
 # Color options
-console_show_colored_text:   1		# 1 = Use color in console output, 0 = monochrome
-console_show_filament_color: 1		# 1 = Use colored "swatch" for filament, 0 = Safe, non-colored asterisk (*)
+console_show_colored_text   : 1		# 1 = Use color in console output, 0 = monochrome
+console_show_filament_color : 1		# 1 = Use colored "swatch" for filament, 0 = Safe, non-colored asterisk (*)
 
 
 # Misc ---------------------------------------------------------------------------------------------------------------
@@ -277,38 +277,38 @@ console_show_filament_color: 1		# 1 = Use colored "swatch" for filament, 0 = Saf
 #
 # Temperature and timeouts
 #
-timeout_pause:              72000	# Idle time out (printer shuts down) in seconds used when in MMU pause state
-disable_heater:             600		# Delay in seconds after which the hotend heater is disabled in the MMU_PAUSE state
-default_extruder_temp:      200		# Default temperature for performing swaps and forming tips when not in print (overridden by gate map)
-extruder_temp_variance:     2		# When waiting for extruder temperature this is the +/- permissible variance in degrees (>= 1)
+timeout_pause              : 72000	# Idle time out (printer shuts down) in seconds used when in MMU pause state
+disable_heater             : 600	# Delay in seconds after which the hotend heater is disabled in the MMU_PAUSE state
+default_extruder_temp      : 200	# Default temperature for performing swaps and forming tips when not in print (overridden by gate map)
+extruder_temp_variance     : 2		# When waiting for extruder temperature this is the +/- permissible variance in degrees (>= 1)
 
 #
 # Other workflow options
 #
-startup_reset_ttg_map:      0		# 1 = reset TTG map on startup, 0 = do nothing
-show_error_dialog:          1		# 1 = show pop-up dialog in addition to console message, 0 = show error in console
+startup_reset_ttg_map      : 0		# 1 = reset TTG map on startup, 0 = do nothing
+show_error_dialog          : 1		# 1 = show pop-up dialog in addition to console message, 0 = show error in console
 
 # If enabled with MMU with toolhead sensor, this will cause filament position recovery to perform extra moves to
 # look for filament trapped in the space after extruder but before sensor
-strict_filament_recovery:   0
+strict_filament_recovery   : 0
 
-filament_recovery_on_pause: 1		# 1 = Run a quick check to determine current filament position on pause/error, 0 = disable
+filament_recovery_on_pause : 1		# 1 = Run a quick check to determine current filament position on pause/error, 0 = disable
 
 # Whether to automatically retry a failed tool change. If enabled Happy Hare will perform the equivalent of 'MMU_RECOVER' + 'Tx'
 # commands which usually is all that is necessary to recover. Note that enabling this can mask problems with your MMU
-retry_tool_change_on_error: 0		
+retry_tool_change_on_error : 0		
  
-bypass_autoload:            1		# If extruder sensor fitted this controls the automatic loading of extruder for bypass operation
+bypass_autoload            : 1		# If extruder sensor fitted this controls the automatic loading of extruder for bypass operation
 
 #
 # ADVANCED OPTIONS. Don't mess unless you fully understand. Read documentation.
 #
 # Enabled for Happy Hare to automatically detect start and end of print and call MMU_PRINT_START and MMU_PRINT_END automatically.
 # Harmless to leave enabled but can disable if you think it is causing problems and known START/END is covered in your macros
-print_start_detection:      1		
+print_start_detection      : 1		
 
-gcode_load_sequence:        0		# VERY ADVANCED: Gcode loading sequence 1=enabled, 0=internal logic (default)
-gcode_unload_sequence:      0		# VERY ADVANCED: Gcode unloading sequence, 1=enabled, 0=internal logic (default)
+gcode_load_sequence        : 0		# VERY ADVANCED: Gcode loading sequence 1=enabled, 0=internal logic (default)
+gcode_unload_sequence      : 0		# VERY ADVANCED: Gcode unloading sequence, 1=enabled, 0=internal logic (default)
 
 
 #
@@ -316,17 +316,17 @@ gcode_unload_sequence:      0		# VERY ADVANCED: Gcode unloading sequence, 1=enab
 #   'filament_type': (max_temp, drying_time_mins)
 #
 drying_data: {
-    'pla'   :  (45, 300),
-    'pla+'  :  (55, 300),
-    'petg'  :  (60, 300),
-    'tpu'   :  (55, 300),
-    'abs'   :  (70, 300),
-    'abs+'  :  (75, 300),
-    'asa'   :  (65, 300),
-    'nylon' :  (75, 600),
-    'pc'    :  (75, 600),
-    'pva'   :  (75, 600),
-    'hips'  :  (75, 600)
+    'pla'   : (45, 300),
+    'pla+'  : (55, 300),
+    'petg'  : (60, 300),
+    'tpu'   : (55, 300),
+    'abs'   : (70, 300),
+    'abs+'  : (75, 300),
+    'asa'   : (65, 300),
+    'nylon' : (75, 600),
+    'pc'    : (75, 600),
+    'pva'   : (75, 600),
+    'hips'  : (75, 600)
     }
 
 
@@ -343,24 +343,24 @@ drying_data: {
 # operations especially so with CANbus connected MCUs. Happy Hare uses many homing moves for reliable extruder loading
 # and unloading and enabling this option affords klipper more tolerance and avoids this dreaded error
 # 1 = Increase TRSYNC_TIMEOUT, 0 = Leave the klipper default
-update_trsync: 0
+update_trsync            : 0
 
 # Some CANbus boards are prone to this but it have been seen on regular USB boards where a comms timeout will kill
 # the print. Since it seems to occur only on homing moves they can be safely retried to workaround. This has been
 # working well in practice
 # Number of retries. Recommend the default of 3.
-canbus_comms_retries: 3
+canbus_comms_retries     : 3
 
 # Older neopixels have very finicky timing and can generate lots of "Unable to obtain 'neopixel_result' response"
 # errors in klippy.log. An often cited workaround is to increase BIT_MAX_TIME in neopixel.py. This option does that
 # automatically for you to save dirtying klipper
 # 1 = Increase BIT_MAX_TIME, 0 = Leave the klipper default
-update_bit_max_time: 1
+update_bit_max_time      : 1
 
 # BTT ViViD used a AHT30 sensor. If you are using an older klipper you may not have this sensor available. If so, use
 # AHT10 and set this to 1 to convert AHT30 commands to AHT10
 # 1 = Config AHT10 for BTT ViViD heater sensor on older klipper, 0 = Leave the klipper default
-update_aht10_commands: 0
+update_aht10_commands    : 0
 
 
 # Macros -------------------------------------------------------------------------------------------------------------
@@ -376,18 +376,18 @@ update_aht10_commands: 0
 # Other macros are detailed in 'mmu_sequence.cfg'
 # Also see form_tip_macro in Tip Forming section and purge_macro in Purging section
 #
-pause_macro:               PAUSE			# What macro to call to pause the print
-action_changed_macro:      _MMU_ACTION_CHANGED		# Called when action (printer.mmu.action) changes
-print_state_changed_macro: _MMU_PRINT_STATE_CHANGED	# Called when print state (printer.mmu.print_state) changes
-mmu_event_macro:           _MMU_EVENT			# Called on useful MMU events
-post_preload_macro:        _MMU_POST_PRELOAD		# Called after successful preload of filament
-pre_unload_macro:          _MMU_PRE_UNLOAD		# Called before starting the unload
-post_form_tip_macro:       _MMU_POST_FORM_TIP		# Called immediately after tip forming
-post_unload_macro:         _MMU_POST_UNLOAD		# Called after unload completes
-pre_load_macro:            _MMU_PRE_LOAD		# Called before starting the load
-post_load_macro:           _MMU_POST_LOAD		# Called after the load is complete
-unload_sequence_macro:     _MMU_UNLOAD_SEQUENCE		# VERY ADVANCED: Optionally called based on 'gcode_unload_sequence'
-load_sequence_macro:       _MMU_LOAD_SEQUENCE		# VERY ADVANCED: Optionally called based on 'gcode_load_sequence'
+pause_macro               : PAUSE			# What macro to call to pause the print
+action_changed_macro      : _MMU_ACTION_CHANGED		# Called when action (printer.mmu.action) changes
+print_state_changed_macro : _MMU_PRINT_STATE_CHANGED	# Called when print state (printer.mmu.print_state) changes
+mmu_event_macro           : _MMU_EVENT			# Called on useful MMU events
+post_preload_macro        : _MMU_POST_PRELOAD		# Called after successful preload of filament
+pre_unload_macro          : _MMU_PRE_UNLOAD		# Called before starting the unload
+post_form_tip_macro       : _MMU_POST_FORM_TIP		# Called immediately after tip forming
+post_unload_macro         : _MMU_POST_UNLOAD		# Called after unload completes
+pre_load_macro            : _MMU_PRE_LOAD		# Called before starting the load
+post_load_macro           : _MMU_POST_LOAD		# Called after the load is complete
+unload_sequence_macro     : _MMU_UNLOAD_SEQUENCE	# VERY ADVANCED: Optionally called based on 'gcode_unload_sequence'
+load_sequence_macro       : _MMU_LOAD_SEQUENCE		# VERY ADVANCED: Optionally called based on 'gcode_load_sequence'
 
 
 # Reset detaults -----------------------------------------------------------------------------------------------------
@@ -443,8 +443,8 @@ load_sequence_macro:       _MMU_LOAD_SEQUENCE		# VERY ADVANCED: Optionally calle
 #
 # Pin configuration is flexible: no need to comment out, empty pins are ignored
 #
-extruder_switch_pin: [[PIN_EXTRUDER_SENSOR]]
-toolhead_switch_pin: [[PIN_TOOLHEAD_SENSOR]]
+extruder_switch_pin         : [[PIN_EXTRUDER_SENSOR]]
+toolhead_switch_pin         : [[PIN_TOOLHEAD_SENSOR]]
 
 # To support hall-effect filament width sensor fitted on Qidi printers, this configuration allows it to
 # emulate a extruder/toolhead sensor! (note slight homing inaccuracy). If configured it will override
@@ -460,7 +460,7 @@ toolhead_switch_pin: [[PIN_TOOLHEAD_SENSOR]]
 
 # Whether to register the sensors for visibility in klipper UI's and with QUERY_SENSOR command
 #
-register_toolhead_sensors:   [[PARAM_REGISTER_TOOLHEAD_SENSORS]]
+register_toolhead_sensors   : [[PARAM_REGISTER_TOOLHEAD_SENSORS]]
 
 # IMPORTANT: These next three settings are based on the physical dimensions of your toolhead
 # Once a homing position is determined, Happy Hare needs to know the final move distance to the nozzle. There is only
@@ -470,15 +470,15 @@ register_toolhead_sensors:   [[PARAM_REGISTER_TOOLHEAD_SENSORS]]
 # NOTE: If you have a toolhead sensor you can automate the calculation of these parameters! Read about the
 # `MMU_CALIBRATE_TOOLHEAD` command (https://github.com/moggieuk/Happy-Hare/wiki/Blobbing-and-Stringing#---calibrating-toolhead)
 #
-toolhead_extruder_to_nozzle: [[PARAM_TOOLHEAD_EXTRUDER_TO_NOZZLE]]	# Distance from extruder gears (entrance) to nozzle
-toolhead_sensor_to_nozzle:   [[PARAM_TOOLHEAD_SENSOR_TO_NOZZLE]]	# Distance from toolhead sensor to nozzle (ignored if not fitted)
-toolhead_entry_to_extruder:  [[PARAM_TOOLHEAD_ENTRY_TO_EXTRUDER]]	# Distance from extruder "entry" sensor to extruder gears (ignored if not fitted)
+toolhead_extruder_to_nozzle : [[PARAM_TOOLHEAD_EXTRUDER_TO_NOZZLE]]	# Distance from extruder gears (entrance) to nozzle
+toolhead_sensor_to_nozzle   : [[PARAM_TOOLHEAD_SENSOR_TO_NOZZLE]]	# Distance from toolhead sensor to nozzle (ignored if not fitted)
+toolhead_entry_to_extruder  : [[PARAM_TOOLHEAD_ENTRY_TO_EXTRUDER]]	# Distance from extruder "entry" sensor to extruder gears (ignored if not fitted)
 
 # This setting represents how much residual filament is left behind in the nozzle when filament is removed, it is thus
 # used to reduce the extruder loading length and prevent excessive blobbing but also in the calculation of purge volume.
 # Note that this value can also be measured with the `MMU_CALIBRATE_TOOLHEAD` procedure
 #
-toolhead_residual_filament:  [[PARAM_TOOLHEAD_RESIDUAL_FILAMENT]]		# Reduction in extruder loading length because of residual filament left behind
+toolhead_residual_filament  : [[PARAM_TOOLHEAD_RESIDUAL_FILAMENT]]		# Reduction in extruder loading length because of residual filament left behind
 
 # TUNING: Finally, this is the last resort tuning value to fix blobbing. It is expected that this value is NEAR ZERO as
 # it represents a further reduction in extruder load length to fix blobbing. If using a wipetower and you experience blobs
@@ -487,7 +487,7 @@ toolhead_residual_filament:  [[PARAM_TOOLHEAD_RESIDUAL_FILAMENT]]		# Reduction i
 # Similarly a value >+5mm also suggests the four settings above are not correct. Also see 'retract' setting in
 # 'mmu_macro_vars.cfg' for final in-print ooze tuning.
 #
-toolhead_ooze_reduction:     [[PARAM_TOOLHEAD_OOZE_REDUCTION]]		# Reduction in extruder loading length to prevent ooze (represents filament remaining)
+toolhead_ooze_reduction     : [[PARAM_TOOLHEAD_OOZE_REDUCTION]]		# Reduction in extruder loading length to prevent ooze (represents filament remaining)
 
 
 
@@ -505,79 +505,79 @@ toolhead_ooze_reduction:     [[PARAM_TOOLHEAD_OOZE_REDUCTION]]		# Reduction in e
 # that 'define_on' is optional and if specified can be used to restrict effect creation to the desired segments
 #
 [mmu_led_effect mmu_breathing_red]
-layers:       breathing 4 0 top (1,0,0)
+layers    : breathing 4 0 top (1,0,0)
 
 [mmu_led_effect mmu_white_slow]
-define_on:    exit, status
-layers:       breathing 1.0 0 top (0.8,0.8,0.8)
+define_on : exit, status
+layers    : breathing 1.0 0 top (0.8,0.8,0.8)
 
 [mmu_led_effect mmu_white_fast]
-define_on:    exit, status
-layers:       breathing 0.6 0 top (0.2,0.2,0.2)
+define_on : exit, status
+layers    : breathing 0.6 0 top (0.2,0.2,0.2)
 
 [mmu_led_effect mmu_blue_clockwise_slow]
-define_on:    gates, status
-layers:       chase .5 .5 top (0,0,1), (0,0,.4)
+define_on : gates, status
+layers    : chase .5 .5 top (0,0,1), (0,0,.4)
 
 [mmu_led_effect mmu_blue_clockwise_fast]
-define_on:    gates, status
-layers:       chase 1 .5 top (0,0,1), (0,0,.4)
+define_on : gates, status
+layers    : chase 1 .5 top (0,0,1), (0,0,.4)
 
 [mmu_led_effect mmu_blue_anticlock_slow]
-define_on:    gates, status
-layers:       chase -.5 .5 top (0,0,1), (0,0,.4)
+define_on : gates, status
+layers    : chase -.5 .5 top (0,0,1), (0,0,.4)
 
 [mmu_led_effect mmu_blue_anticlock_fast]
-define_on:    gates, status
-layers:       chase -1 .5 top (0,0,1), (0,0,.4)
+define_on : gates, status
+layers    : chase -1 .5 top (0,0,1), (0,0,.4)
 
 [mmu_led_effect mmu_strobe]
-layers:       strobe    1 1.5 add (1,1,1)
-              breathing 2 0   difference (0.95,0,0)
-              static    0 0   top (1,0,0)
+layers    : strobe    1 1.5 add (1,1,1)
+            breathing 2 0   difference (0.95,0,0)
+            static    0 0   top (1,0,0)
 
 [mmu_led_effect mmu_static_green]
-define_on:    gates
-layers:       static 0 0 top (0,0.5,0)
+define_on : gates
+layers    : static 0 0 top (0,0.5,0)
 
 [mmu_led_effect mmu_ready_green]
-define_on:    gates
-layers:       breathing 2 0 subtract (0,0.35,0)
-              static 0 0 top (0,0.5,0)
+define_on : gates
+layers    : breathing 2 0 subtract (0,0.35,0)
+            static 0 0 top (0,0.5,0)
 
 [mmu_led_effect mmu_static_orange]
-define_on:    gates
-layers:       static 0 0 top (0.5,0.2,0)
+define_on : gates
+layers    : static 0 0 top (0.5,0.2,0)
 
 [mmu_led_effect mmu_ready_orange]
-define_on:    gates
-layers:       breathing 2 0 subtract (0.35,0.14,0)
-              static 0 0 top (0.5,0.2,0)
+define_on : gates
+layers    : breathing 2 0 subtract (0.35,0.14,0)
+            static 0 0 top (0.5,0.2,0)
 
 [mmu_led_effect mmu_ready_orange2]
-define_on:    gates
-layers:       breathing 2 0 top (0.175,0.07,0)
+define_on : gates
+layers    : breathing 2 0 top (0.175,0.07,0)
 
 [mmu_led_effect mmu_static_blue]
-define_on:    gates
-layers:       static 0 0 top (0,0,1)
+define_on : gates
+layers    : static 0 0 top (0,0,1)
 
 [mmu_led_effect mmu_ready_blue]
-define_on:    gates
-layers:       breathing 2 0 add (0,0,0.5)
-              static 0 0 top (0,0,0)
+define_on : gates
+layers    : breathing 2 0 add (0,0,0.5)
+            static 0 0 top (0,0,0)
 
 [mmu_led_effect mmu_static_black]
-define_on:    gates
-layers:       static 0 0 top (0,0,0)
+define_on : gates
+layers    : static 0 0 top (0,0,0)
 
 [mmu_led_effect mmu_rainbow]
-define_on:    entry, exit, status
-layers:       gradient  0.8  0.5 add (0.3, 0.0, 0.0), (0.0, 0.3, 0.0), (0.0, 0.0, 0.3)
+define_on : entry, exit, status
+layers    : gradient  0.8  0.5 add (0.3, 0.0, 0.0), (0.0, 0.3, 0.0), (0.0, 0.0, 0.3)
 
 [mmu_led_effect mmu_sparkle]
-define_on:    exit
-layers:       twinkle 8 0.15 top (0.3,0.3,0.3), (0.4,0,0.25)
+define_on : exit
+layers    : twinkle 8 0.15 top (0.3,0.3,0.3), (0.4,0,0.25)
 
 
 
@@ -598,21 +598,21 @@ layers:       twinkle 8 0.15 top (0.3,0.3,0.3), (0.4,0,0.25)
 # Gentry bumper servo optionally used by toolhead filament cutter
 #
 [mmu_servo mmu_gantry_servo]
-pin:                 [[PIN_GANTRY_BUMPER_SERVO]]
-maximum_servo_angle: 180
-minimum_pulse_width: 0.00075
-maximum_pulse_width: 0.00225
-initial_angle:       180
+pin                      : [[PIN_GANTRY_BUMPER_SERVO]]
+maximum_servo_angle      : 180
+minimum_pulse_width      : 0.00075
+maximum_pulse_width      : 0.00225
+initial_angle            : 180
 
 [% endif %]
 [% if MMU_HAS_SERVO_CUTTER %]
 # Servo based filament cutter at MMU end of bowden
 #
 [mmu_servo cut_servo]
-pin:                 [[PIN_SERVO_CUTTER_SERVO]]
-maximum_servo_angle: 180	# Set this to 60 for a 60° Servo
-minimum_pulse_width: 0.0005	# Adapt these for your servo
-maximum_pulse_width: 0.0025	# Adapt these for your servo
+pin                      : [[PIN_SERVO_CUTTER_SERVO]]
+maximum_servo_angle      : 180		# Set this to 60 for a 60° Servo
+minimum_pulse_width      : 0.0005	# Adapt these for your servo
+maximum_pulse_width      : 0.0025	# Adapt these for your servo
 
 [% endif %]
 [% if MMU_HAS_BLOBIFIER %]
@@ -622,69 +622,69 @@ maximum_pulse_width: 0.0025	# Adapt these for your servo
 # comment out the [tmc2209 ...] block and uncomment/edit the matching SPI block.
 #
 [manual_stepper stepper_blobifier]
-step_pin:              [[PIN_BLOBIFIER_STEPPER_STEP]]
-dir_pin:               [[PIN_BLOBIFIER_STEPPER_DIR]]
-enable_pin:            [[PIN_BLOBIFIER_STEPPER_ENABLE]]
-endstop_pin:           [[PIN_BLOBIFIER_STEPPER_ENDSTOP]]
-microsteps:            4
-gear_ratio:            1:1
-rotation_distance:     62.83
-position_min:          0		# Not supported in Kalico - leave disabled there
-position_max:          21		# Not supported in Kalico - leave disabled there
-homing_speed:          20		# Unused in the macros, here for completeness
-velocity:              150
-accel:                 1000
+step_pin                 : [[PIN_BLOBIFIER_STEPPER_STEP]]
+dir_pin                  : [[PIN_BLOBIFIER_STEPPER_DIR]]
+enable_pin               : [[PIN_BLOBIFIER_STEPPER_ENABLE]]
+endstop_pin              : [[PIN_BLOBIFIER_STEPPER_ENDSTOP]]
+microsteps               : 4
+gear_ratio               : 1:1
+rotation_distance        : 62.83
+position_min             : 0		# Not supported in Kalico - leave disabled there
+position_max             : 21		# Not supported in Kalico - leave disabled there
+homing_speed             : 20		# Unused in the macros, here for completeness
+velocity                 : 150
+accel                    : 1000
 
 [tmc2209 manual_stepper stepper_blobifier]
-uart_pin:              [[PIN_BLOBIFIER_STEPPER_UART]]
-run_current:           [[PARAM_BLOBIFIER_STEPPER_RUN_CURRENT]]
-hold_current:          0.1
-interpolate:           true
-stealthchop_threshold: 99999999
-sense_resistor:        0.110
+uart_pin                 : [[PIN_BLOBIFIER_STEPPER_UART]]
+run_current              : [[PARAM_BLOBIFIER_STEPPER_RUN_CURRENT]]
+hold_current             : 0.1
+interpolate              : true
+stealthchop_threshold    : 99999999
+sense_resistor           : 0.110
 
 # --- TMC2240 (SPI) alternative ---
 #[tmc2240 manual_stepper stepper_blobifier]
-#cs_pin:                [[PIN_BLOBIFIER_STEPPER_UART]]
-#spi_software_sclk_pin: PG8
-#spi_software_mosi_pin: PG6
-#spi_software_miso_pin: PG7
-#driver_SLOPE_CONTROL:  2
-#run_current:           [[PARAM_BLOBIFIER_STEPPER_RUN_CURRENT]]
-#hold_current:          0.2
-#interpolate:           true
-#stealthchop_threshold: 99999999
+#cs_pin                   : [[PIN_BLOBIFIER_STEPPER_UART]]
+#spi_software_sclk_pin    : PG8
+#spi_software_mosi_pin    : PG6
+#spi_software_miso_pin    : PG7
+#driver_SLOPE_CONTROL     : 2
+#run_current              : [[PARAM_BLOBIFIER_STEPPER_RUN_CURRENT]]
+#hold_current             : 0.2
+#interpolate              : true
+#stealthchop_threshold    : 99999999
 
 # --- TMC5160 (SPI) alternative ---
 #[tmc5160 manual_stepper stepper_blobifier]
-#cs_pin:                [[PIN_BLOBIFIER_STEPPER_UART]]
-#spi_software_sclk_pin: PG8
-#spi_software_mosi_pin: PG6
-#spi_software_miso_pin: PG7
-#run_current:           [[PARAM_BLOBIFIER_STEPPER_RUN_CURRENT]]
-#hold_current:          0.2
-#interpolate:           true
-#stealthchop_threshold: 99999999
-#sense_resistor:        0.075
+#cs_pin                   : [[PIN_BLOBIFIER_STEPPER_UART]]
+#spi_software_sclk_pin    : PG8
+#spi_software_mosi_pin    : PG6
+#spi_software_miso_pin    : PG7
+#run_current              : [[PARAM_BLOBIFIER_STEPPER_RUN_CURRENT]]
+#hold_current             : 0.2
+#interpolate              : true
+#stealthchop_threshold    : 99999999
+#sense_resistor           : 0.075
 [% else %]
 # Blobifier tray actuator: SERVO
 #
 [mmu_servo blobifier]
-pin: [[PIN_BLOBIFIER_SERVO]]
+pin                      : [[PIN_BLOBIFIER_SERVO]]
 # Adjust until a 'BLOBIFIER_SERVO POS=out' extends the tray fully without a buzzing sound
-minimum_pulse_width: [[PARAM_BLOBIFIER_MINIMUM_PULSE_WIDTH]]
+minimum_pulse_width      : [[PARAM_BLOBIFIER_MINIMUM_PULSE_WIDTH]]
 # Adjust until a 'BLOBIFIER_SERVO POS=in' retracts the tray fully without a buzzing sound
-maximum_pulse_width: [[PARAM_BLOBIFIER_MAXIMUM_PULSE_WIDTH]]
-maximum_servo_angle: 180	# Recommend leaving this value at 180
+maximum_pulse_width      : [[PARAM_BLOBIFIER_MAXIMUM_PULSE_WIDTH]]
+maximum_servo_angle      : 180		# Recommend leaving this value at 180
 [% endif %]
 
 # Blobifer bucket hardware
 #
 [gcode_button bucket]
-pin: [[PIN_BLOBIFIER_BUCKET_SWITCH]]		 # The pullup ( ^ ) is important here
-press_gcode:
+pin                      : [[PIN_BLOBIFIER_BUCKET_SWITCH]]		 # The pullup (^) is important here
+press_gcode: 
   M117 bucket installed
-release_gcode:
+release_gcode: 
   M117 bucket removed
   _BLOBIFIER_COUNT_RESET
 [% endif %]

--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -60,7 +60,6 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 #
 
-
 # ┌──────────────────────────────┐
 # │ ███╗   ███╗ ██████╗██╗   ██╗ │
 # │ ████╗ ████║██╔════╝██║   ██║ │
@@ -81,10 +80,10 @@
 [% for i in range(0, PARAM_NUM_GATES|int) %]
 [mcu [[MCU_NAME]]_gate[[i]]]
 [% if CHOICE_MMU_CONNECTION_TYPE_SERIAL %]
-serial:           [[ (PARAM_MMU_SERIAL_DEVICE_|d)[i] ]]
+serial                   : [[ (PARAM_MMU_SERIAL_DEVICE_|d)[i] ]]
 [% elif CHOICE_MMU_CONNECTION_TYPE_CANBUS %]
-canbus_uuid:      [[ (PARAM_MMU_CANBUS_UUID_|d)[i] ]]
-canbus_interface: can0
+canbus_uuid              : [[ (PARAM_MMU_CANBUS_UUID_|d)[i] ]]
+canbus_interface         : can0
 [% else %]
 #serial:
 #canbus_uuid:
@@ -95,9 +94,9 @@ canbus_interface: can0
 [% else %]
 [mcu [[MCU_NAME]]]
 [% if CHOICE_MMU_CONNECTION_TYPE_SERIAL %]
-serial:      [[PARAM_MMU_SERIAL_DEVICE]]
+serial                   : [[PARAM_MMU_SERIAL_DEVICE]]
 [% elif CHOICE_MMU_CONNECTION_TYPE_CANBUS %]
-canbus_uuid: [[PARAM_MMU_CANBUS_UUID]]
+canbus_uuid              : [[PARAM_MMU_CANBUS_UUID]]
 [% else %]
 #serial:
 #canbus_uuid:
@@ -107,9 +106,9 @@ canbus_uuid: [[PARAM_MMU_CANBUS_UUID]]
 [% if MMU_HAS_BUFFER_MCU %]
 [mcu [[MCU_NAME]]_buffer]
 [% if CHOICE_BUFFER_CONNECTION_TYPE_SERIAL %]
-serial: [[PARAM_BUFFER_SERIAL_DEVICE]]
+serial                   : [[PARAM_BUFFER_SERIAL_DEVICE]]
 [% elif CHOICE_BUFFER_CONNECTION_TYPE_CANBUS %]
-canbus_uuid: [[PARAM_BUFFER_CANBUS_UUID]]
+canbus_uuid              : [[PARAM_BUFFER_CANBUS_UUID]]
 [% else %]
 #serial:
 #canbus_uuid:
@@ -133,23 +132,23 @@ canbus_uuid: [[PARAM_BUFFER_CANBUS_UUID]]
 #
 [mmu_unit [[UNIT_NAME]]]
 # MMU Vendor & Version is used to automatically configure some parameters, validate configuration and set logos
-vendor:              [[PARAM_VENDOR]]		# MMU family
-version:             [[PARAM_VERSION]]		# MMU hardware version number
+vendor                   : [[PARAM_VENDOR]]
+version                  : [[PARAM_VERSION]]
 
-num_gates:           [[PARAM_NUM_GATES]]			# Number of gates/lanes *this* mmu_unit
+num_gates                : [[PARAM_NUM_GATES]]			# Number of gates/lanes *this* mmu_unit
 
-display_name:        [[PARAM_DISPLAY_NAME]]		# Display name of mmu_unit in UI's. Defaults to the vendor name
+display_name             : [[PARAM_DISPLAY_NAME]]		# Display name of mmu_unit in UI's. Defaults to the vendor name
 [% if MMU_HAS_ENCODER %]
-encoder:             [[PARAM_ENCODER_NAME]]		# Name of [mmu_encoder XXX] if fitted (can be shared with other mmu_units)
+encoder                  : [[PARAM_ENCODER_NAME]]		# Name of [mmu_encoder XXX] if fitted (can be shared with other mmu_units)
 [% endif %]
 [% if MMU_HAS_SYNC_FEEDBACK_BUFFER %]
-buffer:              [[PARAM_SYNC_FEEDBACK_BUFFER_NAME]]		# Name of sync-feedback [mmu_buffer XXX] if fitted (can be shared with other mmu_units)
+buffer                   : [[PARAM_SYNC_FEEDBACK_BUFFER_NAME]]		# Name of sync-feedback [mmu_buffer XXX] if fitted (can be shared with other mmu_units)
 [% endif %]
 [% if MMU_HAS_ESPOOLER %]
-espooler:            [[UNIT_NAME]]		# Name of [mmu_espooler XXX] if fitted
+espooler                 : [[UNIT_NAME]]		# Name of [mmu_espooler XXX] if fitted
 [% endif %]
-toolhead:            default		# Name of [mmu_toolhead XXX] associated with unit (defined in mmu.cfg, can be shared)
-extruder_name:       [[PARAM_EXTRUDER_NAME]]		# Name of extruder that mmu_unit is attached to. Defaults to 'extruder'
+toolhead                 : default		# Name of [mmu_toolhead XXX] associated with unit (defined in mmu.cfg, can be shared)
+extruder_name            : [[PARAM_EXTRUDER_NAME]]		# Name of extruder that mmu_unit is attached to. Defaults to 'extruder'
 
 [% if MMU_HAS_ENVIRONMENT_SENSOR %]
 [% if not MMU_HAS_PER_GATE_ENV_SENSORS %]
@@ -158,7 +157,7 @@ extruder_name:       [[PARAM_EXTRUDER_NAME]]		# Name of extruder that mmu_unit i
 # E.g. If you have a section like this: [temperature_sensor MMU_enclosure]
 #      Set: environment_sensor: temperature_sensor MMU_enclosure
 #
-environment_sensor:  [[PARAM_ENVIRONMENT_SENSOR]]
+environment_sensor       : [[PARAM_ENVIRONMENT_SENSOR]]
 
 [% endif %]
 [% if MMU_HAS_PER_GATE_ENV_SENSORS %]
@@ -172,7 +171,7 @@ environment_sensor:  [[PARAM_ENVIRONMENT_SENSOR]]
 [% endif %]
 [% endfor %]
 [% if env_sensors %]
-environment_sensors: [[ env_sensors|join(', ') ]]
+environment_sensors      : [[ env_sensors|join(', ') ]]
 [% endif %]
 [% endif %]
 [% endif %]
@@ -182,15 +181,15 @@ environment_sensors: [[ env_sensors|join(', ') ]]
 # E.g. If you have a section like this: [heater_generic MMU_heater]
 #      Set: filament_heater: heater_generic MMU_heater
 #
-filament_heater:     [[PARAM_FILAMENT_HEATER]]
+filament_heater          : [[PARAM_FILAMENT_HEATER]]
 
 [% endif %]
 [% if MMU_HAS_PER_GATE_HEATERS %]
 # PER-GATE heaters. Some modular MMU designs have per-gate control (e.g. EMU). For this type of MMU, leave
 # 'filament_heater' empty and define a comma separated list of heaters here (length must match the number of gates)
 #
-filament_heaters:    [[PARAM_FILAMENT_HEATERS]]
-max_concurrent_heaters: [[PARAM_MAX_CONCURRENT_HEATERS]]		# Limit the number of simultaneously active heaters (power/PSU protection)
+filament_heaters         : [[PARAM_FILAMENT_HEATERS]]
+max_concurrent_heaters   : [[PARAM_MAX_CONCURRENT_HEATERS]]		# Limit the number of simultaneously active heaters (power/PSU protection)
 [% endif %]
 [% endif %]
 
@@ -201,16 +200,16 @@ max_concurrent_heaters: [[PARAM_MAX_CONCURRENT_HEATERS]]		# Limit the number of 
 # It is safe to leave these settings empty if not applicable - they will be ignored.
 #
 [% if MMU_HAS_SELECTOR_STEPPER %]
-selector_stepper:    [[UNIT_NAME]]_selector
+selector_stepper         : [[UNIT_NAME]]_selector
 [% endif %]
 [% if MMU_HAS_SELECTOR_SERVO %]
-selector_servo:      [[UNIT_NAME]]_selector_servo
+selector_servo           : [[UNIT_NAME]]_selector_servo
 [% endif %]
 [% if MULTIGEAR %]
-gear_steppers:       [[UNIT_NAME]]_gear, [% for i in range(1, PARAM_NUM_GATES|int) %][[UNIT_NAME]]_gear_[[i]][% if not loop.last %], [% endif %][% endfor %]
+gear_steppers            : [[UNIT_NAME]]_gear, [% for i in range(1, PARAM_NUM_GATES|int) %][[UNIT_NAME]]_gear_[[i]][% if not loop.last %], [% endif %][% endfor %]
 
 [% else %]
-gear_stepper:        [[UNIT_NAME]]_gear
+gear_stepper             : [[UNIT_NAME]]_gear
 [% endif %]
 
 # MMU Capabilities
@@ -222,12 +221,12 @@ gear_stepper:        [[UNIT_NAME]]_gear
 #   Type-B: VirtualSelector
 #   Type-C: LinearMultiGearSelector
 #
-selector_type:               [[PARAM_SELECTOR_TYPE]]
-variable_bowden_lengths:     [[PARAM_VARIABLE_BOWDEN_LENGTHS]]		# 1 = If MMU design has different bowden lengths per gate, 0 = bowden length is the same
-variable_rotation_distances: [[PARAM_VARIABLE_ROTATION_DISTANCES]]		# 1 = If MMU design has dissimilar drive/BMG gears, thus rotation distance, 0 = One drive gear (e.g. Tradrack)
-require_bowden_move:         [[PARAM_REQUIRE_BOWDEN_MOVE]]		# 1 = If MMU design has bowden move that is included in load/unload, 0 = zero length bowden (skip bowden move)
-filament_always_gripped:     [[PARAM_FILAMENT_ALWAYS_GRIPPED]]		# 1 = Filament is always trapped by MMU (most type-B designs), 0 = MMU can release filament
-show_bypass:                 [[PARAM_HAS_BYPASS]]		# 1 = Force showing of bypass gate in UI (overruled if selector explicitly implements bypass)
+selector_type               : [[PARAM_SELECTOR_TYPE]]
+variable_bowden_lengths     : [[PARAM_VARIABLE_BOWDEN_LENGTHS]]		# 1 = If MMU design has different bowden lengths per gate, 0 = bowden length is the same
+variable_rotation_distances : [[PARAM_VARIABLE_ROTATION_DISTANCES]]		# 1 = If MMU design has dissimilar drive/BMG gears, thus rotation distance, 0 = One drive gear (e.g. Tradrack)
+require_bowden_move         : [[PARAM_REQUIRE_BOWDEN_MOVE]]		# 1 = If MMU design has bowden move that is included in load/unload, 0 = zero length bowden (skip bowden move)
+filament_always_gripped     : [[PARAM_FILAMENT_ALWAYS_GRIPPED]]		# 1 = Filament is always trapped by MMU (most type-B designs), 0 = MMU can release filament
+show_bypass                 : [[PARAM_HAS_BYPASS]]		# 1 = Force showing of bypass gate in UI (overruled if selector explicitly implements bypass)
 
 
 
@@ -250,38 +249,38 @@ show_bypass:                 [[PARAM_HAS_BYPASS]]		# 1 = Force showing of bypass
 # (see 'extruder_homing_endstop; mmu_gear_touch' in mmu_parameters.cfg)
 #
 [[ "[" ~ PARAM_GEAR_TMC ~ " mmu_stepper " ~ UNIT_NAME ~ "_gear]" ]]
-uart_pin:                [[PIN_GEAR_UART]]
+uart_pin                 : [[PIN_GEAR_UART]]
 [% if BOARD_TYPE_EASY_BRD %]
-uart_address:            0		# Only for old EASY-BRD mcu
+uart_address             : 0		# Only for old EASY-BRD mcu
 [% endif %]
-run_current:             [[PARAM_GEAR_RUN_CURRENT]]
-hold_current:            [[PARAM_GEAR_HOLD_CURRENT]]		# Recommend to be small if not using "touch" or move (TMC stallguard)
-interpolate:             True
-sense_resistor:          0.110		# Usually 0.11, 0.15 for BTT TMC2226
-stealthchop_threshold:   0		# Spreadcycle has more torque and better at speed
+run_current              : [[PARAM_GEAR_RUN_CURRENT]]
+hold_current             : [[PARAM_GEAR_HOLD_CURRENT]]		# Recommend to be small if not using "touch" or move (TMC stallguard)
+interpolate              : True
+sense_resistor           : 0.110	# Usually 0.11, 0.15 for BTT TMC2226
+stealthchop_threshold    : 0		# Spreadcycle has more torque and better at speed
 
 # Uncomment two lines below if you have TMC and want the ability to use filament "touch" homing with gear stepper
 [% if PIN_GEAR_DIAG != "" %]
-diag_pin:                [[PIN_GEAR_DIAG]]		# Set to MCU pin connected to TMC DIAG pin for gear stepper
-driver_SGTHRS:           60		# 255 is most sensitive value, 0 is least sensitive
+diag_pin                 : [[PIN_GEAR_DIAG]]		# Set to MCU pin connected to TMC DIAG pin for gear stepper
+driver_SGTHRS            : 60		# 255 is most sensitive value, 0 is least sensitive
 [% else %]
-#diag_pin:                [[PIN_GEAR_DIAG]]		# Set to MCU pin connected to TMC DIAG pin for gear stepper
-#driver_SGTHRS:           60		# 255 is most sensitive value, 0 is least sensitive
+#diag_pin                 : [[PIN_GEAR_DIAG]]		# Set to MCU pin connected to TMC DIAG pin for gear stepper
+#driver_SGTHRS            : 60		# 255 is most sensitive value, 0 is least sensitive
 [% endif %]
 
 [mmu_stepper [[UNIT_NAME]]_gear]
-step_pin:                [[PIN_GEAR_STEP]]
-dir_pin:                 [[PIN_GEAR_DIR]]
-enable_pin:              [[PIN_GEAR_ENABLE]]
-rotation_distance:       [[PARAM_GEAR_ROTATION_DISTANCE]]	# Typically 22.73 for Bondtech. OVERRIDDEN by calibrated 'mmu_*_gear_rotation_distances' in mmu_vars.cfg
-gear_ratio:              [[PARAM_GEAR_GEAR_RATIO]]		# E.g. ERCFv2 80:20, Tradrack 50:17
-microsteps:              [[PARAM_GEAR_MICROSTEPS]]		# Recommend 16. Increase only if you "step compress" issues when syncing
-full_steps_per_rotation: 200				# 200 for 1.8 degree, 400 for 0.9 degree
+step_pin                 : [[PIN_GEAR_STEP]]
+dir_pin                  : [[PIN_GEAR_DIR]]
+enable_pin               : [[PIN_GEAR_ENABLE]]
+rotation_distance        : [[PARAM_GEAR_ROTATION_DISTANCE]]	# Typically 22.73 for Bondtech. OVERRIDDEN by calibrated 'mmu_*_gear_rotation_distances' in mmu_vars.cfg
+gear_ratio               : [[PARAM_GEAR_GEAR_RATIO]]		# E.g. ERCFv2 80:20, Tradrack 50:17
+microsteps               : [[PARAM_GEAR_MICROSTEPS]]		# Recommend 16. Increase only if you "step compress" issues when syncing
+full_steps_per_rotation  : 200		# 200 for 1.8 degree, 400 for 0.9 degree
 
 # Uncomment the two lines below to enable filament "touch" movement option with gear motor
 [% if PIN_GEAR_DIAG != "" %]
-extra_endstops:
-    mmu_gear_touch=[[PARAM_GEAR_TMC]]_[[UNIT_NAME]]_gear:virtual_endstop
+extra_endstops: 
+    mmu_gear_touch=[[PARAM_GEAR_TMC]]_[[UNIT_NAME]]_gear : virtual_endstop
 [% else %]
 #extra_endstops:
 #    mmu_gear_touch=[[PARAM_GEAR_TMC]]_[[UNIT_NAME]]_gear:virtual_endstop
@@ -295,19 +294,19 @@ extra_endstops:
 [% for i in range(1, PARAM_NUM_GATES|int) %]
 # Filament Drive Gear_[[i]] --------------------------
 [[ "[" ~ PARAM_GEAR_TMC ~ " mmu_stepper " ~ UNIT_NAME ~ "_gear_" ~ i ~ "]" ]]
-uart_pin:                [[ (PIN_GEAR_UART_|d)[i] ]]
+uart_pin                 : [[ (PIN_GEAR_UART_|d)[i] ]]
 [% if PIN_GEAR_DIAG != "" and (PIN_GEAR_DIAG|d)[i] != "" %]
-diag_pin:                [[ (PIN_GEAR_DIAG_|d)[i] ]]
-driver_SGTHRS:           60
+diag_pin                 : [[ (PIN_GEAR_DIAG_|d)[i] ]]
+driver_SGTHRS            : 60
 [% endif %]
 
 [mmu_stepper [[UNIT_NAME]]_gear_[[i]]]
-step_pin:                [[ (PIN_GEAR_STEP_|d)[i] ]]
-dir_pin:                 [[ (PIN_GEAR_DIR_|d)[i] ]]
-enable_pin:              [[ (PIN_GEAR_ENABLE_|d)[i] ]]
+step_pin                 : [[ (PIN_GEAR_STEP_|d)[i] ]]
+dir_pin                  : [[ (PIN_GEAR_DIR_|d)[i] ]]
+enable_pin               : [[ (PIN_GEAR_ENABLE_|d)[i] ]]
 [% if PIN_GEAR_DIAG != "" and (PIN_GEAR_DIAG|d)[i] != "" %]
-extra_endstops:
-    mmu_gear_touch=[[PARAM_GEAR_TMC]]_[[UNIT_NAME]]_gear_[[i]]:virtual_endstop
+extra_endstops: 
+    mmu_gear_touch=[[PARAM_GEAR_TMC]]_[[UNIT_NAME]]_gear_[[i]] : virtual_endstop
 [% endif %]
 
 [% endfor %]
@@ -336,38 +335,38 @@ extra_endstops:
 # Consult wiki doc if you want to setup selector for stallguard homing instead or physical endstop
 #
 [[ "[" ~ PARAM_SELECTOR_TMC ~ " mmu_stepper " ~ UNIT_NAME ~ "_selector]" ]]
-uart_pin:                [[PIN_SELECTOR_UART]]
+uart_pin                 : [[PIN_SELECTOR_UART]]
 [% if BOARD_TYPE_EASY_BRD %]
-uart_address:            1 # Only for old EASY-BRD mcu
+uart_address             : 1 # Only for old EASY-BRD mcu
 [% endif %]
-run_current:             [[PARAM_SELECTOR_RUN_CURRENT]]
-hold_current:            [[PARAM_SELECTOR_HOLD_CURRENT]]		# Can be small if not using "touch" movement (TMC stallguard)
-interpolate:             True
-sense_resistor:          0.110
-stealthchop_threshold:   100		# Stallguard "touch" movement (slower speeds) best done with stealthchop
+run_current              : [[PARAM_SELECTOR_RUN_CURRENT]]
+hold_current             : [[PARAM_SELECTOR_HOLD_CURRENT]]		# Can be small if not using "touch" movement (TMC stallguard)
+interpolate              : True
+sense_resistor           : 0.110
+stealthchop_threshold    : 100		# Stallguard "touch" movement (slower speeds) best done with stealthchop
 
 # Uncomment two lines below if you have TMC and want to use selector "touch" movement
 [% if PIN_SELECTOR_DIAG != "" %]
-diag_pin:                [[PIN_SELECTOR_DIAG]]		# Set to MCU pin connected to TMC DIAG pin for selector stepper
-driver_SGTHRS:           75		# 255 is most sensitive value, 0 is least sensitive
+diag_pin                 : [[PIN_SELECTOR_DIAG]]		# Set to MCU pin connected to TMC DIAG pin for selector stepper
+driver_SGTHRS            : 75		# 255 is most sensitive value, 0 is least sensitive
 [% else %]
-#diag_pin:                [[PIN_SELECTOR_DIAG]]		# Set to MCU pin connected to TMC DIAG pin for selector stepper
-#driver_SGTHRS:           75		# 255 is most sensitive value, 0 is least sensitive
+#diag_pin                 : [[PIN_SELECTOR_DIAG]]		# Set to MCU pin connected to TMC DIAG pin for selector stepper
+#driver_SGTHRS            : 75		# 255 is most sensitive value, 0 is least sensitive
 [% endif %]
 
 [mmu_stepper [[UNIT_NAME]]_selector]
-step_pin:                [[PIN_SELECTOR_STEP]]
-dir_pin:                 [[PIN_SELECTOR_DIR]]
-enable_pin:              [[PIN_SELECTOR_ENABLE]]
-rotation_distance:       [[PARAM_SELECTOR_ROTATION_DISTANCE]]
-gear_ratio:              [[PARAM_SELECTOR_GEAR_RATIO]]
-microsteps:              16		# Don't need high fidelity
-full_steps_per_rotation: 200		# 200 for 1.8 degree, 400 for 0.9 degree
+step_pin                 : [[PIN_SELECTOR_STEP]]
+dir_pin                  : [[PIN_SELECTOR_DIR]]
+enable_pin               : [[PIN_SELECTOR_ENABLE]]
+rotation_distance        : [[PARAM_SELECTOR_ROTATION_DISTANCE]]
+gear_ratio               : [[PARAM_SELECTOR_GEAR_RATIO]]
+microsteps               : 16		# Don't need high fidelity
+full_steps_per_rotation  : 200		# 200 for 1.8 degree, 400 for 0.9 degree
 [% if PIN_SELECTOR_ENDSTOP %]
-endstop_pin:             [[PIN_SELECTOR_ENDSTOP]]		# Selector default endstop (likely microswitch)
+endstop_pin              : [[PIN_SELECTOR_ENDSTOP]]		# Selector default endstop (likely microswitch)
 [% endif %]
 
-extra_endstops:
+extra_endstops: 
 [% if PIN_SELECTOR_ENDSTOP %]
     [[PARAM_SELECTOR_ENDSTOP_NAME]]=default,
 [% endif %]
@@ -377,7 +376,7 @@ extra_endstops:
 [% endfor %]
 [% endif %]
 [% if PIN_SELECTOR_DIAG != "" %]
-    mmu_sel_touch=[[PARAM_SELECTOR_TMC]]_[[UNIT_NAME]]_selector:virtual_endstop
+    mmu_sel_touch=[[PARAM_SELECTOR_TMC]]_[[UNIT_NAME]]_selector : virtual_endstop
 [% else %]
 # Add to extra_endstops for selector "touch" support
 #    mmu_sel_touch=[[PARAM_SELECTOR_TMC]]_[[UNIT_NAME]]_selector:virtual_endstop
@@ -398,10 +397,10 @@ extra_endstops:
 # SELECTOR SERVO: Basic servo PWM setup. Note that if these values are changed then any calibrated angles will also change
 #
 [mmu_servo [[UNIT_NAME]]_selector_servo]
-pin:                 [[PIN_SELECTOR_SERVO]]
-maximum_servo_angle: [[PARAM_SERVO_MAXIMUM_ANGLE]]
-minimum_pulse_width: [[PARAM_SERVO_MIN_PULSE_WIDTH]]
-maximum_pulse_width: [[PARAM_SERVO_MAX_PULSE_WIDTH]]
+pin                      : [[PIN_SELECTOR_SERVO]]
+maximum_servo_angle      : [[PARAM_SERVO_MAXIMUM_ANGLE]]
+minimum_pulse_width      : [[PARAM_SERVO_MIN_PULSE_WIDTH]]
+maximum_pulse_width      : [[PARAM_SERVO_MAX_PULSE_WIDTH]]
 
 
 
@@ -429,23 +428,23 @@ maximum_pulse_width: [[PARAM_SERVO_MAX_PULSE_WIDTH]]
 [mmu_sensors [[UNIT_NAME]]]
 [% if MMU_HAS_SENSOR_ENTRY %]
 [% for i in range(0, PARAM_NUM_GATES|int) %]
-mmu_entry_switch_pin_[[i]]:     [[ (PIN_ENTRY_SENSOR_|d)[i] ]]
+mmu_entry_switch_pin_[[i]]     : [[ (PIN_ENTRY_SENSOR_|d)[i] ]]
 [% endfor %]
 
 [% endif %]
 [% if MMU_HAS_SENSOR_EXIT %]
 [% for i in range(0, PARAM_NUM_GATES|int) %]
-mmu_exit_switch_pin_[[i]]:      [[ (PIN_EXIT_SENSOR_|d)[i] ]]
+mmu_exit_switch_pin_[[i]]      : [[ (PIN_EXIT_SENSOR_|d)[i] ]]
 [% endfor %]
 
 [% endif %]
 [% if MMU_HAS_SENSOR_SHARED_EXIT %]
 # This is a sensor shared by all gates. On type-B designs it is often on the exit of the filament combiner (hub)
-mmu_shared_exit_switch_pin: [[PIN_SHARED_EXIT_SENSOR]]
+mmu_shared_exit_switch_pin : [[PIN_SHARED_EXIT_SENSOR]]
 [% endif %]
 
 # Whether to register the sensors for visibility in klipper UI's and with QUERY_SENSOR command
-register_mmu_sensors:       [[PARAM_REGISTER_MMU_SENSORS]]
+register_mmu_sensors       : [[PARAM_REGISTER_MMU_SENSORS]]
 
 
 
@@ -465,17 +464,17 @@ register_mmu_sensors:       [[PARAM_REGISTER_MMU_SENSORS]]
 [% if not MMU_HAS_PER_GATE_ENV_SENSORS %]
 [% if PARAM_ENVIRONMENT_SENSOR != "" %]
 [temperature_sensor [[UNIT_NAME]]_env]
-sensor_type:          [[PARAM_ENVIRONMENT_SENSOR_I2C_BUS]]
-i2c_address:          [[PARAM_ENVIRONMENT_SENSOR_I2C_ADDRESS]]
+sensor_type              : [[PARAM_ENVIRONMENT_SENSOR_I2C_BUS]]
+i2c_address              : [[PARAM_ENVIRONMENT_SENSOR_I2C_ADDRESS]]
 [% if PARAM_ENVIRONMENT_SENSOR_REPORT_TIME %]
-aht10_report_time:    [[PARAM_ENVIRONMENT_SENSOR_REPORT_TIME]]
+aht10_report_time        : [[PARAM_ENVIRONMENT_SENSOR_REPORT_TIME]]
 [% endif %]
-i2c_mcu:              [[MCU_NAME]]
+i2c_mcu                  : [[MCU_NAME]]
 [% if CHOICE_ENVIRONMENT_SENSOR_I2C_HARDWARE %]
-i2c_bus:              [[PARAM_ENVIRONMENT_SENSOR_I2C_BUS]]
+i2c_bus                  : [[PARAM_ENVIRONMENT_SENSOR_I2C_BUS]]
 [% else %]
-i2c_software_scl_pin: [[MCU_NAME]]:[[PIN_ENVIRONMENT_SENSOR_SCL]]
-i2c_software_sda_pin: [[MCU_NAME]]:[[PIN_ENVIRONMENT_SENSOR_SDA]]
+i2c_software_scl_pin     : [[MCU_NAME]]:[[PIN_ENVIRONMENT_SENSOR_SCL]]
+i2c_software_sda_pin     : [[MCU_NAME]]:[[PIN_ENVIRONMENT_SENSOR_SDA]]
 [% endif %]
 
 [% endif %]
@@ -483,17 +482,17 @@ i2c_software_sda_pin: [[MCU_NAME]]:[[PIN_ENVIRONMENT_SENSOR_SDA]]
 [% for i in range(0, PARAM_NUM_GATES|int) %]
 [% if (PARAM_ENVIRONMENT_SENSOR_NAME_|d)[i] != "" %]
 [temperature_sensor [[UNIT_NAME]]_env[[i]]]
-sensor_type:          [[PARAM_ENVIRONMENT_SENSOR_TYPE]]
-i2c_address:          [[(PARAM_ENVIRONMENT_SENSOR_I2C_ADDRESS_|d)[i]]]
+sensor_type              : [[PARAM_ENVIRONMENT_SENSOR_TYPE]]
+i2c_address              : [[(PARAM_ENVIRONMENT_SENSOR_I2C_ADDRESS_|d)[i]]]
 [% if (PARAM_ENVIRONMENT_SENSOR_REPORT_TIME_|d)[i] %]
-aht10_report_time:    [[(PARAM_ENVIRONMENT_SENSOR_REPORT_TIME_|d)[i]]]
+aht10_report_time        : [[(PARAM_ENVIRONMENT_SENSOR_REPORT_TIME_|d)[i]]]
 [% endif %]
-i2c_mcu:              [[MCU_NAME]]_gate[[i]]
+i2c_mcu                  : [[MCU_NAME]]_gate[[i]]
 [% if (CHOICE_ENVIRONMENT_SENSOR_I2C_HARDWARE_|d)[i] %]
-i2c_bus:              [[(PARAM_ENVIRONMENT_SENSOR_I2C_BUS_|d)[i]]]
+i2c_bus                  : [[(PARAM_ENVIRONMENT_SENSOR_I2C_BUS_|d)[i]]]
 [% else %]
-i2c_software_scl_pin: [[MCU_NAME]]_gate[[i]]:[[(PIN_ENVIRONMENT_SENSOR_SCL_|d)[i]]]
-i2c_software_sda_pin: [[MCU_NAME]]_gate[[i]]:[[(PIN_ENVIRONMENT_SENSOR_SDA_|d)[i]]]
+i2c_software_scl_pin     : [[MCU_NAME]]_gate[[i]]:[[(PIN_ENVIRONMENT_SENSOR_SCL_|d)[i]]]
+i2c_software_sda_pin     : [[MCU_NAME]]_gate[[i]]:[[(PIN_ENVIRONMENT_SENSOR_SDA_|d)[i]]]
 [% endif %]
 
 [% endif %]
@@ -504,20 +503,20 @@ i2c_software_sda_pin: [[MCU_NAME]]_gate[[i]]:[[(PIN_ENVIRONMENT_SENSOR_SDA_|d)[i
 [% if MMU_HAS_PER_GATE_MCU %]
 [% for i in range(0, PARAM_NUM_GATES|int) %]
 [temperature_sensor [[ ('_' if MMU_HIDE_MCU_ENVIRONMENT_SENSORS else '') ~ UNIT_NAME ~ '_mcu' ~ i ]]]
-sensor_type:          temperature_mcu
-sensor_mcu:           [[MCU_NAME]]_gate[[i]]
+sensor_type              : temperature_mcu
+sensor_mcu               : [[MCU_NAME]]_gate[[i]]
 
 [% endfor %]
 [% else %]
 [temperature_sensor [[UNIT_NAME]]_mcu]
-sensor_type:          temperature_mcu
-sensor_mcu:           [[MCU_NAME]]
+sensor_type              : temperature_mcu
+sensor_mcu               : [[MCU_NAME]]
 
 [% endif %]
 [% if MMU_HAS_BUFFER_MCU %]
 [temperature_sensor [[UNIT_NAME]]_mcu_buffer]
-sensor_type:          temperature_mcu
-sensor_mcu:           [[MCU_NAME]]_buffer
+sensor_type              : temperature_mcu
+sensor_mcu               : [[MCU_NAME]]_buffer
 
 [% endif %]
 [% endif %]
@@ -538,8 +537,8 @@ sensor_mcu:           [[MCU_NAME]]_buffer
 #
 [% for i in range(0, PARAM_NUM_GATES|int) %]
 [gcode_button [[UNIT_NAME]]_eject_[[i]]]
-pin:         [[ (PIN_EJECT_BUTTON_|d)[i] ]]
-press_gcode: MMU_EJECT UNIT=[[UNIT_NAME]] LGATE=[[i]]
+pin                      : [[ (PIN_EJECT_BUTTON_|d)[i] ]]
+press_gcode              : MMU_EJECT UNIT=[[UNIT_NAME]] LGATE=[[i]]
 
 [% endfor %]
 
@@ -560,12 +559,12 @@ press_gcode: MMU_EJECT UNIT=[[UNIT_NAME]] LGATE=[[i]]
 # starting with '_0'.
 #
 [mmu_espooler [[UNIT_NAME]]]
-pwm:                  1		# 1=PWM control (typical), 0=digital on/off control
-hardware_pwm:         0		# See klipper doc
-cycle_time:           0.1	# See klipper doc
-scale:                1		# Scales the PWM output range
-value:                0		# See klipper doc
-shutdown_value:       0		# See klipper doc
+pwm                  : 1		# 1=PWM control (typical), 0=digital on/off control
+hardware_pwm         : 0		# See klipper doc
+cycle_time           : 0.1		# See klipper doc
+scale                : 1		# Scales the PWM output range
+value                : 0		# See klipper doc
+shutdown_value       : 0		# See klipper doc
 
 # Pins (note that empty pins will be ignored and can be left blank)
 # respool_motor_pin is PWM (or digital) pin for rewind/respool movement
@@ -574,12 +573,12 @@ shutdown_value:       0		# See klipper doc
 # assist_trigger_pin is tigger pin for sensing need to assist during print
 #
 [% for i in range(0, PARAM_NUM_GATES|int) %]
-respool_motor_pin_[[i]]:  [[ (PIN_ESPOOLER_RWD_|d)[i] ]]
-assist_motor_pin_[[i]]:   [[ (PIN_ESPOOLER_FWD_|d)[i] ]]
+respool_motor_pin_[[i]]  : [[ (PIN_ESPOOLER_RWD_|d)[i] ]]
+assist_motor_pin_[[i]]   : [[ (PIN_ESPOOLER_FWD_|d)[i] ]]
 [% if HAS_ESPOOLER_ENABLE_PIN %]
-enable_motor_pin_[[i]]:   [[ (PIN_ESPOOLER_EN_|d)[i] ]]
+enable_motor_pin_[[i]]   : [[ (PIN_ESPOOLER_EN_|d)[i] ]]
 [% endif %]
-assist_trigger_pin_[[i]]: [[ (PIN_ESPOOLER_TRIG_|d)[i] ]]
+assist_trigger_pin_[[i]] : [[ (PIN_ESPOOLER_TRIG_|d)[i] ]]
 
 [% endfor %]
 
@@ -603,23 +602,23 @@ assist_trigger_pin_[[i]]: [[ (PIN_ESPOOLER_TRIG_|d)[i] ]]
 [% if MMU_HAS_PER_GATE_MCU %]
 [% for i in range(0, PARAM_NUM_GATES|int) %]
 [neopixel [[UNIT_NAME]]_gate[[i]]_leds]
-pin:         [[ (PIN_NEOPIXEL_|d)[i] ]]
-chain_count: [[PARAM_CHAIN_COUNT]]
-color_order: [[PARAM_COLOR_ORDER]]
+pin         : [[ (PIN_NEOPIXEL_|d)[i] ]]
+chain_count : [[PARAM_CHAIN_COUNT]]
+color_order : [[PARAM_COLOR_ORDER]]
 
 [% if PARAM_VENDOR == "EMU" and PARAM_BOARD_TYPE == "SLB v1" %]
 [neopixel [[UNIT_NAME]]_gate[[i]]_box]
-pin:         [[ (PIN_NEOPIXEL_BOX_|d)[i] ]]
-chain_count: 1
-color_order: [[PARAM_COLOR_ORDER]]
+pin         : [[ (PIN_NEOPIXEL_BOX_|d)[i] ]]
+chain_count : 1
+color_order : [[PARAM_COLOR_ORDER]]
 
 [% endif %]
 [% endfor %]
 [% else %]
 [neopixel [[UNIT_NAME]]_leds]
-pin:         [[PIN_NEOPIXEL]]
-chain_count: [[PARAM_CHAIN_COUNT]]
-color_order: [[PARAM_COLOR_ORDER]]
+pin         : [[PIN_NEOPIXEL]]
+chain_count : [[PARAM_CHAIN_COUNT]]
+color_order : [[PARAM_COLOR_ORDER]]
 
 [% endif %]
 [% endif %]
@@ -662,26 +661,26 @@ color_order: [[PARAM_COLOR_ORDER]]
 #
 [mmu_leds [[UNIT_NAME]]]
 [% set parts = PARAM_ENTRY_LEDS.split(';') %]
-entry_leds:  [[parts[0].strip()]]
+entry_leds  : [[parts[0].strip()]]
 [% for part in parts[1:] %]
-             [[part.strip()]]
+              [[part.strip()]]
 [% endfor %]
 [% set parts = PARAM_EXIT_LEDS.split(';') %]
-exit_leds:   [[parts[0].strip()]]
+exit_leds   : [[parts[0].strip()]]
 [% for part in parts[1:] %]
-             [[part.strip()]]
+              [[part.strip()]]
 [% endfor %]
 [% set parts = PARAM_STATUS_LEDS.split(';') %]
-status_leds: [[parts[0].strip()]]
+status_leds : [[parts[0].strip()]]
 [% for part in parts[1:] %]
-             [[part.strip()]]
+              [[part.strip()]]
 [% endfor %]
 [% set parts = PARAM_LOGO_LEDS.split(';') %]
-logo_leds:   [[parts[0].strip()]]
+logo_leds   : [[parts[0].strip()]]
 [% for part in parts[1:] %]
-             [[part.strip()]]
+              [[part.strip()]]
 [% endfor %]
-frame_rate:  15
+frame_rate  : 15
 
 # Default effects for LED segments when not providing action status
 #    off            - LED's off
@@ -692,15 +691,15 @@ frame_rate:  15
 #   (r,g,b)         - display static r,g,b color e.g. "0,0,0.3" for dim blue
 #    _effect_       - display the named led effect
 #
-enabled:       [[PARAM_ENABLED]]			# True = LEDs are enabled at startup (MMU_LED can control), False = Disabled
-animation:     [[PARAM_ANIMATION]]			# True = Use led-animation-effects, False = Static LEDs
-exit_effect:   gate_status		# off|gate_status|filament_color|slicer_color|r,g,b|_effect_
-entry_effect:  filament_color		# off|gate_status|filament_color|slicer_color|r,g,b|_effect_
-status_effect: filament_color		# on|off|gate_status|filament_color|slicer_color|r,g,b|_effect_
-logo_effect:   (0, 0, 0.3)		# off                                        |r,g,b|_effect_
-white_light:   (1, 1, 1)		# RGB color for static white light
-black_light:   (.01, 0, .02)		# RGB color used to represent "black" (filament)
-empty_light:   (0, 0, 0)		# RGB color used to represent empty gate
+enabled       : [[PARAM_ENABLED]]			# True = LEDs are enabled at startup (MMU_LED can control), False = Disabled
+animation     : [[PARAM_ANIMATION]]			# True = Use led-animation-effects, False = Static LEDs
+exit_effect   : gate_status		# off|gate_status|filament_color|slicer_color|r,g,b|_effect_
+entry_effect  : filament_color		# off|gate_status|filament_color|slicer_color|r,g,b|_effect_
+status_effect : filament_color		# on|off|gate_status|filament_color|slicer_color|r,g,b|_effect_
+logo_effect   : (0, 0, 0.3)		# off                                        |r,g,b|_effect_
+white_light   : (1, 1, 1)		# RGB color for static white light
+black_light   : (.01, 0, .02)		# RGB color used to represent "black" (filament)
+empty_light   : (0, 0, 0)		# RGB color used to represent empty gate
 filament_color_intensity: 0.5		# Intensity reduction when displaying filament or slicer color
 
 # Default effects (animation: True) / static rbg (animation False) to apply to actions
@@ -708,23 +707,23 @@ filament_color_intensity: 0.5		# Intensity reduction when displaying filament or
 #
 # IMPORTANT: Effects must be from [mmu_led_effects] set defined in mmu_leds.cfg
 #
-effect_loading:            mmu_blue_clockwise_slow, (0, 0, 0.4)
-effect_loading_extruder:   mmu_blue_clockwise_fast, (0, 0, 1)
-effect_unloading:          mmu_blue_anticlock_slow, (0, 0, 0.4)
-effect_unloading_extruder: mmu_blue_anticlock_fast, (0, 0, 1)
-effect_heating:            mmu_breathing_red,       (0.3, 0, 0)
-effect_selecting:          mmu_white_fast,          (0.2, 0.2, 0.2)
-effect_checking:           mmu_white_fast,          (0.8, 0.8, 0.8)
-effect_initialized:        mmu_rainbow,             (0.5, 0.2, 0)
-effect_error:              mmu_strobe,              (1, 0, 0)
-effect_complete:           mmu_sparkle,             (0.3, 0.3, 0.3)
-effect_gate_selected:      mmu_static_blue,         (0, 0, 1)
-effect_gate_available:     mmu_static_green,        (0, 0.5, 0)
-effect_gate_available_sel: mmu_ready_green,         (0, 0.75, 0)
-effect_gate_unknown:       mmu_static_orange,       (0.5, 0.2, 0)
-effect_gate_unknown_sel:   mmu_ready_orange,        (0.75, 0.3, 0)
-effect_gate_empty:         mmu_static_black,        (0, 0, 0)
-effect_gate_empty_sel:     mmu_ready_orange2,       (0.1, 0.04, 0)
+effect_loading            : mmu_blue_clockwise_slow, (0, 0, 0.4)
+effect_loading_extruder   : mmu_blue_clockwise_fast, (0, 0, 1)
+effect_unloading          : mmu_blue_anticlock_slow, (0, 0, 0.4)
+effect_unloading_extruder : mmu_blue_anticlock_fast, (0, 0, 1)
+effect_heating            : mmu_breathing_red,       (0.3, 0, 0)
+effect_selecting          : mmu_white_fast,          (0.2, 0.2, 0.2)
+effect_checking           : mmu_white_fast,          (0.8, 0.8, 0.8)
+effect_initialized        : mmu_rainbow,             (0.5, 0.2, 0)
+effect_error              : mmu_strobe,              (1, 0, 0)
+effect_complete           : mmu_sparkle,             (0.3, 0.3, 0.3)
+effect_gate_selected      : mmu_static_blue,         (0, 0, 1)
+effect_gate_available     : mmu_static_green,        (0, 0.5, 0)
+effect_gate_available_sel : mmu_ready_green,         (0, 0.75, 0)
+effect_gate_unknown       : mmu_static_orange,       (0.5, 0.2, 0)
+effect_gate_unknown_sel   : mmu_ready_orange,        (0.75, 0.3, 0)
+effect_gate_empty         : mmu_static_black,        (0, 0, 0)
+effect_gate_empty_sel     : mmu_ready_orange2,       (0.1, 0.04, 0)
 
 
 
@@ -744,18 +743,18 @@ effect_gate_empty_sel:     mmu_ready_orange2,       (0.1, 0.04, 0)
 [% if not MMU_HAS_PER_GATE_MCU %]
 [% if PIN_FAN != "" %]
 [fan_generic _mmu_fan]
-pin:             [[PIN_FAN]]
-max_power:       [[PARAM_FAN_MAX_POWER]]
-kick_start_time: [[PARAM_FAN_KICK_START_TIME]]
+pin             : [[PIN_FAN]]
+max_power       : [[PARAM_FAN_MAX_POWER]]
+kick_start_time : [[PARAM_FAN_KICK_START_TIME]]
 
 [% endif %]
 [% else %]
 [% for i in range(0, PARAM_NUM_GATES|int) %]
 [% if (PIN_FAN_|d)[i] != "" %]
 [fan_generic _[[UNIT_NAME]]_fan[[i]]]
-pin:             [[ (PIN_FAN_|d)[i] ]]
-max_power:       [[PARAM_FAN_MAX_POWER]]
-kick_start_time: [[PARAM_FAN_KICK_START_TIME]]
+pin             : [[ (PIN_FAN_|d)[i] ]]
+max_power       : [[PARAM_FAN_MAX_POWER]]
+kick_start_time : [[PARAM_FAN_KICK_START_TIME]]
 
 [% endif %]
 [% endfor %]
@@ -792,42 +791,41 @@ kick_start_time: [[PARAM_FAN_KICK_START_TIME]]
 #   compression   tension        compression-only                      tension-only
 #
 [mmu_buffer [[UNIT_NAME]]]
-buffer_range:            [[PARAM_BUFFER_RANGE]]	# Travel in "buffer" between compression/tension or one sensor and end (see above)
-buffer_maxrange:         [[PARAM_BUFFER_MAXRANGE]]	# Absolute maximum end-to-end travel (mm) provided by buffer (see above)
+buffer_range            : [[PARAM_BUFFER_RANGE]]		# Travel in "buffer" between compression/tension or one sensor and end (see above)
+buffer_maxrange         : [[PARAM_BUFFER_MAXRANGE]]		# Absolute maximum end-to-end travel (mm) provided by buffer (see above)
 
 [% if not UNSELECT_MMU_HAS_SENSOR_BUFFER_TENSION %]
-tension_pin:             [[PIN_BUFFER_TENSION]]
+tension_pin             : [[PIN_BUFFER_TENSION]]
 [% endif %]
 [% if not UNSELECT_MMU_HAS_SENSOR_BUFFER_COMPRESSION %]
-compression_pin:         [[PIN_BUFFER_COMPRESSION]]
+compression_pin         : [[PIN_BUFFER_COMPRESSION]]
 [% endif %]
 
 # If the buffer is sprung and reliably rests in one position it can be set here. This aids filament detection
 # logic. If 'none' (default) no assumption will be made about resting position.
 #
-buffer_spring_state:     [[PARAM_BUFFER_SPRING_STATE]]	# Default state: none|tension|neutral|compressed
+buffer_spring_state     : [[PARAM_BUFFER_SPRING_STATE]]		# Default state: none|tension|neutral|compressed
 
 # Proportional sync feedback sensor configuration. Leave empty if not fitted.
 # (if you have a proportional sensor the sync_feedback_tension_pin and sync_feedback_compression_pin would likely be empty)
-#
 [% if MMU_HAS_SENSOR_BUFFER_PROPORTIONAL %]
-analog_pin:              [[PIN_BUFFER_ANALOG]]	# The ADC pin where the proportional filament pressure sensor is installed
-analog_max_compression:  [[PARAM_ANALOG_MAX_COMPRESSION]]	# Raw sensor reading at max filament compression (buffer squeezed)
-analog_max_tension:      [[PARAM_ANALOG_MAX_TENSION]]	# Raw sensor reading at max filament tension (buffer expanded)
-analog_neutral_point:    [[PARAM_ANALOG_NEUTRAL_POINT]]	# Biasing of neutral point (sensor value 0). Normally close to 0.5
-analog_gamma:            [[PARAM_ANALOG_GAMMA]]	# Hidden option to change the "shape" the response around neutral_point
-analog_sensor_threshold: [[PARAM_ANALOG_SENSOR_THRESHOLD]]	# The point at which the virtual compression/tension sensors are triggered (on 0-1 scale)
+analog_pin              : [[PIN_BUFFER_ANALOG]]	# The ADC pin where the proportional filament pressure sensor is installed
+analog_max_compression  : [[PARAM_ANALOG_MAX_COMPRESSION]]		# Raw sensor reading at max filament compression (buffer squeezed)
+analog_max_tension      : [[PARAM_ANALOG_MAX_TENSION]]		# Raw sensor reading at max filament tension (buffer expanded)
+analog_neutral_point    : [[PARAM_ANALOG_NEUTRAL_POINT]]		# Biasing of neutral point (sensor value 0). Normally close to 0.5
+analog_gamma            : [[PARAM_ANALOG_GAMMA]]		# Hidden option to change the "shape" the response around neutral_point
+analog_sensor_threshold : [[PARAM_ANALOG_SENSOR_THRESHOLD]]		# The point at which the virtual compression/tension sensors are triggered (on 0-1 scale)
 [% else %]
-#analog_pin:              pin		# The ADC pin where the proportional filament pressure sensor is installed
-#analog_max_compression:  1		# Raw sensor reading at max filament compression (buffer squeezed)
-#analog_max_tension:      0		# Raw sensor reading at max filament tension (buffer expanded)
-#analog_neutral_point:    0.5		# Biasing of neutral point (sensor value 0). Normally close to 0.5
-#analog_gamma:            1		# Hidden option to change the "shape" the response around neutral_point
-#analog_sensor_threshold: 0.9		# The point at which the virtual compression/tension sensors are triggered
+#analog_pin              : pin		# The ADC pin where the proportional filament pressure sensor is installed
+#analog_max_compression  : 1		# Raw sensor reading at max filament compression (buffer squeezed)
+#analog_max_tension      : 0		# Raw sensor reading at max filament tension (buffer expanded)
+#analog_neutral_point    : 0.5		# Biasing of neutral point (sensor value 0). Normally close to 0.5
+#analog_gamma            : 1		# Hidden option to change the "shape" the response around neutral_point
+#analog_sensor_threshold : 0.9		# The point at which the virtual compression/tension sensors are triggered
 [% endif %]
 
 # Whether to register the sensors for visibility in klipper UI's and with QUERY_SENSOR command
-register_buffer_sensors: [[PARAM_REGISTER_BUFFER_SENSORS]]
+register_buffer_sensors : [[PARAM_REGISTER_BUFFER_SENSORS]]
 
 
 
@@ -852,12 +850,12 @@ register_buffer_sensors: [[PARAM_REGISTER_BUFFER_SENSORS]]
 # 24 / (2 * 17) = 0.7059 for TRCT5000 based sensor
 # 24 / (2 * 12) = 1.0 for Binky with 12 tooth disc
 #
-[mmu_encoder        [[UNIT_NAME]]]
-encoder_pin:        [[PIN_ENCODER]]
-encoder_resolution: [[PARAM_ENCODER_RESOLUTION]]	# This is just a starter value. OVERRIDDEN by calibrated 'mmu_*_encoder_resolution' in mmm_vars.cfg
-desired_headroom:   5.0		# The clog/runout headroom that MMU attempts to maintain (closest point to triggering runout)
-average_samples:    4		# The "damping" effect of last measurement (higher value means slower automatic clog_length reduction)
-flowrate_samples:   20		# How many "movements" of the extruder to measure average flowrate over
+[mmu_encoder [[UNIT_NAME]]]
+encoder_pin        : [[PIN_ENCODER]]
+encoder_resolution : [[PARAM_ENCODER_RESOLUTION]]	# This is just a starter value. OVERRIDDEN by calibrated 'mmu_*_encoder_resolution' in mmm_vars.cfg
+desired_headroom   : 5.0	# The clog/runout headroom that MMU attempts to maintain (closest point to triggering runout)
+average_samples    : 4		# The "damping" effect of last measurement (higher value means slower automatic clog_length reduction)
+flowrate_samples   : 20		# How many "movements" of the extruder to measure average flowrate over
 
 
 

--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -803,8 +803,11 @@ compression_pin         : [[PIN_BUFFER_COMPRESSION]]
 
 # If the buffer is sprung and reliably rests in one position it can be set here. This aids filament detection
 # logic. If 'none' (default) no assumption will be made about resting position.
+# Note: with a proportional sensor, 'tension' or 'neutral' is required for extruder collision homing
+# (extruder_homing_endstop: filament_compression) and the load/unload/recovery validation probes.
+# 'compression' and 'none' limit the sensor to sync-feedback control.
 #
-buffer_spring_state     : [[PARAM_BUFFER_SPRING_STATE]]		# Default state: none|tension|neutral|compressed
+buffer_spring_state     : [[PARAM_BUFFER_SPRING_STATE]]		# Default state: none|tension|neutral|compression
 
 # Proportional sync feedback sensor configuration. Leave empty if not fitted.
 # (if you have a proportional sensor the sync_feedback_tension_pin and sync_feedback_compression_pin would likely be empty)

--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -692,10 +692,8 @@ variable_tray_stepper_speed                 : [[VAR_BLOBIFIER_TRAY_STEPPER_SPEED
 # the position of your nozzle stop.
 
 # Start X location of the brush. Indicative defaults for 250, 300 and 350mm are provided below.
-# Uncomment as necessary
-#variable_brush_start                        : 34  # For 250mm build
-variable_brush_start                        : [[VAR_BLOBIFIER_BRUSH_START]]  # For 300mm build
-#variable_brush_start                        : 84  # for 350mm build
+#   34 For 250mm build, 67 For 300mm build, 84 for 350mm build
+variable_brush_start                        : [[VAR_BLOBIFIER_BRUSH_START]]
 
 variable_brush_width                        : [[VAR_BLOBIFIER_BRUSH_WIDTH]] # in MM on X axis
 

--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -42,20 +42,20 @@
 [% if PARAM_SELECTOR_TYPE in ["LinearSelector", "LinearServoSelector", "LinearMultiGearSelector", "RotarySelector", "IndexedSelector", "Testing"] %]
 # Selector stepper movement speeds
 #
-selector_move_speed: [[PARAM_SELECTOR_MOVE_SPEED]]		# mm/s speed of selector movement
+selector_move_speed      : [[PARAM_SELECTOR_MOVE_SPEED]]			# mm/s speed of selector movement
 [% if PARAM_SELECTOR_TYPE not in ["IndexedSelector"] %]
-selector_homing_speed: [[PARAM_SELECTOR_HOMING_SPEED]]		# mm/s speed of initial selector homing move (not touch)
+selector_homing_speed    : [[PARAM_SELECTOR_HOMING_SPEED]]			# mm/s speed of initial selector homing move (not touch)
 [% endif %]
 [% if PARAM_SELECTOR_TYPE not in ["RotarySelector", "IndexedSelector"] %]
-selector_touch_speed: [[PARAM_SELECTOR_TOUCH_SPEED]]		# mm/s speed of all "touch" selector moves (if stallguard configured)
+selector_touch_speed     : [[PARAM_SELECTOR_TOUCH_SPEED]]			# mm/s speed of all "touch" selector moves (if stallguard configured)
 [% endif %]
-selector_accel: 1200			# Selector stepper acceleration
+selector_accel           : 1200			# Selector stepper acceleration
 [% if PIN_SELECTOR_DIAG != "" and PARAM_SELECTOR_TYPE not in ["RotarySelector", "IndexedSelector"] %]
 
 # Selector touch (stallguard) operation. If stallguard is configured, then this can be used to switch on touch movement which
 # can detect blocked filament path and try to recover automatically but it is more difficult to set up
 #
-selector_touch_enabled: [[PARAM_SELECTOR_TOUCH_ENABLED]]		# If selector touch operation configured this can be used to disable it 1=enabled, 0=disabled
+selector_touch_enabled   : [[PARAM_SELECTOR_TOUCH_ENABLED]]			# If selector touch operation configured this can be used to disable it 1=enabled, 0=disabled
 [% endif %]
 
 [% endif %]
@@ -63,8 +63,8 @@ selector_touch_enabled: [[PARAM_SELECTOR_TOUCH_ENABLED]]		# If selector touch op
 # RotarySelector: The direction of filament movement can be changed per-gate to support designs like 3DChameleon
 # Also if 'filament_always_gripped: 0' then an alternative gate can be selected to ungrip in the current gate
 #
-selector_gate_directions: [[PARAM_SELECTOR_GATE_DIRECTIONS]]	# Directions of gear depending on gate (RotarySelector).    E.g. 1, 1, 0, 0
-selector_release_gates: [[PARAM_SELECTOR_RELEASE_GATES]]	# Gate to move to when releasing filament (RotarySelector). E.g. 2, 3, 0, 1
+selector_gate_directions : [[PARAM_SELECTOR_GATE_DIRECTIONS]]		# Directions of gear depending on gate (RotarySelector).    E.g. 1, 1, 0, 0
+selector_release_gates   : [[PARAM_SELECTOR_RELEASE_GATES]]		# Gate to move to when releasing filament (RotarySelector). E.g. 2, 3, 0, 1
 
 [% endif %]
 [% if PARAM_SELECTOR_TYPE in ["IndexedSelector", "Testing"] %]
@@ -73,15 +73,15 @@ selector_release_gates: [[PARAM_SELECTOR_RELEASE_GATES]]	# Gate to move to when 
 # by half of this distance to position the selector in the exact center of the sensor for accurate alignment.
 # Note these settings are replaced if calibrated with MMU_CALIBRATE_SELECTOR_INDEXES
 #
-selector_gate_order: [[PARAM_SELECTOR_GATE_ORDER]]		# Order of gates when selector is moving in forward direction
-selector_endstop_width: [[PARAM_SELECTOR_ENDSTOP_WIDTH]]		# Width (degrees if rotary like ViViD) of index sensor trigger range
+selector_gate_order      : [[PARAM_SELECTOR_GATE_ORDER]]		# Order of gates when selector is moving in forward direction
+selector_endstop_width   : [[PARAM_SELECTOR_ENDSTOP_WIDTH]]			# Width (degrees if rotary like ViViD) of index sensor trigger range
 
 [% endif %]
 [% if PARAM_SELECTOR_TYPE in ["MacroSelector"] %]
 # MacroSelector:
 #
-select_tool_macro: select_tool_macro	# Name of macro called to change gates
-select_tool_num_switches: 0		# Number of switches
+select_tool_macro        : select_tool_macro	# Name of macro called to change gates
+select_tool_num_switches : 0		# Number of switches
 
 [% endif %]
 [% if MMU_HAS_SELECTOR_SERVO %]
@@ -93,11 +93,11 @@ select_tool_num_switches: 0		# Number of switches
 #          The move position also can be used to passively grip the filament like on the ERCFv2 design
 # Note these positions are only for initial config and are replaced with calibrated servo positions in `mmu_vars.cfg`
 #
-servo_up_angle:   [[PARAM_SERVO_UP_ANGLE]]
-servo_down_angle: [[PARAM_SERVO_DOWN_ANGLE]]
-servo_move_angle: [[PARAM_SERVO_MOVE_ANGLE]]			# Optional angle used when selector is moved (defaults to up position)
+servo_up_angle           : [[PARAM_SERVO_UP_ANGLE]]
+servo_down_angle         : [[PARAM_SERVO_DOWN_ANGLE]]
+servo_move_angle         : [[PARAM_SERVO_MOVE_ANGLE]]			# Optional angle used when selector is moved (defaults to up position)
 
-servo_buzz_gear_on_down: [[PARAM_SERVO_BUZZ_GEAR_ON_DOWN]]		# Whether to "buzz" the gear stepper on down to aid engagement
+servo_buzz_gear_on_down  : [[PARAM_SERVO_BUZZ_GEAR_ON_DOWN]]			# Whether to "buzz" the gear stepper on down to aid engagement
 
 [% endif %]
 [% if PARAM_SELECTOR_TYPE in ["ServoSelector", "Testing"] %]
@@ -105,23 +105,25 @@ servo_buzz_gear_on_down: [[PARAM_SERVO_BUZZ_GEAR_ON_DOWN]]		# Whether to "buzz" 
 # can be specified as a list. If empty, calibration will be forced. Note that the "release angle" is by default the
 # nearest position between calibrated selection angles. This can be overriden by setting and explicit servo_release_angle.
 #
-servo_min_angle: [[PARAM_SERVO_MIN_ANGLE]]				# Protect servo by defining min angle
-servo_max_angle: [[PARAM_SERVO_MAX_ANGLE]]				# Protect servo by defining max angle
-servo_gate_angles: [[PARAM_SERVO_GATE_ANGLES]]	# Optional default list of gate angles (overriden by calibration)
-servo_bypass_angle: [[PARAM_SERVO_BYPASS_ANGLE]]			# Optional default servo angle when bypass is selected, -1=No bypass angle
-servo_release_angle: [[PARAM_SERVO_RELEASE_ANGLE]]			# Optionally force a specific "release" angle, -1=Default (between gate angles) behavior
+servo_min_angle          : [[PARAM_SERVO_MIN_ANGLE]]			# Protect servo by defining min angle
+servo_max_angle          : [[PARAM_SERVO_MAX_ANGLE]]			# Protect servo by defining max angle
+servo_gate_angles        : [[PARAM_SERVO_GATE_ANGLES]]	# Optional default list of gate angles (overriden by calibration)
+servo_bypass_angle       : [[PARAM_SERVO_BYPASS_ANGLE]]			# Optional default servo angle when bypass is selected, -1=No bypass angle
+servo_release_angle      : [[PARAM_SERVO_RELEASE_ANGLE]]			# Optionally force a specific "release" angle, -1=Default (between gate angles) behavior
 
 [% endif %]
 # Fine tuning servo movement. Usually defaults are fine but tweak for slow servos
 #
-servo_duration: [[PARAM_SERVO_DURATION]]			# Duration of PWM burst sent to servo (default non-active mode, automatically turns off)
-servo_dwell: [[PARAM_SERVO_DWELL]]			# Minimum time given to servo to complete movement prior to next move
+servo_duration           : [[PARAM_SERVO_DURATION]]			# Duration of PWM burst sent to servo (default non-active mode, automatically turns off)
+servo_dwell              : [[PARAM_SERVO_DWELL]]			# Minimum time given to servo to complete movement prior to next move
 
 # Note that leaving the servo active can stress the servo and electronics (especially 5v power supply). Make sure your hardware is suitable for the job!
+# ⚠️  CAUTION - CAN DAMAGE COMMON SERVOS, USE AT YOUR OWN RISK
+# 1=Force servo to always stay active, 0=Release after movement
 #
-servo_always_active: [[PARAM_SERVO_ALWAYS_ACTIVE]] 		# ⚠️  CAUTION - CAN DAMAGE COMMON SERVOS, USE AT YOUR OWN RISK: 1=Force servo to always stay active, 0=Release after movement
+servo_always_active      : [[PARAM_SERVO_ALWAYS_ACTIVE]]
 [% if PARAM_SELECTOR_TYPE in ["LinearServoSelector", "Testing"] %]
-servo_active_down: [[PARAM_SERVO_ACTIVE_DOWN]]		# ⚠️  CAUTION - CAN DAMAGE COMMON SERVOS, USE AT YOUR OWN RISK: 1=Force servo to stay active when down only, 0=Release after movement
+servo_active_down        : [[PARAM_SERVO_ACTIVE_DOWN]]
 [% endif %]
 [% endif %]
 
@@ -137,27 +139,27 @@ servo_active_down: [[PARAM_SERVO_ACTIVE_DOWN]]		# ⚠️  CAUTION - CAN DAMAGE C
 #
 # MOVEMENT SPEEDS: Long moves are faster than the small ones and used for the bulk of the bowden movement.
 #
-gear_load_speed: [[PARAM_GEAR_LOAD_SPEED]]			# mm/s Speed when loading filament
-gear_load_accel: [[PARAM_GEAR_LOAD_ACCEL]]			# Acceleration when loading
+gear_load_speed          : [[PARAM_GEAR_LOAD_SPEED]]			# mm/s Speed when loading filament
+gear_load_accel          : [[PARAM_GEAR_LOAD_ACCEL]]			# Acceleration when loading
 [% if MMU_HAS_FILAMENT_BUFFER %]
 
 # On systems with a buffer to catch loose filament you can set a second faster load speed (not used for calibration or on first load).
 # Typically this can be 50%-100% faster without loosing steps because it doesn't need to overcome friction and spool inertia.
-gear_from_filament_buffer_speed: [[PARAM_GEAR_FROM_FILAMENT_BUFFER_SPEED]]	# mm/s Speed when loading filament from buffer. Conservative is 100mm/s, Max around 400mm/s
-gear_from_filament_buffer_accel: [[PARAM_GEAR_FROM_FILAMENT_BUFFER_ACCEL]]	# Normal acceleration when loading filament
+gear_from_filament_buffer_speed : [[PARAM_GEAR_FROM_FILAMENT_BUFFER_SPEED]]	# mm/s Speed when loading filament from buffer. Conservative is 100mm/s, Max around 400mm/s
+gear_from_filament_buffer_accel : [[PARAM_GEAR_FROM_FILAMENT_BUFFER_ACCEL]]	# Normal acceleration when loading filament
 [% endif %]
 
 # Unloading speed defaults to the load speed but can be tuned if you have a rewinder system that imposes additional limits.
-gear_unload_speed: [[PARAM_GEAR_UNLOAD_SPEED]]			# mm/s Use (lower) speed when unloading filament (defaults to "load" speed)
-gear_unload_accel: [[PARAM_GEAR_UNLOAD_ACCEL]]			# Acceleration when unloading filament (defaults to "load" accel)
+gear_unload_speed        : [[PARAM_GEAR_UNLOAD_SPEED]]			# mm/s Use (lower) speed when unloading filament (defaults to "load" speed)
+gear_unload_accel        : [[PARAM_GEAR_UNLOAD_ACCEL]]			# Acceleration when unloading filament (defaults to "load" accel)
 
-gear_homing_speed: [[PARAM_GEAR_HOMING_SPEED]]			# mm/s Speed of gear stepper only homing moves (e.g. homing to gate or extruder)
+gear_homing_speed        : [[PARAM_GEAR_HOMING_SPEED]]			# mm/s Speed of gear stepper only homing moves (e.g. homing to gate or extruder)
 
-virtual_sensor_homing_speed: [[PARAM_VIRTUAL_SENSOR_HOMING_SPEED]]		# mm/s Speed of gear stepper when homing to virtual sensor/endstop
+virtual_sensor_homing_speed : [[PARAM_VIRTUAL_SENSOR_HOMING_SPEED]]		# mm/s Speed of gear stepper when homing to virtual sensor/endstop
 
-gear_short_move_speed: [[PARAM_GEAR_SHORT_MOVE_SPEED]]		# mm/s Speed when making short moves (including incremental retracts with encoder)
-gear_short_move_accel: [[PARAM_GEAR_SHORT_MOVE_ACCEL]]		# Usually the same as gear_from_buffer_accel (for short movements)
-gear_short_move_threshold: [[PARAM_GEAR_SHORT_MOVE_THRESHOLD]]		# Move distance that controls application of 'short_move' speed/accel
+gear_short_move_speed    : [[PARAM_GEAR_SHORT_MOVE_SPEED]]			# mm/s Speed when making short moves (including incremental retracts with encoder)
+gear_short_move_accel    : [[PARAM_GEAR_SHORT_MOVE_ACCEL]]			# Usually the same as gear_from_buffer_accel (for short movements)
+gear_short_move_threshold : [[PARAM_GEAR_SHORT_MOVE_THRESHOLD]]			# Move distance that controls application of 'short_move' speed/accel
 
 
 # Gate loading/unloading ---------------------------------------------------------------------------------------------
@@ -187,25 +189,25 @@ gear_short_move_threshold: [[PARAM_GEAR_SHORT_MOVE_THRESHOLD]]		# Move distance 
 # However it can be useful on type-B MMU's when preloading filament to the gate specific 'mmu_exit' sensor even if the gate
 # endstop is something else.
 #
-gate_homing_endstop: [[PARAM_GATE_HOMING_ENDSTOP]]		# Name of gate endstop used for filament parking
-gate_homing_max: [[PARAM_GATE_HOMING_MAX]]			# Maximum extra move distance to home (or actual move distance if encoder endstop)
-gate_parking_distance: [[PARAM_GATE_PARKING_DISTANCE]]		# ⚠️  Parking position relative to homing endstop (must be retraction unless endstop is mmu_exit)
+gate_homing_endstop       : [[PARAM_GATE_HOMING_ENDSTOP]]		# Name of gate endstop used for filament parking
+gate_homing_max           : [[PARAM_GATE_HOMING_MAX]]			# Maximum extra move distance to home (or actual move distance if encoder endstop)
+gate_parking_distance     : [[PARAM_GATE_PARKING_DISTANCE]]			# ⚠️  Parking position relative to homing endstop (must be retraction unless endstop is mmu_exit)
 
-gate_preload_endstop: [[PARAM_GATE_PRELOAD_ENDSTOP]]			# Name of endstop used when preloading (if not set will default to gate_homing_endstop)
-gate_preload_homing_max: [[PARAM_GATE_PRELOAD_HOMING_MAX]]		# Maximum homing distance to the mmu_exit endstop (if MMU is fitted with one)
-gate_preload_parking_distance: [[PARAM_GATE_PRELOAD_PARKING_DISTANCE]]	# Parking position relative to mmu_exit endstop (-ve value means move forward)
-gate_preload_attempts: 5		# How many "grabbing" attempts are made to pick up the filament with preload feature
+gate_preload_endstop      : [[PARAM_GATE_PRELOAD_ENDSTOP]]			# Name of endstop used when preloading (if not set will default to gate_homing_endstop)
+gate_preload_homing_max   : [[PARAM_GATE_PRELOAD_HOMING_MAX]]			# Maximum homing distance to the mmu_exit endstop (if MMU is fitted with one)
+gate_preload_parking_distance : [[PARAM_GATE_PRELOAD_PARKING_DISTANCE]]		# Parking position relative to mmu_exit endstop (-ve value means move forward)
+gate_preload_attempts     : 5			# How many "grabbing" attempts are made to pick up the filament with preload feature
 
 [% if MMU_HAS_ENCODER %]
-gate_endstop_to_encoder: [[PARAM_GATE_ENDSTOP_TO_ENCODER]]		# Distance between gate endstop and encoder (IF both fitted. +ve if encoder after endstop)
+gate_endstop_to_encoder   : [[PARAM_GATE_ENDSTOP_TO_ENCODER]]			# Distance between gate endstop and encoder (IF both fitted. +ve if encoder after endstop)
 [% endif %]
 [% if PARAM_SELECTOR_TYPE in ["LinearServoSelector", "Testing"] %]
-gate_load_retries: 2			# Number of times MMU will attempt to grab the filament on initial load (type-A designs with servo)
+gate_load_retries         : 2			# Number of times MMU will attempt to grab the filament on initial load (type-A designs with servo)
 [% endif %]
 [% if MMU_HAS_SENSOR_ENTRY %]
-gate_autoload: 1			# If mmu entry sensor fitted this controls the automatic loading of the gate
+gate_autoload             : 1			# If mmu entry sensor fitted this controls the automatic loading of the gate
 [% endif %]
-gate_final_eject_distance: [[PARAM_GATE_FINAL_EJECT_DISTANCE]]		# Additional distance to eject filament on MMU_EJECT to clear MMU's grip
+gate_final_eject_distance : [[PARAM_GATE_FINAL_EJECT_DISTANCE]]			# Additional distance to eject filament on MMU_EJECT to clear MMU's grip
 
 
 # Bowden tube loading/unloading --------------------------------------------------------------------------------------
@@ -218,15 +220,15 @@ gate_final_eject_distance: [[PARAM_GATE_FINAL_EJECT_DISTANCE]]		# Additional dis
 #
 # BOWDEN LOADING/UNLOADING: Settings that control filament movement in the bowden tube
 #
-bowden_homing_max: 2000			# Maximum attempted bowden move (for calibration). Should be larger than your actual bowden!
+bowden_homing_max                : 2000		# Maximum attempted bowden move (for calibration). Should be larger than your actual bowden!
 
 # These are the reduction of the bowden move which occurs at a fast speed. In most designs it is important that the
 # bowden move doesn't overshoot it's target to allow for slower homing to the endstop.
 # Note that additional "extra" homing distance is defined in the gate and extruder sections which is automatically added
 # to the expected "slow" distance. Also note that before calibration all moves are slower homing moves.
 #
-bowden_load_homing_buffer:   20 	# Distance to reduce fast bowden load to prevent collisions and allow for accurate extruder homing
-bowden_unload_homing_buffer: 40		# Distance to reduce fast bowden unload to allow for accurate gate homing
+bowden_load_homing_buffer        : 20		# Distance to reduce fast bowden load to prevent collisions and allow for accurate extruder homing
+bowden_unload_homing_buffer      : 40		# Distance to reduce fast bowden unload to allow for accurate gate homing
 
 [% if MMU_HAS_ENCODER %]
 # If you MMU is equiped with an encoder the following options are available:
@@ -236,19 +238,19 @@ bowden_unload_homing_buffer: 40		# Distance to reduce fast bowden unload to allo
 # reading and make correction moves to bring the filament to within the 'bowden_allowable_encoder_delta' of the end of
 # bowden position (this does require a reliable encoder and is not recommended for very high speed loading >350mm/s)
 #
-bowden_apply_correction: 0		# 1 to enable, 0 disabled
-bowden_allowable_encoder_delta: 20.0	# How close in mm the correction moves will attempt to get to target
+bowden_apply_correction          : 0		# 1 to enable, 0 disabled
+bowden_allowable_encoder_delta   : 20.0		# How close in mm the correction moves will attempt to get to target
 
 # This saftey check uses the encoder to verify the filament is free of extruder before the fast bowden movement to
 # reduce possibility of grinding filament. If enabled the trigger can be tuned by setting the "bowden_pre_unload_error_tolerance"
 # which represents the percentage of allowable mismatch between actual movement and that seen by encoder. Setting to 50% tolerance
 # usually works well. Increasing will make test more tolerant and a value of 100% essentially disables error detection
-bowden_pre_unload_test: 1		# 1 to check for bowden movement before full pull (slower), 0 don't check (faster)
-bowden_pre_unload_error_tolerance: 50	# ADVANCED: % tune pre_unload_test sensitivity
+bowden_pre_unload_test            : 1		# 1 to check for bowden movement before full pull (slower), 0 don't check (faster)
+bowden_pre_unload_error_tolerance : 50		# ADVANCED: % tune pre_unload_test sensitivity
 
 # ADVANCED: Controls the detection of successful bowden load/unload movement and represents the percentage of allowable
 # mismatch between actual movement and that seen by encoder. Setting to 100% tolerance effectively turns off checking.
-bowden_move_error_tolerance: 60		# ADVANVED: % tune bowden move test sensitivity
+bowden_move_error_tolerance       : 60		# ADVANVED: % tune bowden move test sensitivity
 [% endif %]
 
 
@@ -285,18 +287,18 @@ bowden_move_error_tolerance: 60		# ADVANVED: % tune bowden move test sensitivity
 #                          Fast bowden load will move to the extruder gears. Option is fine if using toolhead sensor
 # Note: The homing_endstop will be ignored ("none") if a toolhead sensor is available unless "extruder_force_homing: 1"
 #
-extruder_homing_endstop: [[PARAM_EXTRUDER_HOMING_ENDSTOP]]	# Filament homing method/endstop name (fallback if toolhead sensor not available)
-extruder_homing_max: 100		# Maximum distance to advance in order to attempt to home to the extruder
+extruder_homing_endstop           : [[PARAM_EXTRUDER_HOMING_ENDSTOP]]	# Filament homing method/endstop name (fallback if toolhead sensor not available)
+extruder_homing_max               : 100		# Maximum distance to advance in order to attempt to home to the extruder
 
 # When using collision homing method (encoder or mmu_gear_touch) the current of the gear stepper can be reduced when homing
-extruder_collision_homing_current: 30	# % gear stepper current (10%-100%)
+extruder_collision_homing_current : 30		# % gear stepper current (10%-100%)
 
 [% if MMU_HAS_SENSOR_TOOLHEAD %]
 # If you have a toolhead sensor it will always be used as a homing point making the homing outside of the extruder
 # potentially unnecessary. However you can still force this initial homing step by setting this option in which case
 # the filament will home to the extruder and then home to the toolhead sensor in two steps
 #
-extruder_force_homing: 0
+extruder_force_homing             : 0
 
 
 [% endif %]
@@ -318,27 +320,27 @@ extruder_force_homing: 0
 # you have toolhead sensor it is past the extruder gear and the driver needs to know the max distance (from end of
 # bowden move) to attempt homing
 #
-toolhead_homing_max: 40			# Maximum distance to advance in order to attempt to home to defined homing endstop
+toolhead_homing_max               : 40		# Maximum distance to advance in order to attempt to home to defined homing endstop
 
 # Distance added to the extruder unload movement to ensure filament is free of extruder. This adds some degree of tolerance
 # to slightly incorrect configuration or extruder slippage. However don't use as an excuse for incorrect toolhead settings
 #
-toolhead_unload_safety_margin: 10	# Extra movement safety margin (default: 10mm)
+toolhead_unload_safety_margin     : 10		# Extra movement safety margin (default: 10mm)
 
 # If not synchronizing gear and extruder and you experience a "false" encoder clog detection immediately after the tool
 # change it might be because of a long bowden and/or large internal diameter that causes slack in the filament. This optional
 # move will tighten the filament after a load by % of current clog detection length. Gear stepper will run at 50% current
 #
-toolhead_post_load_tighten: 60		# % of clog detection length, 0 to disable. Ignored if 'sync_to_extruder: 1'
+toolhead_post_load_tighten        : 60		# % of clog detection length, 0 to disable. Ignored if 'sync_to_extruder: 1'
 
 # If synchronizing gear and extruder and you have a sync-feedback "buffer" (switch based or proportional) this setting
 # determines whether to use it to create neutral tension after loading
-toolhead_post_load_tension_adjust: 1	# 1 to enable (recommended), 0 to disable
+toolhead_post_load_tension_adjust : 1	# 1 to enable (recommended), 0 to disable
 
 # If sync-feedback compression sensor is available this test will ensure the filament passes the extruder entry by checking
 # for neutral tension when moving filament with just the extruder. Recommended with sprung loaded sync-feedback buffers.
 # This is ignored if toolhead sensor is available.
-toolhead_entry_tension_test: 1		# 1 to enable (recommended), 0 to disable
+toolhead_entry_tension_test       : 1		# 1 to enable (recommended), 0 to disable
 [% if MMU_HAS_ENCODER %]
 
 # ADVANCED: Controls the detection of successful extruder load/unload movement and represents the percentage of allowable
@@ -348,7 +350,7 @@ toolhead_entry_tension_test: 1		# 1 to enable (recommended), 0 to disable
 # friction is too high on the filament and in that case masking the error is not a good idea. Try reducing friction
 # and lowering speed first!
 #
-toolhead_move_error_tolerance: 60	# ADVANCED: % tune toolhead move test sensitivity
+toolhead_move_error_tolerance     : 60		# ADVANCED: % tune toolhead move test sensitivity
 [% endif %]
 
 
@@ -365,10 +367,10 @@ toolhead_move_error_tolerance: 60	# ADVANCED: % tune toolhead move test sensitiv
 # If equipped with TMC drivers the current of the gear and extruder motors can be controlled to optimize performance.
 # This can be useful to control gear stepper temperature when printing with synchronized motor
 #
-sync_to_extruder: [[PARAM_SYNC_TO_EXTRUDER]]			# Gear motor is synchronized to extruder during print
-sync_gear_current: [[PARAM_SYNC_GEAR_CURRENT]]			# % of gear_stepper current (10%-100%) to use when syncing with extruder during print
-sync_form_tip: [[PARAM_SYNC_FORM_TIP]]			# Synchronize during standalone tip formation (initial part of unload)
-sync_purge: [[PARAM_SYNC_PURGE]]				# Synchronize during standalone purging (last part of load)
+sync_to_extruder                : [[PARAM_SYNC_TO_EXTRUDER]]	# Gear motor is synchronized to extruder during print
+sync_gear_current               : [[PARAM_SYNC_GEAR_CURRENT]]	# % of gear_stepper current (10%-100%) to use when syncing with extruder during print
+sync_form_tip                   : [[PARAM_SYNC_FORM_TIP]]	# Synchronize during standalone tip formation (initial part of unload)
+sync_purge                      : [[PARAM_SYNC_PURGE]]	# Synchronize during standalone purging (last part of load)
 
 
 [% if MMU_HAS_SYNC_FEEDBACK_BUFFER %]
@@ -382,16 +384,17 @@ sync_purge: [[PARAM_SYNC_PURGE]]				# Synchronize during standalone purging (las
 # then the rotation distance will autotune to correct setting (recommend you also enable 'autotune_rotation_distance: 1'
 # so that values are saved)
 #
-sync_feedback_enabled: [[PARAM_SYNC_FEEDBACK_ENABLED]]			# Turn off even if sensor is installed and active
-sync_feedback_speed_multiplier: 5	# % "twolevel" gear speed delta to keep filament neutral in buffer (recommend 5%)
-sync_feedback_boost_multiplier: 3	# % "twolevel" extra gear speed boost for finding initial neutral position (recommend 3%)
-sync_feedback_extrude_threshold: 5	# Extruder movement (mm) for updates (keep small but set > retract distance)
+sync_feedback_enabled           : [[PARAM_SYNC_FEEDBACK_ENABLED]]	# Turn off even if sensor is installed and active
+sync_feedback_speed_multiplier  : 5	# % "twolevel" gear speed delta to keep filament neutral in buffer (recommend 5%)
+sync_feedback_boost_multiplier  : 3	# % "twolevel" extra gear speed boost for finding initial neutral position (recommend 3%)
+sync_feedback_extrude_threshold : 5	# Extruder movement (mm) for updates (keep small but set > retract distance)
 
 # If defined this forces debugging to a telemetry log file "sync_<gate>.jsonl". This is great if trying to tune clog/tangle
 # detection or for getting help on the Happy Hare forum. To plot graph of sync-feedback operation, run:
 #  ~/Happy-Hare/utils/plot_sync_feedback.sh
+#   0 = disable (normal operation), 1 = enable telemetry log (for debugging)
 #
-sync_feedback_debug_log: 0		# 0 = disable (normal operation), 1 = enable telemetry log (for debugging)
+sync_feedback_debug_log         : 0
 
 
 [% endif %]
@@ -411,7 +414,7 @@ sync_feedback_debug_log: 0		# 0 = disable (normal operation), 1 = enable telemet
 #
 # Encoder detection: This monitors encoder movement and compares to extruder (only available if encoder is fitted)
 #
-flowguard_enabled: [[PARAM_FLOWGUARD_ENABLED]]			# 0 = Flowguard protection disabled, 1 = Enabled
+flowguard_enabled         : [[PARAM_FLOWGUARD_ENABLED]]		# 0 = Flowguard protection disabled, 1 = Enabled
 
 [% if MMU_HAS_SYNC_FEEDBACK_BUFFER %]
 # The flowguard_max_relief is the amount of relief movement (effective mm change in filament length between MMU and extruder)
@@ -419,18 +422,18 @@ flowguard_enabled: [[PARAM_FLOWGUARD_ENABLED]]			# 0 = Flowguard protection disa
 # relief movement is hightly dependent on filament "spring" in the bowden tube, filament friction, and
 # 'sync_feedback_buffer_range', it is generally good to start high and then decrease if a more sensitive trigger is desired.
 # Analog proportional (type P) sensors can generally have a much lower value. Increase if you have false triggers.
-flowguard_max_relief: [[PARAM_FLOWGUARD_MAX_RELIEF]]
+flowguard_max_relief      : [[PARAM_FLOWGUARD_MAX_RELIEF]]
 
 # Tangle prevention boosts the gear stepper current to 100% when the proportional sync-feedback sensor reports high
 # filament tension (the gear struggling to pull from the spool), restoring normal current once tension eases. This pulls
 # through minor spool resistance before it develops into a tangle. Requires a proportional (type P) sensor.
-tangle_prevention_enabled: [[PARAM_TANGLE_PREVENTION_ENABLED]]		# 0 = Tangle prevention disabled, 1 = Enabled
+tangle_prevention_enabled : [[PARAM_TANGLE_PREVENTION_ENABLED]]		# 0 = Tangle prevention disabled, 1 = Enabled
 
 # Tension level (fraction of the tension half of the sensor range) at which gear current is boosted (threshold) and
 # the level at which it is restored to normal (release). The gap between them provides hysteresis to avoid thrashing;
 # 'release' must be lower than 'threshold'. Lower threshold triggers sooner; raise it if you get false triggers.
-tangle_prevention_threshold: [[PARAM_TANGLE_PREVENTION_THRESHOLD]]	# Tension (0.2-0.9) to boost gear current to 100%
-tangle_prevention_release: [[PARAM_TANGLE_PREVENTION_RELEASE]]		# Tension (0.15-0.8) to restore gear current
+tangle_prevention_threshold : [[PARAM_TANGLE_PREVENTION_THRESHOLD]]	# Tension (0.2-0.9) to boost gear current to 100%
+tangle_prevention_release : [[PARAM_TANGLE_PREVENTION_RELEASE]]		# Tension (0.15-0.8) to restore gear current
 
 [% endif %]
 [% if MMU_HAS_ENCODER %]
@@ -439,13 +442,13 @@ tangle_prevention_release: [[PARAM_TANGLE_PREVENTION_RELEASE]]		# Tension (0.15-
 # the distance to be adjusted automatically (mode=2) will generally allow for a quicker trigger but use a static length
 # (mode=1, set encoder_max_motion) if you get false triggers (see flowguard guide on wiki for more details).
 # Note that this feature cannot distinguish between clog or tangle.
-flowguard_encoder_mode: [[PARAM_FLOWGUARD_ENCODER_MODE]]		# 0 = Disable, 1 = Static detection length, 2 = Autotuned detection length
+flowguard_encoder_mode   : [[PARAM_FLOWGUARD_ENCODER_MODE]]		# 0 = Disable, 1 = Static detection length, 2 = Autotuned detection length
 
 # The encoder_max_motion is the absolute max permitted extruder movement without the encoder seeing movement when using
 # status mode (mode=1). Smaller values are more sensitive but beware of going too small - slack and friction in the
 # bowden may cause gaps in encoder movement. Increase if you have false triggers.
 # Note that this value is overriden by any calibrated value stored in 'mmu_vars.cfg' if in automatic mode (mode=2).
-flowguard_encoder_max_motion: [[PARAM_FLOWGUARD_ENCODER_MAX_MOTION]]
+flowguard_encoder_max_motion : [[PARAM_FLOWGUARD_ENCODER_MAX_MOTION]]
 
 [% endif %]
 
@@ -478,30 +481,30 @@ flowguard_encoder_max_motion: [[PARAM_FLOWGUARD_ENCODER_MAX_MOTION]]
 # If using a digitally controlled espooler motor (not PWM) then you should turn off the "print" mode and set
 # 'espooler_min_stepper_speed' to prevent "over movement"
 #
-espooler_min_distance: 30			# Individual stepper movements less than this distance will not active espooler
-espooler_max_stepper_speed: 300			# Gear stepper speed at which espooler will be at maximum power
-espooler_min_stepper_speed: 0			# Gear stepper speed at which espooler will become inactive (useful for non PWM control)
-espooler_speed_exponent: 0.5			# Controls non-linear espooler power relative to stepper speed (see notes)
-espooler_assist_reduced_speed: 50		# Control the % of the rewind speed that is applied to assisting load (want rewind to be faster)
-espooler_printing_power: 0			# If >0, fixes the % of PWM power while printing. 0=allows burst movement
-espooler_operations: rewind, assist, print	# List of operational modes (allows disabling even if h/w is configured)
+espooler_min_distance    : 30			# Individual stepper movements less than this distance will not active espooler
+espooler_max_stepper_speed : 300		# Gear stepper speed at which espooler will be at maximum power
+espooler_min_stepper_speed : 0			# Gear stepper speed at which espooler will become inactive (useful for non PWM control)
+espooler_speed_exponent  : 0.5			# Controls non-linear espooler power relative to stepper speed (see notes)
+espooler_assist_reduced_speed : 50		# Control the % of the rewind speed that is applied to assisting load (want rewind to be faster)
+espooler_printing_power  : 0			# If >0, fixes the % of PWM power while printing. 0=allows burst movement
+espooler_operations      : rewind, assist, print	# List of operational modes (allows disabling even if h/w is configured)
 #
 # The following burst configuration is used to control the small rotation in the ASSIST direction optionally used
 # when in 'print' operation is enabled, 'espooler_printing_power: 0' and is triggered (tension switch or extruder movement).
 # It can also be used to loosen filament with 'MMU_ESPOOLER COMMAND=assist BURST=1'
 #
-espooler_assist_extruder_move_length: 100	# Distance (mm) extruder needs to move between each assist burst
-espooler_assist_burst_power: 100		# The % power of the burst move
-espooler_assist_burst_duration: 0.4		# The duration of the burst move is seconds
-espooler_assist_burst_trigger: 0		# If trigger assist switch is fitted 0=disable, 1=enable
-espooler_assist_burst_trigger_max: 3		# If trigger assist switch is fitted this limits the max number of back-to-back advances
+espooler_assist_extruder_move_length : 100	# Distance (mm) extruder needs to move between each assist burst
+espooler_assist_burst_power : 100		# The % power of the burst move
+espooler_assist_burst_duration : 0.4		# The duration of the burst move is seconds
+espooler_assist_burst_trigger : 0		# If trigger assist switch is fitted 0=disable, 1=enable
+espooler_assist_burst_trigger_max : 3		# If trigger assist switch is fitted this limits the max number of back-to-back advances
 #
 # The following burst configuration is used to control the small rotation in the REWIND direction optionally used
 # when running running the filament drying cycle. The goal is to rotate the spool 60-90 degrees. It can also be
 # used to tighten the filament with 'MMU_ESPOOLER COMMAND=rewind BURST=1'
 #
-espooler_rewind_burst_power: 100		# The % power of the rewind burst move
-espooler_rewind_burst_duration: 0.4		# The duration of the rewind burst move is seconds
+espooler_rewind_burst_power : 100		# The % power of the rewind burst move
+espooler_rewind_burst_duration : 0.4		# The duration of the rewind burst move is seconds
 
 
 [% endif %]
@@ -514,14 +517,14 @@ espooler_rewind_burst_duration: 0.4		# The duration of the rewind burst move is 
 # ██║  ██║███████╗██║  ██║   ██║   ███████╗██║  ██║
 # ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝   ╚═╝   ╚══════╝╚═╝  ╚═╝
 #
-heater_max_temp: [[PARAM_HEATER_MAX_TEMP]]			# Absolute max heater setting to protect the MMU enclosure construction (adjust to match material)
-heater_default_dry_temp: [[PARAM_HEATER_DEFAULT_DRY_TEMP]]		# Default drying temperature if filament type is not matched in drying_data
-heater_default_dry_time: [[PARAM_HEATER_DEFAULT_DRY_TIME]]		# Default drying cycle time in minutes
-heater_default_dry_humidity: [[PARAM_HEATER_DEFAULT_DRY_HUMIDITY]]		# Default humidity % goal. Drying will terminate if this value is reached
-heater_vent_macro: [[PARAM_HEATER_VENT_MACRO]]		# Name of macro to periodicaly call during drying cycle
-heater_vent_interval: [[PARAM_HEATER_VENT_INTERVAL]]			# Interval in minutes to call heater_vent_macro during drying cycle, 0=disable venting
+heater_max_temp             : [[PARAM_HEATER_MAX_TEMP]]		# Absolute max heater setting to protect the MMU enclosure construction (adjust to match material)
+heater_default_dry_temp     : [[PARAM_HEATER_DEFAULT_DRY_TEMP]]		# Default drying temperature if filament type is not matched in drying_data
+heater_default_dry_time     : [[PARAM_HEATER_DEFAULT_DRY_TIME]]		# Default drying cycle time in minutes
+heater_default_dry_humidity : [[PARAM_HEATER_DEFAULT_DRY_HUMIDITY]]		# Default humidity % goal. Drying will terminate if this value is reached
+heater_vent_macro           : [[PARAM_HEATER_VENT_MACRO]]		# Name of macro to periodicaly call during drying cycle
+heater_vent_interval        : [[PARAM_HEATER_VENT_INTERVAL]]			# Interval in minutes to call heater_vent_macro during drying cycle, 0=disable venting
 [% if MMU_HAS_ESPOOLER %]
-heater_rotate_interval: [[PARAM_HEATER_ROTATE_INTERVAL]]		# Interval in minutes to rotate filament (requires eSpooler and filament end attached to spool)
+heater_rotate_interval      : [[PARAM_HEATER_ROTATE_INTERVAL]]			# Interval in minutes to rotate filament (requires eSpooler and filament end attached to spool)
 [% endif %]
 
 
@@ -555,12 +558,12 @@ heater_rotate_interval: [[PARAM_HEATER_ROTATE_INTERVAL]]		# Interval in minutes 
 #  skip_cal_encoder           - Will rely on installed default value (although it can still be calibrated).
 [% endif %]
 #
-autocal_bowden_length: [[PARAM_AUTOCAL_BOWDEN_LENGTH]]	# Automated bowden length calibration. 1=automatic, 0=manual/off
-autotune_bowden_length: [[PARAM_AUTOTUNE_BOWDEN_LENGTH]]	# Automated bowden length tuning. 1=on, 0=off
-skip_cal_rotation_distance: [[PARAM_SKIP_CAL_ROTATION_DISTANCE]]	# Skip rotation distance calibration (MMU_CALIBRATE_GEAR), 1=skip, 0=require
-autotune_rotation_distance: [[PARAM_AUTOTUNE_ROTATION_DISTANCE]]	# Automated gate calibration/tuning. 1=automatic, 0=manual/off
+autocal_bowden_length      : [[PARAM_AUTOCAL_BOWDEN_LENGTH]]		# Automated bowden length calibration. 1=automatic, 0=manual/off
+autotune_bowden_length     : [[PARAM_AUTOTUNE_BOWDEN_LENGTH]]		# Automated bowden length tuning. 1=on, 0=off
+skip_cal_rotation_distance : [[PARAM_SKIP_CAL_ROTATION_DISTANCE]]		# Skip rotation distance calibration (MMU_CALIBRATE_GEAR), 1=skip, 0=require
+autotune_rotation_distance : [[PARAM_AUTOTUNE_ROTATION_DISTANCE]]		# Automated gate calibration/tuning. 1=automatic, 0=manual/off
 [% if MMU_HAS_ENCODER %]
-skip_cal_encoder: [[PARAM_SKIP_CAL_ENCODER]]		# Skip encoder calibration (MMU_CALIBRATE_ENCODER), 1=skip, 0=require
+skip_cal_encoder           : [[PARAM_SKIP_CAL_ENCODER]]		# Skip encoder calibration (MMU_CALIBRATE_ENCODER), 1=skip, 0=require
 [% endif %]
 
 
@@ -575,11 +578,14 @@ skip_cal_encoder: [[PARAM_SKIP_CAL_ENCODER]]		# Skip encoder calibration (MMU_CA
 # MISCELLANEOUS: These are supplemental workflow options that apply just to this unit (empty for some types)
 
 [% if PARAM_SELECTOR_TYPE in ["LinearSelector", "LinearServoSelector", "LinearMultiGearSelector", "IndexedSelector", "RotarySelector", "Testing"] %]
-startup_home_selector: 0	# 1 = force mmu homing on startup if unloaded, 0 = do nothing
+# Whether to home the selector at startup
+#  1 = force mmu homing on startup if unloaded, 0 = do nothing
+startup_home_selector    : 0
 [% endif %]
 [% if MMU_HAS_ENCODER %]
-encoder_move_validation: 1	# ADVANCED: 1 = Normally Encoder validates move distances are within given tolerance
-				#           0 = Validation is disabled (eliminates slight pause between moves but less safe)
+# ADVANCED: Determines if encoder measurement should be used to validate movement distance
+#  0 = Validation is disabled (eliminates slight pause between moves but less safe)
+encoder_move_validation  : 1
 [% endif %]
 
 
@@ -599,16 +605,16 @@ encoder_move_validation: 1	# ADVANCED: 1 = Normally Encoder validates move dista
 #
 [% if PARAM_SELECTOR_TYPE in ["LinearSelector", "LinearServoSelector", "LinearMultiGearSelector", "Testing"] %]
 # LinearSelector, LinearServoSelector, LinearMultiGearSelector: this supports ERCF, Tradrack, custom type-C variations
-#cad_gate0_pos: 4.2				# Approximate distance from endstop to first gate. Used for rough calibration only
-#cad_gate_width: 21.0				# Width of each gate
-#cad_bypass_offset: 0				# Distance from limit of travel back to the bypass (e.g. ERCF v2.0)
-#cad_last_gate_offset: 2.0			# Distance from limit of travel back to last gate
-#cad_selector_tolerance: 10.0 			# How much extra selector movement to allow for calibration
+#cad_gate0_pos          : 4.2		# Approximate distance from endstop to first gate. Used for rough calibration only
+#cad_gate_width         : 21.0		# Width of each gate
+#cad_bypass_offset      : 0		# Distance from limit of travel back to the bypass (e.g. ERCF v2.0)
+#cad_last_gate_offset   : 2.0		# Distance from limit of travel back to last gate
+#cad_selector_tolerance : 10.0 		# How much extra selector movement to allow for calibration
 [% endif %]
 [% if PARAM_SELECTOR_TYPE in ["IndexedSelector", "Testing"] %]
-# IndexedSelector: this supports BTT ViViD variations
-#cad_gate_width: 90.0				# Rotation distance is typicall set to make this equivalent to degrees between gates
-#cad_max_rotations: 2				# Maximum full rotations of indexed selector wheel
+# IndexedSelector supports BTT ViViD variations
+#cad_gate_width         : 90.0		# Rotation distance is typicall set to make this equivalent to degrees between gates
+#cad_max_rotations      : 2		# Maximum full rotations of indexed selector wheel
 [% endif %]
 
 [% endif %]

--- a/extras/mmu/mmu_constants.py
+++ b/extras/mmu/mmu_constants.py
@@ -164,6 +164,10 @@ SENSOR_ENTRY_PREFIX      = "mmu_entry"
 EXTRUDER_ENDSTOPS = [SENSOR_EXTRUDER_ENCODER, SENSOR_GEAR_TOUCH, SENSOR_EXTRUDER_ENTRY, SENSOR_EXTRUDER_NONE, SENSOR_COMPRESSION]
 GATE_ENDSTOPS     = [SENSOR_SHARED_EXIT, SENSOR_ENCODER, SENSOR_EXIT_PREFIX, SENSOR_EXTRUDER_ENTRY]
 
+PROPORTIONAL_GRIP_SHIFT_MARGIN     = 0.3 # Min proportional shift confirming the extruder grips/moves filament
+PROPORTIONAL_COMPRESSION_FAULT     = 0.8 # Resting value (toward compression) => MMU gear failed to retract on unload
+PROPORTIONAL_BOWDEN_SLACK_FACTOR   = 2.0 # Over-move factor so retract probe overcomes bowden slack to shift the sensor
+
 # Gear/Extruder synchronization modes
 DRIVE_UNSYNCED                = 0
 DRIVE_EXTRUDER_SYNCED_TO_GEAR = 1 # Aka 'gear+extruder'

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1145,9 +1145,15 @@ class MmuFilamentMovement:
             wait=True,
         )
 
-        moved = grip_distance
+        self.movequeue_dwell(0.2) # Let ADC sensor catch up
+        self.movequeue_wait()
 
-        # Phase 2: extruder-only probes until compression releases
+        prop     = self.sensor_manager.get_sensor_obj(SENSOR_PROPORTIONAL)
+        baseline = prop.get_status(0).get('value', 0.)
+        moved    = grip_distance
+
+        # Phase 2: extruder-only probes. A gripping extruder draws filament from
+        # the buffer (gear static) shifting the sensor toward tension
         for i in range(max_steps):
             self.move_filament(
                 f"Proportional extruder entry validation step {i + 1}",
@@ -1161,14 +1167,11 @@ class MmuFilamentMovement:
             self.movequeue_dwell(0.2) # Let ADC sensor catch up
             self.movequeue_wait()
 
-# IGIANNAKAS
-# PAUL: seems like this should simply be a test of tension relax and not rely on compression sensor
-# PAUL: because what if compression is not triggered at the start of the operation?
-# PAUL: seems like it would be more reliable this way
-            if not self.sensor_manager.check_sensor(SENSOR_COMPRESSION):
+            shift = prop.get_status(0).get('value', 0.) - baseline # Negative => toward tension
+            if shift < -PROPORTIONAL_GRIP_SHIFT_MARGIN:
                 self.log_info(
-                    f"Proportional post-load validation: compression "
-                    f"released after {moved:.1f}mm (step {i + 1}) - "
+                    f"Proportional post-load validation: buffer moved toward "
+                    f"tension ({shift:.3f}) after {moved:.1f}mm (step {i + 1}) - "
                     f"extruder grip confirmed"
                 )
                 return moved
@@ -1177,8 +1180,7 @@ class MmuFilamentMovement:
 
         raise MmuError(
             f"Failed to load filament past the extruder entrance "
-            f"(proportional sensor still compressed after "
-            f"{moved:.1f}mm)"
+            f"(proportional buffer did not relax after {moved:.1f}mm)"
         )
 
 
@@ -1364,9 +1366,25 @@ class MmuFilamentMovement:
                 # If synced this may move toolhead_unload_safety_margin into the bowden
                 # If unsynced filament should be exactly at extruder gear (reference point)
                 # -------------------------------------------------------------------------------
+                # Proportional validation needs a released tip pulled clear enough to rest in
+                # tension, so extend the safety margin to at least a buffer range when it validates
+                safety_margin = u.p.toolhead_unload_safety_margin
+                if (
+                    validate and not extruder_only
+                    and self.gate_selected != TOOL_GATE_BYPASS
+                    and self.sensor_manager.has_sensor(SENSOR_PROPORTIONAL)
+                ):
+                    if safety_margin < u.buffer.buffer_maxrange:
+                        self.log_info(
+                            f"Unload safety margin ({safety_margin:.1f}mm) is less than buffer "
+                            f"range ({u.buffer.buffer_maxrange:.1f}mm); extending for proportional "
+                            f"unload validation"
+                        )
+                    safety_margin = max(safety_margin, u.buffer.buffer_maxrange)
+
                 length = (
                     max(0, u.toolhead_wrapper.p.toolhead_extruder_to_nozzle + self.drive().get_filament_position())
-                    + u.p.toolhead_unload_safety_margin
+                    + safety_margin
                 )
                 self.log_debug(
                     f"Unloading last {length:.1f}mm to exit the extruder"
@@ -1385,7 +1403,7 @@ class MmuFilamentMovement:
                     self.set_filament_pos_state(FILAMENT_POS_HOMED_EXTRUDER)
                     self.drive().set_filament_position(-(u.toolhead_wrapper.p.toolhead_extruder_to_nozzle))
                 else:
-                    overshoot += u.p.toolhead_unload_safety_margin
+                    overshoot += safety_margin
 
                 # -------------------------------------------------------------------------------
                 # If possible validate we are free of the extruder
@@ -1427,62 +1445,77 @@ class MmuFilamentMovement:
             return synced, overshoot
 
 
-# PAUL
-# IGIANNAKAS: this seems to be problematic ... the extruder could pick up the filament again!
-# IGIANNAKAS: if probe distance > unload safety then it probably will and springiness in the filament
-# IGIANNAKAS: could cause it to catch.
-# IGIANNAKAS: why not just move extruder in retract direction, if proportional indicates further compression,
-# IGIANNAKAS: then the filament is still trapped. If no change (or more tension) filament is confirmed out
-# IGIANNAKAS: That said, why not change unload_extruder() so that the 'toolhead_unload_safety_margin'
-# IGIANNAKAS: move is done JUST with extruder stepper... that guarantee's removal and doesn't complicate with
-# IGIANNAKAS: overshoot into bowden?!
     def _validate_extruder_unload_proportional(self):
         """
-        Use proportional sync-feedback buffer to validate filament is out of the extruder
-        Verify the extruder released filament: spin it forward and confirm the proportional sensor doesn't
-        shift toward compression (a shift means the extruder is still gripping).
+        Validate the extruder released filament using only the proportional sensor.
+        Keyed off the sensor's resting state after the synced unload:
+          Stage 1 (passive): compression at rest => MMU gear didn't retract (unload fault)
+          Stage 2 (probe): stepped extruder-only retract. Shift toward compression => extruder
+            still gripping (stop early); no shift over the budget => filament free in bowden.
+            Retract direction avoids re-feeding toward the nozzle, and stepping lets us stop on
+            the first grip response rather than over-driving the sensor into its rail.
+        A fully grinding extruder (can't bite) reads as free (needs encoder/switch to catch).
 
         Return:
-          bool Validation success
+          bool True if filament confirmed free, False on detected fault
         """
-        return True # Temp until logic confirmed
         u = self.mmu_unit()
-
         prop = self.sensor_manager.get_sensor_obj(SENSOR_PROPORTIONAL)
-        probe_distance = u.buffer.buffer_maxrange
 
-        pre_spin = prop.get_status(0).get('value', 0.)
-        self.log_info(
-            f"Proportional unload validation: sensor={pre_spin:.3f}, "
-            f"spinning extruder forward {probe_distance:.1f}mm "
-            f"to verify filament released..."
-        )
-
-        self.move_filament(
-            "Proportional unload validation: extruder forward spin",
-            probe_distance,
-            speed=self.p.extruder_load_speed,
-            motor="extruder",
-            wait=True,
-        )
         self.movequeue_dwell(0.2) # Let ADC sensor catch up
         self.movequeue_wait()
-        post_spin = prop.get_status(0).get('value', 0.)
+        resting = prop.get_status(0).get('value', 0.)
 
-        shift = post_spin - pre_spin # Positive => toward compression
-        self.log_info(
-            f"Proportional unload validation: "
-            f"pre={pre_spin:.3f}, post={post_spin:.3f}, shift={shift:.3f}"
-        )
-
-        if shift > 0.1:
+        # Stage 1: compression at rest => MMU gear failed to follow, filament compressed in bowden
+        if resting >= PROPORTIONAL_COMPRESSION_FAULT:
             self.log_warning(
-                f"Warning: Proportional unload validation - extruder may still "
-                f"be gripping filament (sensor shifted {shift:.3f} toward "
-                f"compression)\n"
+                f"Warning: Proportional unload validation - sensor compressed at rest "
+                f"({resting:.3f}), MMU gear may not have retracted filament\n"
                 f"Will attempt to continue..."
             )
             return False
+
+        # Stage 2: extruder-only retract in steps until the sensor shifts toward compression
+        # (extruder still gripping) or the budget is exhausted (filament free). The budget
+        # over-moves the headroom to the compression fault (0.5 * buffer_maxrange mm per unit
+        # value) by the slack factor since bowden slack absorbs part of the move; stepping lets
+        # us stop on the first grip response rather than over-driving the sensor into its rail
+        budget = (
+            (PROPORTIONAL_COMPRESSION_FAULT - resting)
+            * 0.5 * u.buffer.buffer_maxrange
+            * PROPORTIONAL_BOWDEN_SLACK_FACTOR
+        )
+        step_size = u.buffer.buffer_maxrange / 2.
+        max_steps = min(4, max(1, int(math.ceil(budget / step_size))))
+
+        self.log_debug(
+            f"Proportional unload validation: sensor={resting:.3f}, up to {max_steps} x "
+            f"{step_size:.1f}mm extruder-only retract probe(s) to verify filament released"
+        )
+
+        moved = 0.
+        for i in range(max_steps):
+            self.move_filament(
+                f"Proportional unload validation step {i + 1}",
+                -step_size,
+                speed=self.p.extruder_unload_speed,
+                motor="extruder",
+                wait=True,
+            )
+
+            moved += step_size
+
+            self.movequeue_dwell(0.2) # Let ADC sensor catch up
+            self.movequeue_wait()
+
+            shift = prop.get_status(0).get('value', 0.) - resting # Positive => toward compression
+            if shift > PROPORTIONAL_GRIP_SHIFT_MARGIN:
+                self.log_warning(
+                    f"Warning: Proportional unload validation - extruder may still be gripping "
+                    f"filament (sensor shifted {shift:.3f} toward compression after {moved:.1f}mm)\n"
+                    f"Will attempt to continue..."
+                )
+                return False
 
         self.log_info("Proportional unload validation: confirmed - extruder released filament")
         return True

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1027,8 +1027,16 @@ class MmuFilamentMovement:
             ):
                 if self.sensor_manager.has_sensor(SENSOR_PROPORTIONAL):
                     # Sensorless + proportional sensor: distinct grip-establish + extruder pull validation
-                    overshoot = self._validate_extruder_load_proportional(length)
-                    length -= overshoot
+                    # Probe assumes compression endstop homing left the sensor at the compression rail
+                    # and a spring rest state with probe headroom (tension/neutral)
+                    if u.buffer.supports_validation() and u.p.extruder_homing_endstop == SENSOR_COMPRESSION:
+                        overshoot = self._validate_extruder_load_proportional(length)
+                        length -= overshoot
+                    else:
+                        self.log_debug(
+                            "Proportional post-load validation skipped: requires 'buffer_spring_state: "
+                            "tension|neutral' and 'extruder_homing_endstop: %s'" % SENSOR_COMPRESSION
+                        )
 
                 elif self.sensor_manager.check_sensor(SENSOR_COMPRESSION): # None if no mmu_buffer
                     # If we have a compression sensor indicating compression we can
@@ -1110,6 +1118,8 @@ class MmuFilamentMovement:
         """
         Post-load extruder grip check using only the proportional sensor: feed synced to establish grip then
         drive the extruder alone until the compression sensor releases.
+        Caller gated: requires tension/neutral spring rest and compression endstop homing so the
+        probe starts with the sensor at the compression rail (see MmuBuffer.supports_validation)
         Returns:
           distance consumed (0 if skipped)
         """
@@ -1366,13 +1376,15 @@ class MmuFilamentMovement:
                 # If synced this may move toolhead_unload_safety_margin into the bowden
                 # If unsynced filament should be exactly at extruder gear (reference point)
                 # -------------------------------------------------------------------------------
-                # Proportional validation needs a released tip pulled clear enough to rest in
-                # tension, so extend the safety margin to at least a buffer range when it validates
+                # Proportional validation needs a released tip pulled clear enough for the buffer
+                # to reach its spring rest state, so extend the safety margin to at least a buffer
+                # range when it validates
                 safety_margin = u.p.toolhead_unload_safety_margin
                 if (
                     validate and not extruder_only
                     and self.gate_selected != TOOL_GATE_BYPASS
                     and self.sensor_manager.has_sensor(SENSOR_PROPORTIONAL)
+                    and u.buffer.supports_validation()
                 ):
                     if safety_margin < u.buffer.buffer_maxrange:
                         self.log_info(
@@ -1410,7 +1422,7 @@ class MmuFilamentMovement:
                 # -------------------------------------------------------------------------------
                 if validate and not extruder_only and self.gate_selected != TOOL_GATE_BYPASS:
 
-                    if self.sensor_manager.has_sensor(SENSOR_PROPORTIONAL):
+                    if self.sensor_manager.has_sensor(SENSOR_PROPORTIONAL) and u.buffer.supports_validation():
                         # Use proportional sync-feedback buffer movement to validate success
                         self._validate_extruder_unload_proportional()
 
@@ -1455,6 +1467,8 @@ class MmuFilamentMovement:
             Retract direction avoids re-feeding toward the nozzle, and stepping lets us stop on
             the first grip response rather than over-driving the sensor into its rail.
         A fully grinding extruder (can't bite) reads as free (needs encoder/switch to catch).
+        Caller gated: requires tension/neutral spring rest (see MmuBuffer.supports_validation);
+        stage thresholds/budget are keyed off the measured resting value so both rest states work.
 
         Return:
           bool True if filament confirmed free, False on detected fault
@@ -2642,7 +2656,7 @@ class MmuFilamentMovement:
         # Probably loaded: Unless strict we will continue to assume loaded in the absence of sensors to say otherwise
         elif not strict and self.filament_pos == FILAMENT_POS_LOADED and looks_loaded:
             # Gate sensor alone can't tell "in bowden" from "loaded"; use proportional grip check
-            if can_heat and ts is None and es is None and self.sensor_manager.has_sensor(SENSOR_PROPORTIONAL):
+            if can_heat and ts is None and es is None and self.sensor_manager.has_sensor(SENSOR_PROPORTIONAL) and u.buffer.supports_validation():
                 prop_result = self._check_filament_in_extruder_proportional()
                 if prop_result is True:
                     self.log_info("Proportional sensor confirms extruder grip - filament loaded")
@@ -2711,10 +2725,18 @@ class MmuFilamentMovement:
         detected = self.sensor_manager.check_any_sensors_in_path()
 
         # Check resting postion of sprung sync-feedback buffer for positive identification of filament
-        if not detected and u.has_buffer():
+        # (tension/neutral rest states only, consistent with the validation capability tier)
+        if not detected and u.has_buffer() and u.buffer.buffer_spring_state in ('tension', 'neutral'):
             resting_state = u.buffer.buffer_spring_state_num
-            state = u.sync_feedback._get_sensor_state(use_virtual_threshold=True) # Get discrete state
-            if resting_state is not None and state != resting_state:
+            if self.sensor_manager.has_sensor(SENSOR_PROPORTIONAL):
+                # Raw value against spring rest is more sensitive than the discrete vsensor
+                # thresholds (esp. for neutral springs where rest is mid-travel)
+                value = self.sensor_manager.get_sensor_obj(SENSOR_PROPORTIONAL).get_status(0).get('value', float(resting_state))
+                off_rest = abs(value - resting_state) > PROPORTIONAL_GRIP_SHIFT_MARGIN
+            else:
+                state = u.sync_feedback._get_sensor_state(use_virtual_threshold=True) # Get discrete state
+                off_rest = state != resting_state
+            if off_rest:
                 detected = True
                 self.log_debug("Buffer is not in resting position thus filament must be present")
 
@@ -2786,7 +2808,7 @@ class MmuFilamentMovement:
         if ts is True:
             return True
 
-        if self.sensor_manager.has_sensor(SENSOR_PROPORTIONAL):
+        if self.sensor_manager.has_sensor(SENSOR_PROPORTIONAL) and self.mmu_unit().buffer.supports_validation():
             return self._check_filament_in_extruder_proportional()
 
         # Finally resort to movement test with encoder
@@ -2798,6 +2820,7 @@ class MmuFilamentMovement:
         """
         Detect extruder grip using only the proportional sensor: centre the buffer with the gear (still deep
         tension => free in bowden), then extruder-retract (shift toward compression => gripped).
+        Caller gated: requires tension/neutral spring rest (see MmuBuffer.supports_validation)
         Returns True/False, or None if not possible.
         """
         u = self.mmu_unit()
@@ -2809,9 +2832,12 @@ class MmuFilamentMovement:
         self.log_info(f"Checking for filament in extruder using proportional sensor (baseline={baseline:.3f})...")
 
         # Phase 1: gear-only centering. Still deep tension => nothing to compress against => free in bowden
+        # Early exit only valid for tension-rest spring where rest is a preloaded extreme. A neutral
+        # rest coincides with the centering target (free and gripped both read ~0) so discrimination
+        # falls to the phase 2 probe
         _, success = u.sync_feedback.adjust_filament_tension()
         post_adjust = prop.get_status(0).get('value', 0.)
-        if not success and post_adjust <= -0.9:
+        if u.buffer.buffer_spring_state == 'tension' and not success and post_adjust <= -0.9:
             self.log_info(
                 f"Proportional recovery: sensor still in deep tension ({post_adjust:.3f}) "
                 "- filament free in bowden"

--- a/extras/mmu/mmu_unit.py
+++ b/extras/mmu/mmu_unit.py
@@ -411,6 +411,21 @@ class MmuUnit:
         else:
             logging.info("MMU: - No mmu_buffer specified")
 
+        # A proportional-backed compression endstop can only detect extruder collision if the
+        # buffer spring rest state leaves headroom toward compression (physical switch is exempt)
+        if (
+            self.buffer
+            and self.p.extruder_homing_endstop == SENSOR_COMPRESSION
+            and self.buffer.proportional_sensor is not None
+            and self.buffer.compression_sensor is self.buffer.proportional_sensor.compression_vsensor
+            and not self.buffer.supports_validation()
+        ):
+            raise config.error(
+                "'extruder_homing_endstop: %s' is not possible with 'buffer_spring_state: %s' because the "
+                "proportional sensor cannot detect extruder collision. Requires 'tension' or 'neutral' spring "
+                "state, or an alternative extruder homing endstop" % (SENSOR_COMPRESSION, self.buffer.buffer_spring_state)
+            )
+
         # Create sync-feedback controller (created even if no buffer or encoder)
         self.sync_feedback = MmuSyncFeedback(params, self, self.p)
         logging.info("MMU: Created: sync-feedback / autotune controller for unit %s" % self.name)

--- a/extras/mmu/unit/mmu_buffer.py
+++ b/extras/mmu/unit/mmu_buffer.py
@@ -112,6 +112,20 @@ class MmuBuffer:
         self.connected_units.append(mmu_unit)
 
 
+    def supports_validation(self):
+        """
+        Whether the proportional sensor can drive active validation probes (extruder collision
+        homing, load/unload validation, recovery grip checks). Probes displace the buffer away
+        from its spring rest position so require a rest state with headroom toward compression:
+          'tension' - preloaded at tension rail, best friction immunity
+          'neutral' - dual sprung, discrimination relies on spring force ramp
+        'compression' rests at the compression rail (vsensor pre-triggered, probes blind) and
+        'none' has no restoring force (reading reflects last motion, not column force), so both
+        are limited to sync-feedback control
+        """
+        return self.proportional_sensor is not None and self.buffer_spring_state in ('tension', 'neutral')
+
+
     def sync_tension_callback(self, eventtime, t_sensor_name, tension_state, runout_helper):
         """
         Button event handler for sync-feedback tension switch


### PR DESCRIPTION
Addressing review comments.

Code subject to real world testing (to be performed today).

**Key changes:**

**Load side validation**
Reworked the proportional-sensor validation in the extruder load and unload paths, and cleaned up the two spots that were flagged as unfinished.

The grip check used to wait for the compression sensor to release, which could fail whenever the buffer wasn't compressed to begin with. Unlikely scenario however new approach is more robust. It now watches the sensor shift toward tension as the extruder pulls filament through, which is the real signal that the extruder has grabbed regardless of where the buffer started. 

**Unload side validation**
 It's now built around the potential failure modes. 

First it just looks at where the sensor is resting: if it's sitting in compression, the MMU gear never pulled the filament back, so we flag that and stop. 

Otherwise it does extruder-only retract in steps, watching for the sensor to move toward compression. If it does, the extruder is still holding the filament. If it never does across the whole move, the filament's out. 

We retract rather than push so we can't accidentally shove filament back toward the nozzle, and we step-and-check so we stop the moment we see a grip instead of over-driving the buffer into its end.

**Unload safety margin**
There's one physical dependency we need to take into account. The probe only works if a released tip has been pulled far enough back to cross the tension/compression threshold in the tunables. Also it needs to give a strong enough signal taking into account things like bowden slack. 

In the unload move itself this PR now makes sure the safety margin is at least one buffer range whenever the proportional sensor is doing the validating. If its not a log info is thrown notifying the user that their configured value has been overridden.

This max value is applied so the filament-position accounting still balances, and it only kicks in on the proportional path. 

**The tunables all live as named constants:** 
The shift that counts as a grip, the resting level that means "MMU didn't retract" (0.8), and the bowden slack over-move factor. 