### PR TITLE
Fix multi-unit config generation using wrong/empty values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ $(OUT)/$(notdir $(KCONFIG_CONFIG)).pickle: $(KCONFIG_CONFIG) | python_deps $(OUT
 
 $(OUT)/$(notdir $(KCONFIG_CONFIG))_%.pickle: $(KCONFIG_CONFIG)_% | python_deps $(OUT)
 	$(Q)echo "$(C_INFO)Pre-parsing Kconfig $(notdir $(KCONFIG_CONFIG)_$*)$(C_OFF)"
-	$(Q)$(PY) -m installer.build $(V) --pre-parse-kconfig "$(KCONFIG_CONFIG)_$*"
+	$(Q)UNIT_NAME="$*" MCU_NAME="$*" $(PY) -m installer.build $(V) --pre-parse-kconfig "$(KCONFIG_CONFIG)_$*"
 
 
 diff= \

--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ python_deps:
 
 $(OUT)/$(notdir $(KCONFIG_CONFIG)).pickle: $(KCONFIG_CONFIG) | python_deps $(OUT)
 	$(Q)echo "$(C_INFO)Pre-parsing Kconfig $(notdir $(KCONFIG_CONFIG))$(C_OFF)"
-	$(Q)$(PY) -m installer.build $(V) --pre-parse-kconfig "$(KCONFIG_CONFIG)"
+	$(Q)$(if $(filter y,$(CONFIG_MULTI_UNIT)),F_MULTI_UNIT=y F_MULTI_UNIT_ENTRY_POINT=y) $(PY) -m installer.build $(V) --pre-parse-kconfig "$(KCONFIG_CONFIG)"
 
 $(OUT)/$(notdir $(KCONFIG_CONFIG))_%.pickle: $(KCONFIG_CONFIG)_% | python_deps $(OUT)
 	$(Q)echo "$(C_INFO)Pre-parsing Kconfig $(notdir $(KCONFIG_CONFIG)_$*)$(C_OFF)"


### PR DESCRIPTION
## Summary

Fixes two multi-unit config generation bugs where the installer rendered per-unit `.cfg` files with wrong or empty values. Both share the same root cause: when the Kconfig `.pickle` files are pre-parsed during `make install`, the promptless symbols (`UNIT_NAME`, `MCU_NAME`, `MULTI_UNIT`, `MULTI_UNIT_ENTRY_POINT`) are recomputed purely from the environment and ignore the values stored in the config file. The build rules didn't pass the needed context, so the parse fell back to defaults.

## Bug 1 — per-unit files rendered with `unit0`/vendor-0 values

The per-unit pickle rule (`.mmu_config_unitN.pickle`) didn't pass `UNIT_NAME`/`MCU_NAME` to the subprocess. Since these are promptless symbols, kconfiglib ignored the stored `CONFIG_UNIT_NAME="unitN"` and used the default `unit0`.

**Result:** `mmu_hardware_unit1.cfg` / `mmu_parameters_unit1.cfg` rendered `[mcu unit0]`, `[mmu_unit unit0]`, `vendor: EMU`, wrong gate count, etc. — even though `.mmu_config_unit1` was correct.

**Fix:** set `UNIT_NAME`/`MCU_NAME` from the pattern stem in the per-unit pickle rule.

## Bug 2 — `mmu.cfg` rendered an empty `[mmu_toolhead ]`

The base `.mmu_config` pickle was pre-parsed without `F_MULTI_UNIT_ENTRY_POINT`. With `F_MULTI_UNIT=y` exported but the entry-point flag absent, the parse produced the illegal combination `MULTI_UNIT=y` + `MULTI_UNIT_ENTRY_POINT=n`, under which none of the toolhead Kconfig blocks are sourced.

**Result:** `mmu.cfg` rendered `[mmu_toolhead ]` (empty name) with blank `extruder_switch_pin`, `toolhead_switch_pin`, `register_toolhead_sensors`, and toolhead dimension params.

**Fix:** pass `F_MULTI_UNIT=y F_MULTI_UNIT_ENTRY_POINT=y` for the base pickle when `CONFIG_MULTI_UNIT=y`. Keying off the config file (via the `-include`) also keeps a bare `make install` correct without relying on `install.sh` exports.

## Changes

- `Makefile`: base pickle rule passes entry-point env when multi-unit
- `Makefile`: per-unit pickle rule passes `UNIT_NAME`/`MCU_NAME`

## Testing

- Verified on a live multi-unit setup (EMU unit0 + ERCF unit1) via `./install.sh -i -n`:
  - `mmu_hardware_unit1.cfg` now renders `[mcu unit1]`, `[mmu_unit unit1]`, correct vendor/version/gate count
  - `mmu.cfg` now renders `[mmu_toolhead default]` with populated pins and params
