### PR TITLE
save_variables: keep writes off the ready dispatch and never lose one

### DIFF
--- a/extras/mmu/mmu.py
+++ b/extras/mmu/mmu.py
@@ -30,7 +30,7 @@ from .mmu_shared                import *
 from .mmu_logger                import MmuLogger
 from .mmu_selector              import *
 from .mmu_test                  import MmuTest
-from .mmu_utils                 import DebugStepperMovement, PurgeVolCalculator
+from .mmu_utils                 import DebugStepperMovement, PurgeVolCalculator, SaveVariableJournal
 from .mmu_sensor_manager        import MmuSensorManager
 from .mmu_led_manager           import MmuLedManager
 from .mmu_sync_feedback_manager import MmuSyncFeedbackManager
@@ -159,6 +159,10 @@ class Mmu:
     FILAMENT_DRIVE_STATE   = 1
     FILAMENT_HOLD_STATE    = 2
 
+    # save_variable write behavior
+    VARS_FLUSH_ATTEMPTS               = 3     # Write retries when an update raced with the write
+    VARS_FLUSH_RETRY_DELAY            = 0.05  # Re-check interval while a command holds the gcode mutex
+
     # mmu_vars.cfg variables
     VARS_MMU_REVISION                 = "mmu__revision"
     VARS_MMU_CALIB_CLOG_LENGTH        = "mmu_calibration_clog_length"
@@ -265,6 +269,9 @@ class Mmu:
         self._next_gate = None
         self.toolchange_retract = 0.          # Set from mmu_macro_vars
         self._can_write_variables = False
+        self._var_journal = None              # Unpersisted save_variable updates. Setup on connect
+        self._var_flush_timer = None          # Non-None while a coalesced write is outstanding
+        self._writing_variables = False       # Guards against overlapping writes
         self.toolchange_purge_volume = 0.
         self.mmu_logger = None                # Setup on connect
         self._standalone_sync = False         # Used to indicate synced extruder intention whilst out of print
@@ -799,6 +806,10 @@ class Mmu:
         if not self.save_variables or (rd_var is None and revision_var is None):
             raise self.config.error("Calibration settings file (mmu_vars.cfg) not found. Check [save_variables] section in mmu_macro_vars.cfg\nAlso ensure you only have a single [save_variables] section defined in your printer config and it contains the line: mmu__revision = 0. If not, add this line and restart")
 
+        # Must exist before anything calls save_variable(), i.e. before the upgrade block
+        # below and before the managers connect
+        self._var_journal = SaveVariableJournal(self.save_variables)
+
         # Create autotune manager to oversee calibration updates based on available telemetry
         self.calibration_manager = MmuCalibrationManager(self)
 
@@ -807,10 +818,10 @@ class Mmu:
         if bowden_length:
             self.log_debug("Upgrading %s variable" % (self.VARS_MMU_CALIB_BOWDEN_LENGTH))
             bowden_lengths = self._ensure_list_size([round(bowden_length, 1)], self.num_gates)
-            self.save_variables.allVariables.pop(self.VARS_MMU_CALIB_BOWDEN_LENGTH, None)
+            self.delete_variable(self.VARS_MMU_CALIB_BOWDEN_LENGTH)
             # Can't write file now so we let this occur naturally on next write
-            self.save_variables.allVariables[self.VARS_MMU_CALIB_BOWDEN_LENGTHS] = bowden_lengths
-            self.save_variables.allVariables[self.VARS_MMU_CALIB_BOWDEN_HOME] = self.gate_homing_endstop
+            self.save_variable(self.VARS_MMU_CALIB_BOWDEN_LENGTHS, bowden_lengths)
+            self.save_variable(self.VARS_MMU_CALIB_BOWDEN_HOME, self.gate_homing_endstop)
 
         rotation_distance = self.save_variables.allVariables.get(self.VARS_MMU_GEAR_ROTATION_DISTANCE, None)
         if rotation_distance:
@@ -819,12 +830,12 @@ class Mmu:
             for i in range(self.num_gates):
                 ratio = self.save_variables.allVariables.get("%s%d" % (self.VARS_MMU_CALIB_PREFIX, i), 0)
                 rotation_distances.append(round(rotation_distance * ratio, 4))
