### PR TITLE
Fix embedded led-effect shutdown on recent Klipper (set_color now private)

### DIFF
--- a/extras/mmu_led_effect.py
+++ b/extras/mmu_led_effect.py
@@ -260,7 +260,10 @@ class ledFrameHandler:
         for effect in self.effects:
             if not effect.runOnShutown:
                 for chain in self.ledChains:
-                    chain.led_helper.set_color(None, (0.0, 0.0, 0.0, 0.0))
+                    if hasattr(chain.led_helper, '_set_color'):
+                        chain.led_helper._set_color(None, (0.0, 0.0, 0.0, 0.0))
+                    else:
+                        chain.led_helper.set_color(None, (0.0, 0.0, 0.0, 0.0))
                     self._transmit_chain(chain)
                     
         pass


### PR DESCRIPTION
Recent Klipper renamed `LEDHelper.set_color` to `_set_color`, already handled for `check_transmit` in this module. The embedded led-effect `_handle_shutdown` still calls `set_color`, so a `klippy:shutdown` raises `AttributeError`. Adds the matching `_set_color`/`set_color` fallback.

Note: not exercised on a real `klippy:shutdown` (its only trigger) — it's a direct mirror of the existing `_check_transmit`/`check_transmit` fallback just above, and the embedded led-effects otherwise render correctly on current Klipper.
