### PR TITLE
V4: Improve purge/retraction handling using slicer settings

### DIFF
--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -899,8 +899,8 @@ FLUSH_MULTIPLIER_REGEX = r"^;\s*flush_multiplier\s*=\s*(.*)$" #flush multiplier 
 FILAMENT_NAMES_REGEX = r"^;\s*(filament_settings_id)\s*=\s*(.*)$"
 METADATA_FILAMENT_NAMES = "!filament_names!"
 
-# Detection for next pos processing
-T_PATTERN  = r'^T(\d+)\s*(?:;.*)?$'
+# Detection for next pos processing and slicer parameters
+T_PATTERN  = r'^T(\d+)((?:\s+(?:SLICER_PURGE|SLICER_RETRACTION|SLICER_FW_RETRACTION)=[^\s;]+)*)\s*(?:;.*)?$'
 G1_PATTERN = r'^G[01](?=.*\sX(-?[\d.]+))(?=.*\sY(-?[\d.]+)).*$'
 
 def _parse_version_tuple(version_str: str, parts: int = 3):
@@ -1115,6 +1115,7 @@ def process_file(input_filename, output_filename, insert_nextpos, tools_used, to
     with open(input_filename, 'r') as infile, open(output_filename, 'w') as outfile:
         buffer = [] # Buffer lines between a "T" line and the next matching "G1" line
         tool = None # Store the tool number from a "T" line
+        slicer_params = '' # Store slicer parameters from the "T" line
         outfile.write(f'{HAPPY_HARE_FINGERPRINT}\n')
 
         for line in infile:
@@ -1127,25 +1128,27 @@ def process_file(input_filename, output_filename, insert_nextpos, tools_used, to
                     # Now replace "T" line and write buffered lines, including the current "G1" line
                     if insert_nextpos:
                         x, y = g1_match.groups()
-                        outfile.write(f'MMU_CHANGE_TOOL TOOL={tool} NEXT_POS="{x},{y}" ; T{tool}\n')
+                        outfile.write(f'MMU_CHANGE_TOOL TOOL={tool}{slicer_params} NEXT_POS="{x},{y}" ; T{tool}\n')
                     else:
-                        outfile.write(f'MMU_CHANGE_TOOL TOOL={tool} ; T{tool}\n')
+                        outfile.write(f'MMU_CHANGE_TOOL TOOL={tool}{slicer_params} ; T{tool}\n')
                     for buffered_line in buffer:
                         outfile.write(buffered_line)
                     buffer.clear()
                     tool = None
+                    slicer_params = ''
                 continue
 
             t_match = t_pattern.match(line)
             if t_match:
                 tool = t_match.group(1)
+                slicer_params = t_match.group(2) if t_match.lastindex >= 2 else ''
             else:
                 outfile.write(line)
 
         # If there is anything left in buffer it means there wasn't a final "G1" line
         if buffer:
             outfile.write(f"T{tool}\n")
-            outfile.write(f'MMU_CHANGE_TOOL TOOL={tool} ; T{tool}\n')
+            outfile.write(f'MMU_CHANGE_TOOL TOOL={tool}{slicer_params} ; T{tool}\n')
             for line in buffer:
                 outfile.write(line)
 

--- a/config/macros/mmu_sequence.cfg
+++ b/config/macros/mmu_sequence.cfg
@@ -342,7 +342,7 @@ gcode:
     {% if printer.extruder.can_extrude %}
         {% if printer.print_stats.state|lower == 'printing' %}
             {% if printer.mmu.slicer_fw_retraction %}
-                 {% set _ = "including slicer FW retraction (G10) " %}
+                 {% set _ = "and slicer FW retraction (G10) " %}
                  G10
             {% elif printer.mmu.slicer_retraction > 0 %}      
                  {% set _ = "including " ~ printer.mmu.slicer_retraction ~ "mm slicer retraction " %}  

--- a/config/macros/mmu_sequence.cfg
+++ b/config/macros/mmu_sequence.cfg
@@ -337,10 +337,21 @@ gcode:
     {% set park_vars = printer['gcode_macro _MMU_PARK'] %}
     {% set length = park_vars.retracted_length %}
     {% set speed = sequence_vars.unretract_speed|int %}
+    {% set _ = "" %}
 
     {% if printer.extruder.can_extrude %}
+        {% if printer.print_stats.state|lower == 'printing' %}
+            {% if printer.mmu.slicer_fw_retraction %}
+                 {% set _ = "including slicer FW retraction (G10) " %}
+                 G10
+            {% elif printer.mmu.slicer_retraction > 0 %}      
+                 {% set _ = "including " ~ printer.mmu.slicer_retraction ~ "mm slicer retraction " %}  
+                 {% set length = length + printer.mmu.slicer_retraction %}
+            {% endif %}
+        {% endif %}
+
         {% if length > 0 %}
-            MMU_LOG MSG="Un-retracting {length}mm"
+            MMU_LOG MSG="Un-retracting {length}mm {_}"
             M83 ; Extruder relative
             G1 E{length} F{speed|abs * 60}
         {% endif %}

--- a/config/macros/mmu_sequence.cfg
+++ b/config/macros/mmu_sequence.cfg
@@ -340,20 +340,21 @@ gcode:
     {% set _ = "" %}
 
     {% if printer.extruder.can_extrude %}
-        {% if printer.print_stats.state|lower == 'printing' %}
-            {% if printer.mmu.slicer_fw_retraction %}
-                 {% set _ = "and slicer FW retraction (G10) " %}
-                 G10
-            {% elif printer.mmu.slicer_retraction > 0 %}      
-                 {% set _ = "including " ~ printer.mmu.slicer_retraction ~ "mm slicer retraction " %}  
-                 {% set length = length + printer.mmu.slicer_retraction %}
-            {% endif %}
-        {% endif %}
+    ;    {% if printer.print_stats.state|lower == 'printing' and not printer.mmu.num_toolchanges == 0 %}
+    ;        {% if printer.mmu.slicer_fw_retraction %}
+    ;             {% set _ = "and slicer FW retraction " %}
+    ;             G10
+    ;        {% elif printer.mmu.slicer_retraction > 0 %}      
+    ;             {% set _ = "allowing " ~ printer.mmu.slicer_retraction ~ "mm for slicer retraction " %}  
+    ;             {% set length = length - printer.mmu.slicer_retraction %}
+    ;        {% endif %}
+    ;    {% endif %}
 
         {% if length > 0 %}
-            MMU_LOG MSG="Un-retracting {length}mm {_}"
+            MMU_LOG MSG="Un-retracting {length}mm"
             M83 ; Extruder relative
             G1 E{length} F{speed|abs * 60}
+    ;        MMU_CHANGE_TOOL RESET_SLICER_DETAILS=1
         {% endif %}
         SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=retracted_length VALUE=0
     {% else %}

--- a/config/macros/mmu_sequence.cfg
+++ b/config/macros/mmu_sequence.cfg
@@ -337,14 +337,12 @@ gcode:
     {% set park_vars = printer['gcode_macro _MMU_PARK'] %}
     {% set length = park_vars.retracted_length %}
     {% set speed = sequence_vars.unretract_speed|int %}
-    {% set _ = "" %}
 
     {% if printer.extruder.can_extrude %}
         {% if length > 0 %}
             MMU_LOG MSG="Un-retracting {length}mm"
             M83 ; Extruder relative
             G1 E{length} F{speed|abs * 60}
-    ;        MMU_CHANGE_TOOL RESET_SLICER_DETAILS=1
         {% endif %}
         SET_GCODE_VARIABLE MACRO=_MMU_PARK VARIABLE=retracted_length VALUE=0
     {% else %}

--- a/config/macros/mmu_sequence.cfg
+++ b/config/macros/mmu_sequence.cfg
@@ -340,16 +340,6 @@ gcode:
     {% set _ = "" %}
 
     {% if printer.extruder.can_extrude %}
-    ;    {% if printer.print_stats.state|lower == 'printing' and not printer.mmu.num_toolchanges == 0 %}
-    ;        {% if printer.mmu.slicer_fw_retraction %}
-    ;             {% set _ = "and slicer FW retraction " %}
-    ;             G10
-    ;        {% elif printer.mmu.slicer_retraction > 0 %}      
-    ;             {% set _ = "allowing " ~ printer.mmu.slicer_retraction ~ "mm for slicer retraction " %}  
-    ;             {% set length = length - printer.mmu.slicer_retraction %}
-    ;        {% endif %}
-    ;    {% endif %}
-
         {% if length > 0 %}
             MMU_LOG MSG="Un-retracting {length}mm"
             M83 ; Extruder relative

--- a/extras/mmu/commands/mmu_change_tool.py
+++ b/extras/mmu/commands/mmu_change_tool.py
@@ -87,7 +87,7 @@ class MmuChangeToolCommand(BaseCommand):
             slicer_fw_retraction = False
         else:
             slicer_fw_retraction = False
-            mmu.log_error("Error - incorrect slicer FW retraction setting - ignored")
+            mmu.log_error("Error - incorrect slicer FW retraction setting ignored")
      
         # validate retraction settings - if FW & printer supports it, disable slicer retraction, else disable FW
         if slicer_fw_retraction:

--- a/extras/mmu/commands/mmu_change_tool.py
+++ b/extras/mmu/commands/mmu_change_tool.py
@@ -86,11 +86,9 @@ class MmuChangeToolCommand(BaseCommand):
         elif slicer_fw_retraction_raw in ('false', '0'):
             slicer_fw_retraction = False
         else:
-            raise gcmd.error(
-                f"SLICER_FW_RETRACTION must be true|false|0|1, "
-                f"got '{gcmd.get('SLICER_FW_RETRACTION')}'"
-            )
-
+            slicer_fw_retraction = False
+            mmu.log_error("Error - incorrect slicer FW retraction setting - ignored")
+     
         # validate retraction settings - if FW & printer supports it, disable slicer retraction, else disable FW
         if slicer_fw_retraction:
             fw_retraction_obj = mmu.printer.lookup_object('firmware_retraction', None)

--- a/extras/mmu/commands/mmu_change_tool.py
+++ b/extras/mmu/commands/mmu_change_tool.py
@@ -20,6 +20,8 @@ from ..mmu_utils       import MmuError
 from .mmu_base_command import *
 
 
+
+
 class MmuChangeToolCommand(BaseCommand):
 
     CMD = "MMU_CHANGE_TOOL"
@@ -27,14 +29,17 @@ class MmuChangeToolCommand(BaseCommand):
     HELP_BRIEF = "Perform a tool swap (called from Tx command)"
     HELP_PARAMS = (
         f"{CMD}: {HELP_BRIEF}\n"
-        + "QUIET      = [0|1]\n"
-        + "STANDALONE = [0|1]\n"
-        + "RESTORE    = [0|1]\n"
-        + "SKIP_TIP   = [0|1]\n"
-        + "SKIP_PURGE = [0|1]\n"
-        + "NEXT_POS   = X,Y (optional; only used when restore_xy_pos is 'next')\n"
-        + "TOOL       = #(int)\n"
-        + "GATE       = #(int)\n"
+        + "QUIET                = [0|1]\n"
+        + "STANDALONE           = [0|1]\n"
+        + "RESTORE              = [0|1]\n"
+        + "SKIP_TIP             = [0|1]\n"
+        + "SKIP_PURGE           = [0|1]\n"
+        + "SLICER_PURGE         = #(mm)            (optional; slicer purge distance)\n"
+        + "SLICER_RETRACTION    = #(mm)            (optional; slicer retraction distance)\n"
+        + "SLICER_FW_RETRACTION = true|false|0|1   (optional; whether slicer enables firmware retraction)\n"
+        + "NEXT_POS             = X,Y              (optional; only used when restore_xy_pos is 'next')\n"
+        + "TOOL                 = #(int)\n"
+        + "GATE                 = #(int)\n"
     )
     HELP_SUPPLEMENT = (
         "Examples:\n"
@@ -73,6 +78,28 @@ class MmuChangeToolCommand(BaseCommand):
         restore = bool(gcmd.get_int('RESTORE', 1, minval=0, maxval=1))
         skip_tip = bool(gcmd.get_int('SKIP_TIP', 0, minval=0, maxval=1))
         skip_purge = bool(gcmd.get_int('SKIP_PURGE', 0, minval=0, maxval=1))
+
+        # capture slicer retraction parameters
+        slicer_purge = gcmd.get_float('SLICER_PURGE', -1)
+        slicer_retraction = gcmd.get_float('SLICER_RETRACTION', -1)
+        slicer_fw_retraction_raw = gcmd.get('SLICER_FW_RETRACTION', '0').lower().strip()
+        if slicer_fw_retraction_raw in ('true', 'yes', '1'):
+            slicer_fw_retraction = True
+        elif slicer_fw_retraction_raw in ('false', 'no', '0'):
+            slicer_fw_retraction = False
+        else:
+            raise gcmd.error(
+                f"SLICER_FW_RETRACTION must be true|false|yes|no|0|1, "
+                f"got '{gcmd.get('SLICER_FW_RETRACTION')}'"
+            )
+
+        # validate retraction settings - if FW & printer supports it, disable slicer retraction, else disable FW
+        if slicer_fw_retraction:
+            fw_retraction_obj = mmu.printer.lookup_object('firmware_retraction', None)
+            if fw_retraction_obj:
+                slicer_retraction = 0.0
+            else:
+                slicer_fw_retraction = False 
 
         # Handle "next_pos" option for toolhead position restoration
         next_pos = None
@@ -127,6 +154,11 @@ class MmuChangeToolCommand(BaseCommand):
             with mmu.wrap_sync_gear_to_extruder():
                 with mmu.wrap_suspend_filament_monitoring(): # Don't want runout accidently triggering during tool change
                     with mmu.var_manager.wrap_suspend_write_variables(): # Reduce I/O activity to a minimum
+
+                        # set slicer parameters as mmu attributes for macros
+                        mmu.slicer_purge_length  = slicer_purge
+                        mmu.slicer_retraction    = slicer_retraction
+                        mmu.slicer_fw_retraction = slicer_fw_retraction
 
                         # Good place to update automatic clog detection length if applicable
                         if mmu.has_encoder():

--- a/extras/mmu/commands/mmu_change_tool.py
+++ b/extras/mmu/commands/mmu_change_tool.py
@@ -20,8 +20,6 @@ from ..mmu_utils       import MmuError
 from .mmu_base_command import *
 
 
-
-
 class MmuChangeToolCommand(BaseCommand):
 
     CMD = "MMU_CHANGE_TOOL"

--- a/extras/mmu/commands/mmu_change_tool.py
+++ b/extras/mmu/commands/mmu_change_tool.py
@@ -83,13 +83,13 @@ class MmuChangeToolCommand(BaseCommand):
         slicer_purge = gcmd.get_float('SLICER_PURGE', -1)
         slicer_retraction = gcmd.get_float('SLICER_RETRACTION', -1)
         slicer_fw_retraction_raw = gcmd.get('SLICER_FW_RETRACTION', '0').lower().strip()
-        if slicer_fw_retraction_raw in ('true', 'yes', '1'):
+        if slicer_fw_retraction_raw in ('true', '1'):
             slicer_fw_retraction = True
-        elif slicer_fw_retraction_raw in ('false', 'no', '0'):
+        elif slicer_fw_retraction_raw in ('false', '0'):
             slicer_fw_retraction = False
         else:
             raise gcmd.error(
-                f"SLICER_FW_RETRACTION must be true|false|yes|no|0|1, "
+                f"SLICER_FW_RETRACTION must be true|false|0|1, "
                 f"got '{gcmd.get('SLICER_FW_RETRACTION')}'"
             )
 
@@ -97,7 +97,7 @@ class MmuChangeToolCommand(BaseCommand):
         if slicer_fw_retraction:
             fw_retraction_obj = mmu.printer.lookup_object('firmware_retraction', None)
             if fw_retraction_obj:
-                slicer_retraction = 0.0
+                slicer_retraction = -1
             else:
                 slicer_fw_retraction = False 
 

--- a/extras/mmu/commands/mmu_change_tool.py
+++ b/extras/mmu/commands/mmu_change_tool.py
@@ -101,7 +101,7 @@ class MmuChangeToolCommand(BaseCommand):
             if fw_retraction_obj:
                 slicer_retraction = -1
             else:
-                mmu.log_warning("gcode uses firmware retraction but its not enabled in printer") 
+                mmu.log_warning("Print gcode uses firmware retraction but its not enabled in the printer") 
                 slicer_fw_retraction = False
   
 
@@ -156,7 +156,7 @@ class MmuChangeToolCommand(BaseCommand):
 
         try:
             with mmu.wrap_sync_gear_to_extruder():
-                with mmu.wrap_suspend_filament_monitoring(): # Don't want runout accidently triggering during tool change
+                with mmu.wrap_suspend_filament_monitoring(): # Don't want runout accidentally triggering during tool change
                     with mmu.var_manager.wrap_suspend_write_variables(): # Reduce I/O activity to a minimum
 
                         # set slicer parameters as mmu attributes for macros

--- a/extras/mmu/commands/mmu_change_tool.py
+++ b/extras/mmu/commands/mmu_change_tool.py
@@ -72,7 +72,7 @@ class MmuChangeToolCommand(BaseCommand):
 
         mmu.fix_started_state()
 
-        # reset slicer purge distance
+        # reset stored slicer purge length
         if gcmd.get_int('RESET_SLICER_PURGE', 0, minval=0, maxval=1):
             mmu.slicer_purge_length = -1
             return

--- a/extras/mmu/commands/mmu_change_tool.py
+++ b/extras/mmu/commands/mmu_change_tool.py
@@ -101,7 +101,9 @@ class MmuChangeToolCommand(BaseCommand):
             if fw_retraction_obj:
                 slicer_retraction = -1
             else:
-                slicer_fw_retraction = False 
+                mmu.log_warning("gcode uses firmware retraction but its not enabled in printer") 
+                slicer_fw_retraction = False
+  
 
         # Handle "next_pos" option for toolhead position restoration
         next_pos = None

--- a/extras/mmu/commands/mmu_change_tool.py
+++ b/extras/mmu/commands/mmu_change_tool.py
@@ -27,17 +27,18 @@ class MmuChangeToolCommand(BaseCommand):
     HELP_BRIEF = "Perform a tool swap (called from Tx command)"
     HELP_PARAMS = (
         f"{CMD}: {HELP_BRIEF}\n"
-        + "QUIET                = [0|1]\n"
-        + "STANDALONE           = [0|1]\n"
-        + "RESTORE              = [0|1]\n"
-        + "SKIP_TIP             = [0|1]\n"
-        + "SKIP_PURGE           = [0|1]\n"
-        + "SLICER_PURGE         = #(mm)            (optional; slicer purge distance)\n"
-        + "SLICER_RETRACTION    = #(mm)            (optional; slicer retraction distance)\n"
-        + "SLICER_FW_RETRACTION = true|false|0|1   (optional; whether slicer enables firmware retraction)\n"
-        + "NEXT_POS             = X,Y              (optional; only used when restore_xy_pos is 'next')\n"
-        + "TOOL                 = #(int)\n"
-        + "GATE                 = #(int)\n"
+        + "QUIET                 = [0|1]\n"
+        + "STANDALONE            = [0|1]\n"
+        + "RESTORE               = [0|1]\n"
+        + "SKIP_TIP              = [0|1]\n"
+        + "SKIP_PURGE            = [0|1]\n"
+        + "RESET_SLICER_PURGE    = [0|1]            (clear stored slicer purge length and exit)\n"
+        + "SLICER_PURGE          = #(mm)            (optional; slicer purge length)\n"
+        + "SLICER_RETRACTION     = #(mm)            (optional; slicer retraction length)\n"
+        + "SLICER_FW_RETRACTION  = true|false|0|1   (optional; whether slicer enables firmware retraction. Ignored if not enabled in printer)\n"
+        + "NEXT_POS              = X,Y              (optional; only used when restore_xy_pos is 'next')\n"
+        + "TOOL                  = #(int)\n"
+        + "GATE                  = #(int)\n"
     )
     HELP_SUPPLEMENT = (
         "Examples:\n"
@@ -71,6 +72,11 @@ class MmuChangeToolCommand(BaseCommand):
 
         mmu.fix_started_state()
 
+        # reset slicer purge distance
+        if gcmd.get_int('RESET_SLICER_PURGE', 0, minval=0, maxval=1):
+            mmu.slicer_purge_length = -1
+            return
+
         quiet = gcmd.get_int('QUIET', 0, minval=0, maxval=1)
         standalone = bool(gcmd.get_int('STANDALONE', 0, minval=0, maxval=1))
         restore = bool(gcmd.get_int('RESTORE', 1, minval=0, maxval=1))
@@ -87,7 +93,7 @@ class MmuChangeToolCommand(BaseCommand):
             slicer_fw_retraction = False
         else:
             slicer_fw_retraction = False
-            mmu.log_error("Error - incorrect slicer FW retraction setting ignored")
+            mmu.log_error("Invalid slicer FW retraction setting ignored")
      
         # validate retraction settings - if FW & printer supports it, disable slicer retraction, else disable FW
         if slicer_fw_retraction:
@@ -234,7 +240,7 @@ class MmuChangeToolCommand(BaseCommand):
                                     break
                                 except MmuError as ee:
                                     if i == attempts - 1:
-                                        raise MmuError("%s.\nOccured when changing tool: %s" % (str(ee), mmu._last_toolchange))
+                                        raise MmuError("%s.\nOccurred when changing tool: %s" % (str(ee), mmu._last_toolchange))
                                     mmu.log_error("%s.\nOccured when changing tool: %s. Retrying..." % (str(ee), mmu._last_toolchange))
                                     # Try again but recover_filament_pos will ensure conservative treatment of unload
                                     mmu.recover_filament_pos()

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -141,7 +141,7 @@ class MmuController(MmuFilamentMovement):
         self.runout_last_enable_time = self.reactor.monotonic() # Used to help filter late runout callbacks
         self.is_handling_runout = False # True whilst handling a runout
 
-        self.unit_selected = None       # Must not stay None, set when inital gate is set or in _load_persisted_state()
+        self.unit_selected = None       # Must not stay None, set when initial gate is set or in _load_persisted_state()
         self.tool_selected = self.gate_selected = TOOL_GATE_UNKNOWN
         self._last_tool = self._next_tool       = TOOL_GATE_UNKNOWN
         self._next_gate = None
@@ -157,7 +157,10 @@ class MmuController(MmuFilamentMovement):
         self._reset_job_statistics()
         self.form_tip_vars = None       # Current defaults of gcode variables for tip forming macro
         self.gate_maps.clear_slicer_tool_map()
-        self.pending_spool_id = -1      # For automatic assignment of spool_id if set perhaps by rfid reader
+        self.pending_spool_id = -1    # For automatic assignment of spool_id if set perhaps by rfid reader
+        self.slicer_purge_length = -1 # slicer purge distance set by MMU_CHANGE_TOOL
+        self.slicer_retraction = -1   # slicer retraction distance set by MMU_CHANGE_TOOL
+        self.slicer_fw_retraction = 0 # slicer firmware retraction set by MMU_CHANGE_TOOL
         self.saved_toolhead_max_accel = None
         self.num_toolchanges = 0
 
@@ -611,6 +614,9 @@ class MmuController(MmuFilamentMovement):
             'num_toolchanges': self.num_toolchanges,
             'last_tool': self._last_tool,
             'next_tool': self._next_tool,
+            'slicer_purge_length': self.slicer_purge_length,
+            'slicer_retraction': self.slicer_retraction,   
+            'slicer_fw_retraction': self.slicer_fw_retraction,
             'toolchange_purge_volume': self.toolchange_purge_volume,
             'last_toolchange': self._last_toolchange,
             'operation': self.saved_toolhead_operation,

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -615,8 +615,6 @@ class MmuController(MmuFilamentMovement):
             'last_tool': self._last_tool,
             'next_tool': self._next_tool,
             'slicer_purge_length': self.slicer_purge_length,
-            'slicer_retraction': self.slicer_retraction,   
-            'slicer_fw_retraction': self.slicer_fw_retraction,
             'toolchange_purge_volume': self.toolchange_purge_volume,
             'last_toolchange': self._last_toolchange,
             'operation': self.saved_toolhead_operation,

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1730,7 +1730,6 @@ class MmuFilamentMovement:
                         self.log_debug("Retracting to match slicer firmware retraction (G10)")
                         self.gcode.run_script_from_command("G10")
                     elif self.slicer_retraction > 0:
-                        # Get unretract speed from _MMU_SEQUENCE_VARS macro, default to 30 mm/s (F1800)
                         sequence_vars = self.printer.lookup_object("gcode_macro _MMU_SEQUENCE_VARS", None)
                         retract_speed = sequence_vars.variables.get('retract_speed', 30) if sequence_vars else 30
                         self.log_debug("Retracting to match slicer retraction -%.2fmm" % self.slicer_retraction)

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1724,24 +1724,25 @@ class MmuFilamentMovement:
                         else:
                             self.wrap_gcode_command(self.p.post_load_macro, exception=True, wait=True)
 
-                # match orca/prusa/super slicer enforced retractions after post_load when printing
+                # match orca/prusa/super slicer unhandled retractions after post_load when printing
                 if self.is_printing() and self.num_toolchanges >= 1:
-                    retract_len    = 0
-                    retract_speed  = 30
+                    retract_len = 0
+                    speed       = 30
                     
                     if self.slicer_fw_retraction:
                         fw_retract = self.printer.lookup_object('firmware_retraction', None)
                         if fw_retract:
-                            retract_len    = fw_retract.retract_length
-                            retract_speed  = fw_retract.retract_speed
+                            retract_len = fw_retract.retract_length
+                            speed       = fw_retract.retract_speed
                     elif self.slicer_retraction > 0:
-                        sequence_vars  = self.printer.lookup_object("gcode_macro _MMU_SEQUENCE_VARS", None)
-                        retract_len    = self.slicer_retraction
-                        retract_speed  = sequence_vars.variables.get('retract_speed', 30) if sequence_vars else 30
+                        sequence_vars = self.printer.lookup_object("gcode_macro _MMU_SEQUENCE_VARS", None)
+                        retract_len   = self.slicer_retraction
+                        speed         = sequence_vars.variables.get('retract_speed', 30) if sequence_vars else 30
                     
                     if retract_len > 0:
-                        self.log_debug("Un-retracting %.2fmm to match slicer retraction" % retract_len)
-                        self.gcode.run_script_from_command("G1 E%.2f F%d" % (retract_len, int(retract_speed * 60)))
+                        self.log_debug("Retracting %.2fmm to match unhandled slicer retraction" % -retract_len)
+                        motor = "gear+extruder" if self.selector().get_filament_grip_state() == FILAMENT_DRIVE_STATE and not extruder_only else "extruder"
+                        self.move_filament("Unhandled slicer retraction", -retract_len, motor=motor, speed=speed * 60, accel=self.p.extruder_accel)
                     
                     self.slicer_retraction = -1
                     self.slicer_fw_retraction = False

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1050,7 +1050,7 @@ class MmuFilamentMovement:
                     # detect failure in the critical extruder entrance transition by
                     # performing the initial load with just the extruder motor and checking
                     # that the sensor un-triggers before continuing
-                    max_range = u.buffer.buffer_maxrange * 2 # Arbitary but buffer_maxrange is not enough to overcome bowden slack
+                    max_range = u.buffer.buffer_maxrange * 2 # Arbitrary but buffer_maxrange is not enough to overcome bowden slack
                     if length > max_range:
                         self.log_debug("Monitoring extruder entrance transition for up to %.1fmm..." % max_range)
                         actual, success = u.sync_feedback.adjust_filament_tension(use_gear_motor=False, max_move=max_range)
@@ -1727,11 +1727,14 @@ class MmuFilamentMovement:
                 # match orca/prusa/super slicer enforced retractions after post_load when printing
                 if self.is_printing() and self.num_toolchanges >= 1:
                     if self.slicer_fw_retraction:
-                        self.log_debug("Un-retracting to match slicer firmware retraction (G10)")
+                        self.log_debug("Retracting to match slicer firmware retraction (G10)")
                         self.gcode.run_script_from_command("G10")
                     elif self.slicer_retraction > 0:
-                        self.log_debug("Un-retracting to match slicer retraction -%.2fmm" % self.slicer_retraction)
-                        self.gcode.run_script_from_command("G1 E-%.2f F1800" % self.slicer_retraction)
+                        # Get unretract speed from _MMU_SEQUENCE_VARS macro, default to 30 mm/s (F1800)
+                        sequence_vars = self.printer.lookup_object("gcode_macro _MMU_SEQUENCE_VARS", None)
+                        retract_speed = sequence_vars.variables.get('retract_speed', 30) if sequence_vars else 30
+                        self.log_debug("Retracting to match slicer retraction -%.2fmm" % self.slicer_retraction)
+                        self.gcode.run_script_from_command("G1 E-%.2f F%d" % (self.slicer_retraction, retract_speed * 60))
                     self.slicer_retraction = -1
                     self.slicer_fw_retraction = False
 

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1733,20 +1733,20 @@ class MmuFilamentMovement:
                         fw_retract = self.printer.lookup_object('firmware_retraction', None)
                         if fw_retract:
                             retract_len = fw_retract.retract_length
-                            speed       = fw_retract.retract_speed
+                            if fw_retract.retract_speed > 0:
+                                speed = fw_retract.retract_speed 
                     elif self.slicer_retraction > 0:
                         sequence_vars = self.printer.lookup_object("gcode_macro _MMU_SEQUENCE_VARS", None)
                         retract_len   = self.slicer_retraction
-                        speed         = sequence_vars.variables.get('retract_speed', 30) if sequence_vars else 30
+                        speed         = sequence_vars.variables.get('retract_speed', speed) if sequence_vars else speed
                     
                     if retract_len > 0:
                         self.log_debug("Retracting %.2fmm to match unhandled slicer retraction" % -retract_len)
-                        motor = "gear+extruder" if self.selector().get_filament_grip_state() == FILAMENT_DRIVE_STATE and not extruder_only else "extruder"
-                        self.move_filament("Unhandled slicer retraction", -retract_len, motor=motor, speed=speed * 60, accel=self.p.extruder_accel)
+                        self.reset_sync_gear_to_extruder(False if extruder_only else None, force_grip=True)
+                        self.gcode.run_script_from_command("G1 E-%.2f F%d " % (retract_len, speed * 60))
                     
-                    self.slicer_retraction = -1
+                    self.slicer_retraction    = -1
                     self.slicer_fw_retraction = False
-
         except MmuError as ee:
             self._track_gate_statistics('load_failures', self.gate_selected)
             raise MmuError("Load sequence failed because:\n%s" % (str(ee)))

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1724,6 +1724,17 @@ class MmuFilamentMovement:
                         else:
                             self.wrap_gcode_command(self.p.post_load_macro, exception=True, wait=True)
 
+                # match orca/prusa/super slicer enforced retractions after post_load when printing
+                if self.is_printing() and self.num_toolchanges >= 1:
+                    if self.slicer_fw_retraction:
+                        self.log_debug("Un-retracting to match slicer firmware retraction (G10)")
+                        self.gcode.run_script_from_command("G10")
+                    elif self.slicer_retraction > 0:
+                        self.log_debug("Un-retracting to match slicer retraction -%.2fmm" % self.slicer_retraction)
+                        self.gcode.run_script_from_command("G1 E-%.2f F1800" % self.slicer_retraction)
+                    self.slicer_retraction = -1
+                    self.slicer_fw_retraction = False
+
         except MmuError as ee:
             self._track_gate_statistics('load_failures', self.gate_selected)
             raise MmuError("Load sequence failed because:\n%s" % (str(ee)))

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1724,7 +1724,7 @@ class MmuFilamentMovement:
                         else:
                             self.wrap_gcode_command(self.p.post_load_macro, exception=True, wait=True)
 
-                # match orca/prusa/super slicer enforced retractions after post_load when printing
+                # match orca/prusa/super slicer unhandled retractions after post_load when printing
                 if self.is_printing() and self.num_toolchanges >= 1:
                     retract_len    = 0
                     retract_speed  = 30
@@ -1740,8 +1740,9 @@ class MmuFilamentMovement:
                         retract_speed  = sequence_vars.variables.get('retract_speed', 30) if sequence_vars else 30
                     
                     if retract_len > 0:
-                        self.log_debug("Un-retracting %.2fmm to match slicer retraction" % retract_len)
-                        self.gcode.run_script_from_command("G1 E%.2f F%d" % (retract_len, int(retract_speed * 60)))
+                        self.log_debug("Retracting %.2fmm to match unhandled slicer retraction" % -retract_len)
+                        motor = "gear+extruder" if self.selector().get_filament_grip_state() == FILAMENT_DRIVE_STATE else "extruder"
+                        self.move_filament("Unhandled slicer retraction", -retract_len, motor=motor, speed=retract_speed * 60, accel=self.p.extruder_accel)
                     
                     self.slicer_retraction = -1
                     self.slicer_fw_retraction = False

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1726,23 +1726,23 @@ class MmuFilamentMovement:
 
                 # match orca/prusa/super slicer unhandled retractions after post_load when printing
                 if self.is_printing() and self.num_toolchanges >= 1:
-                    retract_len    = 0
-                    retract_speed  = 30
+                    retract_len = 0
+                    speed       = 30
                     
                     if self.slicer_fw_retraction:
                         fw_retract = self.printer.lookup_object('firmware_retraction', None)
                         if fw_retract:
-                            retract_len    = fw_retract.retract_length
-                            retract_speed  = fw_retract.retract_speed
+                            retract_len = fw_retract.retract_length
+                            speed       = fw_retract.retract_speed
                     elif self.slicer_retraction > 0:
-                        sequence_vars  = self.printer.lookup_object("gcode_macro _MMU_SEQUENCE_VARS", None)
-                        retract_len    = self.slicer_retraction
-                        retract_speed  = sequence_vars.variables.get('retract_speed', 30) if sequence_vars else 30
+                        sequence_vars = self.printer.lookup_object("gcode_macro _MMU_SEQUENCE_VARS", None)
+                        retract_len   = self.slicer_retraction
+                        speed         = sequence_vars.variables.get('retract_speed', 30) if sequence_vars else 30
                     
                     if retract_len > 0:
                         self.log_debug("Retracting %.2fmm to match unhandled slicer retraction" % -retract_len)
-                        motor = "gear+extruder" if self.selector().get_filament_grip_state() == FILAMENT_DRIVE_STATE else "extruder"
-                        self.move_filament("Unhandled slicer retraction", -retract_len, motor=motor, speed=retract_speed * 60, accel=self.p.extruder_accel)
+                        motor = "gear+extruder" if self.selector().get_filament_grip_state() == FILAMENT_DRIVE_STATE and not extruder_only else "extruder"
+                        self.move_filament("Unhandled slicer retraction", -retract_len, motor=motor, speed=speed * 60, accel=self.p.extruder_accel)
                     
                     self.slicer_retraction = -1
                     self.slicer_fw_retraction = False

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1726,14 +1726,23 @@ class MmuFilamentMovement:
 
                 # match orca/prusa/super slicer enforced retractions after post_load when printing
                 if self.is_printing() and self.num_toolchanges >= 1:
+                    retract_len    = 0
+                    retract_speed  = 30
+                    
                     if self.slicer_fw_retraction:
-                        self.log_debug("Retracting to match slicer firmware retraction (G10)")
-                        self.gcode.run_script_from_command("G10")
+                        fw_retract = self.printer.lookup_object('firmware_retraction', None)
+                        if fw_retract:
+                            retract_len    = fw_retract.retract_length
+                            retract_speed  = fw_retract.retract_speed
                     elif self.slicer_retraction > 0:
-                        sequence_vars = self.printer.lookup_object("gcode_macro _MMU_SEQUENCE_VARS", None)
-                        retract_speed = sequence_vars.variables.get('retract_speed', 30) if sequence_vars else 30
-                        self.log_debug("Retracting to match slicer retraction -%.2fmm" % self.slicer_retraction)
-                        self.gcode.run_script_from_command("G1 E-%.2f F%d" % (self.slicer_retraction, retract_speed * 60))
+                        sequence_vars  = self.printer.lookup_object("gcode_macro _MMU_SEQUENCE_VARS", None)
+                        retract_len    = self.slicer_retraction
+                        retract_speed  = sequence_vars.variables.get('retract_speed', 30) if sequence_vars else 30
+                    
+                    if retract_len > 0:
+                        self.log_debug("Un-retracting %.2fmm to match slicer retraction" % retract_len)
+                        self.gcode.run_script_from_command("G1 E%.2f F%d" % (retract_len, int(retract_speed * 60)))
+                    
                     self.slicer_retraction = -1
                     self.slicer_fw_retraction = False
 

--- a/install.sh
+++ b/install.sh
@@ -12,19 +12,26 @@
 set -e
 
 SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
-if [ -f ~/klippy-env/bin/activate ]; then
+
+# locate Klipper python environment (klippy-env or klipper-env) and activate it
+if [ -f ~/klipper-env/bin/activate ]; then
+    . ~/klipper-env/bin/activate
+elif [ -f ~/klippy-env/bin/activate ]; then
     . ~/klippy-env/bin/activate
+else
+    echo "${C_ERROR}ERROR: Klipper python environment not found.${C_OFF}" >&2
+    exit 1
 fi
 
 # Check for python 3.x
 if command -v python >/dev/null 2>&1; then
     VER=$(python -c 'import sys; print(sys.version_info[0])')
     if [ "${VER}" -lt 3 ]; then
-        echo "${C_ERROR}ERROR: Python 3 is required to run Happy-Hare 4.x.${C_OFF}" >&2
+        echo "${C_ERROR}ERROR: Python 3 is required to run Happy-Hare. Please upgrade to Python 3.x or later.${C_OFF}" >&2
         exit 1
     fi
 else
-    echo "${C_ERROR}ERROR: Python not found. Please source environment to use for Happy-Hare 4.x.${C_OFF}" >&2
+    echo "${C_ERROR}ERROR: Klipper python not found. Please source correct Klipper python environment to use for Happy-Hare.${C_OFF}" >&2
     exit 1
 fi
 
@@ -271,9 +278,8 @@ fi
 #####################
 
 if [ "${F_UNINSTALL}" ]; then
-    echo "${C_WARNING}This will uninstall and cleanup prior config${C_OFF}"
-    echo
-    if prompt_yn "Are you sure"; then
+    echo "\n${C_WARNING}This will uninstall Happy Hare and cleanup prior config${C_OFF}"
+    if prompt_yn "Are you sure you want to continue?"; then
         echo
         exit 0
     fi

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -1,2 +1,4 @@
 jinja2
 dill
+pycryptodome
+cbor2


### PR DESCRIPTION

[mmu_testing_FW_retract.log](https://github.com/user-attachments/files/30371540/mmu_testing_FW_retract.log)
[mmu_testing_retract.log](https://github.com/user-attachments/files/30371541/mmu_testing_retract.log)
[Retraction Test_FW_PROCESSED_ABS_0.5_11m41s.gcode.txt](https://github.com/user-attachments/files/30369664/Retraction.Test_FW_PROCESSED_ABS_0.5_11m41s.gcode.txt)
[Retraction Test_PROCESSED_ABS_0.5_11m41s.gcode.txt](https://github.com/user-attachments/files/30369665/Retraction.Test_PROCESSED_ABS_0.5_11m41s.gcode.txt)
Add 3 new arguments to `MMU_CHANGE_TOOL` and corresponding `mmu.printer` variables to capture slicer‑managed purge and software/firmware retraction settings to optimise purge workflow and ensure happy-hare reflects slicer retraction expectations before returning control to minimise blobs. Orca/SS/Prusa slicers wrap tool change commands with retraction/unretraction or G10/G11 if FW enabled. This handles this by retracting or issuing G10 after `_mmu_post_load` macro has been called in print before handing control back to gcode.  The slicer provided purge volume is also captured and noop `MMU_CHANGE_TOOL RESET_SLICER_PURGE=1` option provided to clear the cached setting to prevent reuse.  

Enabled by updating slicer change gcode template (orca example): `T[next_extruder] SLICER_PURGE=[flush_length] SLICER_RETRACTION={old_retract_length} SLICER_FW_RETRACTION={use_firmware_retraction}`. This will be expanded into `MMU_CHANGE_TOOL TOOL=3 SLICER_PURGE=89.4074 SLICER_RETRACTION=0.4 SLICER_FW_RETRACTION=false NEXT_POS="60.043,60.231" ; T3`.   

New `MMU_CHANGE_TOOL` arguments:
```
// MMU_CHANGE_TOOL : Perform a tool swap (called from Tx command)
// └ RESET_SLICER_PURGE   = [0|1]            (clear stored slicer purge length and exit)
// └ SLICER_PURGE         = #(mm)            (optional; slicer purge length)
// └ SLICER_RETRACTION    = #(mm)            (optional; slicer retraction length)
// └ SLICER_FW_RETRACTION = true|false|0|1   (optional; whether slicer enables firmware retraction. Ignored if not enabled in printer)
```

Debug messages to look for
```
DEBUG: Retracting to match slicer retraction -0.40mm
DEBUG: Retracting to match slicer firmware retraction (G10)
```
**Updated** Refactored debug message for both use cases. Now using retract distance for FW rather than emitting G10
```
DEBUG: Retracting 0.4mm to match unhandled slicer retraction
```
Abridged (edited) gcode files showing slicer retraction wrapped `MMU_CHANGE_TOOL` commands (2nd toolchange) and later. `MMU.LOG` extracts showing debug messages. 