-                self.save_variables.allVariables.pop("%s%d" % (self.VARS_MMU_CALIB_PREFIX, i), None)
-            self.save_variables.allVariables.pop(self.VARS_MMU_GEAR_ROTATION_DISTANCE, None)
+                self.delete_variable("%s%d" % (self.VARS_MMU_CALIB_PREFIX, i))
+            self.delete_variable(self.VARS_MMU_GEAR_ROTATION_DISTANCE)
             # Can't write file now so we let this occur naturally on next write
-            self.save_variables.allVariables[self.VARS_MMU_GEAR_ROTATION_DISTANCES] = rotation_distances
+            self.save_variable(self.VARS_MMU_GEAR_ROTATION_DISTANCES, rotation_distances)
         else:
-            self.save_variables.allVariables.pop("%s0" % self.VARS_MMU_CALIB_PREFIX, None)
+            self.delete_variable("%s0" % self.VARS_MMU_CALIB_PREFIX)
 
         # Load bowden length configuration (calibration set with MMU_CALIBRATE_BOWDEN) ----------------------
         self.bowden_lengths = self.save_variables.allVariables.get(self.VARS_MMU_CALIB_BOWDEN_LENGTHS, None)
@@ -852,8 +863,8 @@ class Mmu:
         else:
             self.bowden_lengths = [0] * self.num_gates
             self.calibration_status |= self.CALIBRATED_BOWDENS
-        self.save_variables.allVariables[self.VARS_MMU_CALIB_BOWDEN_LENGTHS] = self.bowden_lengths
-        self.save_variables.allVariables[self.VARS_MMU_CALIB_BOWDEN_HOME] = bowden_home
+        self.save_variable(self.VARS_MMU_CALIB_BOWDEN_LENGTHS, self.bowden_lengths)
+        self.save_variable(self.VARS_MMU_CALIB_BOWDEN_HOME, bowden_home)
 
         # Load gear rotation distance configuration (calibration set with MMU_CALIBRATE_GEAR) ---------------
         self.default_rotation_distance = self.gear_rail.steppers[0].get_rotation_distance()[0] # TODO Should probably be per gear in case they are disimilar?
@@ -878,7 +889,7 @@ class Mmu:
         else:
             self.log_warning("Warning: Gear rotation distances not found in mmu_vars.cfg. Probably not calibrated yet")
             self.rotation_distances = [-1] * self.num_gates
-        self.save_variables.allVariables[self.VARS_MMU_GEAR_ROTATION_DISTANCES] = self.rotation_distances
+        self.save_variable(self.VARS_MMU_GEAR_ROTATION_DISTANCES, self.rotation_distances)
 
         # Load encoder configuration (calibration set with MMU_CALIBRATE_ENCODER) ---------------------------
         self.encoder_resolution = 1.0
@@ -926,13 +937,36 @@ class Mmu:
     def handle_disconnect(self):
         self.log_debug('Klipper disconnected!')
 
+        # Last chance to persist, since writes are deferred. Ignores _can_write_variables on
+        # purpose: it means "not yet", but there is no later write, and a suspended batch is
+        # the largest thing we could drop. Best-effort - the reactor has stopped, so a pause
+        # here cannot complete.
+        if self._var_journal and self._var_journal.pending:
+            try:
+                self._can_write_variables = True
+                self._write_variables_now()
+            except Exception:
+                logging.exception("MMU: Unable to flush save_variables on disconnect")
+
         # Sub components
         for m in self.managers:
             if hasattr(m, 'handle_disconnect'):
                 m.handle_disconnect()
 
-    def handle_ready(self):
+    # Enabling writes is deferred to a reactor callback rather than done here.
+    #
+    # Klipper forbids pausing inside its ready handler loop, and SAVE_VARIABLE pauses, so a
+    # write from anywhere in this handler raises "Internal error - reactor pause disabled".
+    # Deferring the FLAG (not just the write) makes that structurally impossible: everything
+    # below stages into the journal and lands in one write once we are clear of the dispatch.
+    def _handle_ready_flush_variables(self, eventtime):
+        if self.printer.is_shutdown():
+            return # A later ready handler failed; gcode is dead
         self._can_write_variables = True
