### PR TITLE
backed out the additional delay on init of the nfc readers

### DIFF
--- a/extras/mmu/unit/mmu_nfc_manager.py
+++ b/extras/mmu/unit/mmu_nfc_manager.py
@@ -90,7 +90,7 @@ class MmuNfcManager:
 
         # Shared-reader polling / debounce state
         self._poll_timer = self.reactor.register_timer(self._poll_shared_reader)
-        self._bootup_init_timer = self.reactor.register_timer(self._delayed_bootup_init)
+#        self._bootup_init_timer = self.reactor.register_timer(self._delayed_bootup_init)
         self._polling = False
         self.reinit()
 
@@ -388,21 +388,21 @@ class MmuNfcManager:
 
     def _handle_mmu_bootup(self):
         """
-        MMU bootup event. Schedule initialization after the I2C bus settles.
+        Delayed event fired once after MMU bootup. Initialize every reader we
+        control and arm shared-reader polling.
         """
         num_readers = (1 if self.shared_reader is not None else 0) + sum(1 for r in self.gate_readers if r is not None)
-        self.mmu.log_debug("NFC: bootup on %s - scheduling %d reader(s) in %.1fs" %
-                           (self.mmu_unit.name, num_readers, NFC_INIT_DELAY))
-        self.reactor.update_timer(self._bootup_init_timer,
-                                  self.reactor.monotonic() + NFC_INIT_DELAY)
-
-
-    def _delayed_bootup_init(self, eventtime):
-        """One-shot, non-blocking NFC initialization scheduled after bootup."""
-        self.mmu.log_debug("NFC: initializing readers on %s after bootup delay" % self.mmu_unit.name)
+        self.mmu.log_debug("NFC: bootup on %s - initializing %d reader(s)" % (self.mmu_unit.name, num_readers))
         self._init_all_readers()
         self._start_polling()
-        return self.reactor.NEVER
+
+
+#    def _delayed_bootup_init(self, eventtime):
+#        """One-shot, non-blocking NFC initialization scheduled after bootup."""
+#        self.mmu.log_debug("NFC: initializing readers on %s after bootup delay" % self.mmu_unit.name)
+#        self._init_all_readers()
+#        self._start_polling()
+#        return self.reactor.NEVER
 
 
     def _handle_printing(self, print_time):

--- a/extras/mmu/unit/mmu_nfc_manager.py
+++ b/extras/mmu/unit/mmu_nfc_manager.py
@@ -397,14 +397,6 @@ class MmuNfcManager:
         self._start_polling()
 
 
-#    def _delayed_bootup_init(self, eventtime):
-#        """One-shot, non-blocking NFC initialization scheduled after bootup."""
-#        self.mmu.log_debug("NFC: initializing readers on %s after bootup delay" % self.mmu_unit.name)
-#        self._init_all_readers()
-#        self._start_polling()
-#        return self.reactor.NEVER
-
-
     def _handle_printing(self, print_time):
         """
         Deactivate all readers while actively printing so no NFC transaction runs


### PR DESCRIPTION
## Summary

Removes the extra 2s delay before NFC reader initialization at bootup.

`_handle_mmu_bootup` wasn't initializing readers directly — it armed a one-shot timer to
do it `NFC_INIT_DELAY` (2.0s) later. That was added on the assumption readers were coming
up before the I2C bus had settled. But `mmu:bootup` already fires well after
`klippy:connect`, so this was a second delay stacked on an event that was late enough on
its own. Readers now initialize directly in the bootup handler.

Init on `klippy:connect` stays deprecated — this only removes the extra hop after
`mmu:bootup`, it doesn't reinstate the early path.

## Testing

5-gate unit, per-gate PN532 readers over CAN, `nfc_deep_read` enabled. All five readers
initialize reliably across repeated restarts without the wait, and shared-reader polling
arms correctly.

## Notes

`NFC_INIT_DELAY` and the `_bootup_init_timer` registration are left in place (the latter
commented out) so the delayed init is easy to restore if the wait turns out to matter on
other hardware. Happy to strip both if you'd rather it landed clean.