+        self._write_variables_now() # Already on the reactor, so write directly
+
+    def handle_ready(self):
+        self.reactor.register_callback(self._handle_ready_flush_variables)
 
         # Pull retraction length from macro config
         sequence_vars_macro = self.printer.lookup_object("gcode_macro _MMU_SEQUENCE_VARS", None)
@@ -3886,21 +3920,68 @@ class Mmu:
         self._set_print_state("standby")
         self.log_always("MMU disabled")
 
-    # Wrapper so we can minimize actual disk writes and batch updates
+    # Wrapper so we can minimize actual disk writes and batch updates.
+    #
+    # Every update is journalled, because SAVE_VARIABLE pauses mid-command and then replaces
+    # klipper's variable dict with a re-read of the file - so anything set during the pause is
+    # silently discarded. See SaveVariableJournal in mmu_utils.py.
     def save_variable(self, variable, value, write=False):
-        self.save_variables.allVariables[variable] = value
+        self.save_variables.allVariables[variable] = self._var_journal.record(variable, value)
         if write:
             self.write_variables()
 
     def delete_variable(self, variable, write=False):
+        self._var_journal.record_delete(variable)
         _ = self.save_variables.allVariables.pop(variable, None)
         if write:
             self.write_variables()
 
+    # Request a write. The disk write itself happens on a reactor timer, so several requests
+    # in the same pass collapse into one, and it never runs inline where SAVE_VARIABLE's pause
+    # would be illegal (klippy:ready) or would need a gcode mutex we may not hold.
     def write_variables(self):
-        if self._can_write_variables:
-            mmu_vars_revision = self.save_variables.allVariables.get(self.VARS_MMU_REVISION, 0) + 1
-            self.gcode.run_script_from_command("SAVE_VARIABLE VARIABLE=%s VALUE=%d" % (self.VARS_MMU_REVISION, mmu_vars_revision))
+        if not self._can_write_variables or self._var_flush_timer is not None:
+            return
+        self._var_flush_timer = self.reactor.register_timer(self._flush_variables, self.reactor.NOW)
+
+    # Retries rather than blocking when a command holds the gcode mutex: run_script would park
+    # this callback mid-flight for the length of that command, and a state save has no deadline.
+    def _flush_variables(self, eventtime):
+        if self._can_write_variables and not self.printer.is_shutdown():
+            if self.gcode.get_mutex().test():
+                return eventtime + self.VARS_FLUSH_RETRY_DELAY # Leave the timer armed
+            try:
+                self._write_variables_now()
+            except Exception:
+                # A failed save must not take the printer down, nor strand the timer handle,
+                # which would stop all future writes. Nothing is lost - the journal keeps
+                # every unconfirmed update for the next attempt.
+                logging.exception("MMU: Error flushing save_variables")
+        self.reactor.unregister_timer(self._var_flush_timer)
+        self._var_flush_timer = None
+        return self.reactor.NEVER
+
+    # Persist by bumping the revision, which rewrites the whole file. Retries only when the
+    # mutation counter shows something was set while we were paused; retrying on any mismatch
+    # would treble every write for a value klipper cannot round-trip.
+    def _write_variables_now(self):
+        if self._writing_variables:
+            return # Re-entrant request; the loop below will pick the new updates up
+        self._writing_variables = True
+        try:
+            for _ in range(self.VARS_FLUSH_ATTEMPTS):
+                self._var_journal.apply()
+                mutations = self._var_journal.mutations
+                mmu_vars_revision = self.save_variables.allVariables.get(self.VARS_MMU_REVISION, 0) + 1
+                self.gcode.run_script("SAVE_VARIABLE VARIABLE=%s VALUE=%d" % (self.VARS_MMU_REVISION, mmu_vars_revision))
+                self._var_journal.reconcile()
+                if not self._var_journal.pending or mutations == self._var_journal.mutations:
+                    break # Nothing left, or nothing raced with us so retrying is futile
+            if self._var_journal.pending:
+                logging.info("MMU: %d save_variable(s) not confirmed on disk after %d attempt(s): %s"
+                             % (len(self._var_journal.pending), self.VARS_FLUSH_ATTEMPTS, sorted(self._var_journal.pending)))
+        finally:
+            self._writing_variables = False
 
     @contextlib.contextmanager
     def _wrap_suspendwrite_variables(self):

--- a/extras/mmu/mmu_selector.py
+++ b/extras/mmu/mmu_selector.py
@@ -320,14 +320,14 @@ class LinearSelector(BaseSelector, object):
         else:
             self.mmu.log_always("Warning: Selector offsets not found in mmu_vars.cfg. Probably not calibrated")
             self.selector_offsets = [-1] * self.mmu.num_gates
-        self.mmu.save_variables.allVariables[self.VARS_MMU_SELECTOR_OFFSETS] = self.selector_offsets
+        self.mmu.save_variable(self.VARS_MMU_SELECTOR_OFFSETS, self.selector_offsets)
 
         self.bypass_offset = self.mmu.save_variables.allVariables.get(self.VARS_MMU_SELECTOR_BYPASS, -1)
         if self.bypass_offset > 0:
             self.mmu.log_debug("Loaded saved bypass offset: %s" % self.bypass_offset)
         else:
             self.bypass_offset = -1 # Ensure -1 value for uncalibrated / non-existent
-        self.mmu.save_variables.allVariables[self.VARS_MMU_SELECTOR_BYPASS] = self.bypass_offset
+        self.mmu.save_variable(self.VARS_MMU_SELECTOR_BYPASS, self.bypass_offset)
 
         # See if we have a TMC controller setup with stallguard
         self.selector_tmc = None
@@ -1241,7 +1241,7 @@ class RotarySelector(BaseSelector, object):
         else:
             self.mmu.log_always("Warning: Selector offsets not found in mmu_vars.cfg. Probably not calibrated")
             self.selector_offsets = [-1] * self.mmu.num_gates
-        self.mmu.save_variables.allVariables[self.VARS_MMU_SELECTOR_OFFSETS] = self.selector_offsets
+        self.mmu.save_variable(self.VARS_MMU_SELECTOR_OFFSETS, self.selector_offsets)
 
     def _ensure_list_size(self, lst, size, default_value=-1):
         lst = lst[:size]

--- a/extras/mmu/mmu_utils.py
+++ b/extras/mmu/mmu_utils.py
@@ -1,6 +1,9 @@
 # Happy Hare MMU Software
 # Utility classes for Happy Hare MMU
 #
+# SaveVariableJournal
+# Goal: Ensure no save_variable update can be lost to a klipper reload
+#
 # DebugStepperMovement
 # Goal: Internal testing class for debugging synced movement
 #
@@ -16,7 +19,69 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 #
-import math
+import copy, math
+
+
+DELETED = object() # Journal sentinel: "this key must not exist on disk"
+
+
+# Tracks save_variable updates that are not yet known to be on disk.
+#
+# SAVE_VARIABLE snapshots klipper's variable dict up front, then pauses, then replaces the
+# dict with a re-read of the file. Anything set mid-command misses the snapshot and is then
+# erased by the re-read - silently, and from memory as well as disk. Any SAVE_VARIABLE opens
+# that window, including ones issued by macros we do not control.
+#
+# So an entry is removed from the journal ONLY once a post-write re-read has proved it
+# reached disk. Nothing else clears it, which means a lost update is simply written again by
+# the next flush.
+class SaveVariableJournal:
+    def __init__(self, save_variables):
+        self.save_variables = save_variables
+        self.pending = {}   # key -> value, or DELETED
+        self.mutations = 0  # Bumped on every change; lets a flush spot a write it raced with
+
+    # Copy containers, pass scalars through. Callers hand us live objects they keep mutating,
+    # so we must own a private copy or we cannot tell a dropped write from a later edit.
+    # No 'set': klipper cannot round-trip one, repr() gives "set()" which won't parse back.
+    @staticmethod
+    def snapshot(value):
+        if isinstance(value, (list, dict, tuple)):
+            return copy.deepcopy(value)
+        return value
+
+    def record(self, key, value):
+        value = self.snapshot(value)
+        self.pending[key] = value
+        self.mutations += 1
+        return value
+
+    def record_delete(self, key):
+        self.pending[key] = DELETED
+        self.mutations += 1
+
+    # Push unpersisted updates into klipper's dict. Gets them into the next SAVE_VARIABLE
+    # snapshot, and repairs the dict after any re-read has replaced it.
+    def apply(self):
+        all_variables = self.save_variables.allVariables
+        for key, value in self.pending.items():
+            if value is DELETED:
+                all_variables.pop(key, None)
+            else:
+                all_variables[key] = value
+
+    # Drop entries the post-write re-read proves are on disk. SAVE_VARIABLE ends by re-reading
+    # the file, so klipper's dict now IS the file contents - this verifies the write rather
+    # than assuming it. Anything left over is re-applied so it is not lost from memory either.
+    def reconcile(self):
+        all_variables = self.save_variables.allVariables
+        for key, value in list(self.pending.items()):
+            if value is DELETED:
+                if key not in all_variables:
+                    del self.pending[key]
+            elif key in all_variables and all_variables[key] == value:
+                del self.pending[key]
+        self.apply()
 
 
 # Internal testing class for debugging synced movement

--- a/test/test_mmu_journal.py
+++ b/test/test_mmu_journal.py
@@ -1,0 +1,140 @@
+# Happy Hare MMU Software
+# Tests for SaveVariableJournal (extras/mmu/mmu_utils.py)
+#
+# Klipper's SAVE_VARIABLE snapshots its variable dict and renders every repr() BEFORE it
+# writes, then discards the live dict and re-reads the file. Anything set in between is
+# missing from the snapshot and is then erased by the re-read - from disk and from memory,
+# with no error. The journal exists so that cannot lose an update.
+#
+# mmu_utils.py is loaded by path because extras/ is a klipper extras directory, not an
+# importable package. It only imports copy+math, so it loads fine standalone - which is the
+# whole reason the journal lives there rather than in mmu.py.
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+#
+import importlib.util
+import os
+import unittest
+
+_PATH = os.path.join(os.path.dirname(__file__), '..', 'extras', 'mmu', 'mmu_utils.py')
+_spec = importlib.util.spec_from_file_location('mmu_utils_under_test', _PATH)
+mmu_utils = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mmu_utils)
+
+
+class FakeSaveVariables:
+    """Just the one attribute Happy Hare touches, plus a way to fake klipper's re-read."""
+
+    def __init__(self, initial=None):
+        self.allVariables = dict(initial or {})
+
+    def reload_as(self, on_disk):
+        """What loadVariables() does: replace the dict wholesale with the file contents."""
+        self.allVariables = dict(on_disk)
+
+
+class TestSaveVariableJournal(unittest.TestCase):
+
+    def setUp(self):
+        self.sv = FakeSaveVariables({'mmu__revision': 1})
+        self.journal = mmu_utils.SaveVariableJournal(self.sv)
+
+    # -- the core invariant ----------------------------------------------------------
+
+    def test_entry_is_dropped_once_it_is_seen_on_disk(self):
+        self.journal.record('mmu_a', 1)
+        self.journal.apply()
+        self.sv.reload_as({'mmu__revision': 2, 'mmu_a': 1})  # the write landed
+        self.journal.reconcile()
+        self.assertEqual(self.journal.pending, {})
+
+    def test_entry_the_reload_dropped_is_kept_and_reapplied(self):
+        """The whole point: a value that missed the snapshot survives in the journal."""
+        self.journal.record('mmu_lost', 42)
+        self.journal.apply()
+        self.sv.reload_as({'mmu__revision': 2})             # 'mmu_lost' never made it
+        self.journal.reconcile()
+        self.assertEqual(self.journal.pending, {'mmu_lost': 42})
+        self.assertEqual(self.sv.allVariables['mmu_lost'], 42, 'not restored to memory')
+
+    def test_a_stale_value_on_disk_does_not_count_as_persisted(self):
+        self.journal.record('mmu_a', 'new')
+        self.sv.reload_as({'mmu_a': 'old'})
+        self.journal.reconcile()
+        self.assertEqual(self.journal.pending, {'mmu_a': 'new'})
+
+    # -- deletes ---------------------------------------------------------------------
+
+    def test_delete_is_dropped_once_the_key_is_gone_from_disk(self):
+        self.journal.record_delete('mmu_gone')
+        self.journal.apply()
+        self.sv.reload_as({'mmu__revision': 2})
+        self.journal.reconcile()
+        self.assertEqual(self.journal.pending, {})
+
+    def test_delete_is_retried_if_the_key_came_back(self):
+        self.journal.record_delete('mmu_gone')
+        self.journal.apply()
+        self.assertNotIn('mmu_gone', self.sv.allVariables)
+        self.sv.reload_as({'mmu_gone': 'resurrected'})       # the delete missed the snapshot
+        self.journal.reconcile()
+        self.assertEqual(self.journal.pending, {'mmu_gone': mmu_utils.DELETED})
+        self.assertNotIn('mmu_gone', self.sv.allVariables, 'not re-removed from memory')
+
+    # -- snapshotting ----------------------------------------------------------------
+
+    def test_journal_is_not_disturbed_by_later_mutation_of_the_callers_object(self):
+        """
+        Callers pass live objects (gate maps, stats) and keep mutating them. Without a
+        private copy the journal could never tell a dropped write from a later edit.
+        """
+        live = [1, 2, 3]
+        self.journal.record('mmu_list', live)
+        live.append(4)
+        self.assertEqual(self.journal.pending['mmu_list'], [1, 2, 3])
+
+        self.sv.reload_as({'mmu_list': [1, 2, 3]})           # what was actually written
+        self.journal.reconcile()
+        self.assertEqual(self.journal.pending, {}, 'should have reconciled against the copy')
+
+    def test_nested_containers_are_deep_copied(self):
+        live = {'gates': [{'id': 0}]}
+        self.journal.record('mmu_nested', live)
+        live['gates'][0]['id'] = 99
+        self.assertEqual(self.journal.pending['mmu_nested'], {'gates': [{'id': 0}]})
+
+    def test_scalars_pass_straight_through(self):
+        for value in (1, 2.5, 'text', None, True):
+            self.assertIs(mmu_utils.SaveVariableJournal.snapshot(value), value)
+
+    def test_sets_are_not_treated_as_containers(self):
+        """
+        Deliberate: repr(set()) is "set()", which ast.literal_eval rejects, so klipper
+        cannot round-trip one. Copying it here would imply support that does not exist.
+        """
+        value = {1, 2}
+        self.assertIs(mmu_utils.SaveVariableJournal.snapshot(value), value)
+
+    # -- the race detector -----------------------------------------------------------
+
+    def test_mutations_counter_moves_on_every_change(self):
+        start = self.journal.mutations
+        self.journal.record('mmu_a', 1)
+        self.journal.record_delete('mmu_b')
+        self.assertEqual(self.journal.mutations, start + 2)
+
+    # -- apply() ---------------------------------------------------------------------
+
+    def test_apply_repairs_a_dict_a_foreign_reload_replaced(self):
+        self.journal.record('mmu_a', 1)
+        self.journal.record_delete('mmu_b')
+        self.sv.reload_as({'blobifier': 'someone elses write', 'mmu_b': 'stale'})
+        self.journal.apply()
+        self.assertEqual(self.sv.allVariables['mmu_a'], 1)
+        self.assertNotIn('mmu_b', self.sv.allVariables)
+        self.assertEqual(self.sv.allVariables['blobifier'], 'someone elses write',
+                         'must not disturb keys we do not own')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Why

Klipper's `SAVE_VARIABLE` now performs threaded io (`aio_executor`), so it **pauses the calling greenlet twice** — once for the write, once for the re-read that follows it. Two bugs fall out of that, and users are hitting the first one at startup:

```
Unable to save variable
...
reactor.ReactorError: Internal error - reactor pause disabled
Unhandled exception during ready callback
```

**Startup crash.** `handle_ready` enabled writes as its very first statement and then ran ~60 lines — `_load_persisted_state`, every sub-manager's `handle_ready`, selector setup. Any write reached from there issues `SAVE_VARIABLE` inside Klipper's `klippy:ready` dispatch, which runs inside `reactor.assert_no_pause()`. Klipper's bare `except:` swallows the `ReactorError` and re-raises `Unable to save variable`, which is why the real cause only shows up in the traceback.

**Lost writes.** `cmd_SAVE_VARIABLE` snapshots `dict(allVariables)` and renders every `repr()` *before* writing, then discards the live dict and re-reads the file. Anything set during either pause misses the snapshot and is then erased by the re-read — from disk **and** from memory, with no error. The pause doesn't have to be ours: any `SAVE_VARIABLE` opens the window, including the one `config/addons/blobifier.cfg` issues.

## What changed

- **`handle_ready` defers enabling writes** to a reactor callback. Moving the *flag* rather than just the write is the point — it makes it structurally impossible for anything in that long handler to write. Everything stages into the journal and lands in one write once clear of the dispatch.
- **New `SaveVariableJournal`** (`mmu_utils.py`). Every `save_variable`/`delete_variable` is recorded and dropped **only once a post-write re-read proves it reached disk**. Nothing else clears it, so a lost update is simply written again by the next flush.
- **Writes move to a coalescing reactor timer.** No caller has to know whether it holds the gcode mutex, and bursts collapse into one file write. The timer retries rather than blocking when a command holds the mutex — parking a reactor callback mid-flight buys nothing and a state save has no deadline.
- **`klippy:disconnect` flush** closes the resulting set-to-disk window. It deliberately ignores `_can_write_variables`: that flag means "not yet", but at disconnect there is no later write, and a `_wrap_suspendwrite_variables` batch is the largest thing that could be dropped.
- **The 16 direct `allVariables` mutations** now go through the wrapper, so the journal can't be bypassed by a later edit in those paths. Only the `mmu__revision` seed stays direct (it feeds the sanity check immediately below it).

## Reviewer notes

**Old Klipper is unaffected.** Every API used predates 2020 — `register_callback` (2018-06), `run_script` (2018-01), `is_shutdown` (2020-04), `get_mutex` (present in both generations). Pre-`aio_executor` Klipper never pauses, so the journal is inert there: exactly one write attempt, always.

**Where the journal lives is deliberate.** `mmu_utils.py` imports only `copy` and `math`, so it loads standalone and the subtle logic — reconciliation, delete semantics, snapshot isolation — is unit-testable without Klipper. `mmu.py` can't be imported outside Klipper, which is why the core was extracted rather than written inline.

**Deep-copied snapshots.** Callers pass live objects they keep mutating (gate maps, stats). Klipper renders `repr()` *before* pausing, so if the journal held those references it could never distinguish "the write dropped this" from "the caller changed it again". `set` is deliberately excluded — `repr(set())` is `"set()"`, which `ast.literal_eval` rejects, so Klipper cannot round-trip one.

**Retry is gated on a mutation counter**, not on a reconcile mismatch. Retrying on any mismatch would be a write-amplification trap: a value Klipper can't round-trip would mismatch forever and treble every flush.

### One behaviour change

`mmu_selector.py:701` and `mmu_calibration_manager.py:86,106` log "...has been saved" immediately after requesting a write. The disk write now lands a reactor pass later, so the message very briefly precedes the file changing. Left alone — milliseconds, and the disconnect flush guarantees durability.

## Testing

11 new unit tests for the journal, all passing (`python3 -m unittest test.test_mmu_journal`). All touched files compile.

> Note: `python3 -m unittest` reports 9 errors from the pre-existing `test_mmu_server.py`, which needs Moonraker's `components.file_manager`. Those fail identically on `main` and are unrelated.

**Not verified on hardware, and the gap is worth knowing about.** This repo has no Klipper test harness, so only the journal logic is actually exercised. The reactor wiring around it — deferred ready flush, the timer, the mutex retry, the disconnect flush — is compile-checked and reviewed by eye only. The equivalent v4 change was developed against a fake-Klipper harness, which caught three real mistakes that nothing here would have caught. Suggested before merge:

- Boot on modern Klipper: no `reactor pause disabled` / `Unable to save variable` in `klippy.log`, one `mmu__revision` bump at startup
- Boot on pre-`aio_executor` Klipper: behaviour unchanged
- Calibration round-trip + restart — exercises the selector paths whose mutations were rerouted

🤖 Generated with [Claude Code](https://claude.com/claude-code)