### PR TITLE
Added nfc custom setup to VVD config

### DIFF
--- a/installer/Kconfig.nfc_reader
+++ b/installer/Kconfig.nfc_reader
@@ -75,6 +75,11 @@ if !UNSELECT_MMU_HAS_NFC_READER
 endif
 
 
+# Define type now so it can be explicitly selected
+config MMU_HAS_PER_GATE_NFC_READERS
+  def_bool n
+
+
 # ------------------------------------
 # NFC reader config
 # ------------------------------------
@@ -327,8 +332,7 @@ if MMU_HAS_NFC_READER && ! CUSTOM_NFC_READER_SETUP
     # --------------------------------------
 
     config MMU_HAS_PER_GATE_NFC_READERS
-      bool "Per-gate NFC readers?"
-      default n
+      prompt "Per-gate NFC readers?"
       help
         Most designs will only have a single NFC reader that allows presenting
         filament prior to preload. However, some designs have a reader built

--- a/installer/boards/custom/Kconfig.vvd
+++ b/installer/boards/custom/Kconfig.vvd
@@ -54,33 +54,6 @@ if BOARD_TYPE_VVD_1_0
   config PIN_ENTRY_SENSOR_3
     default "$(MCU_NAME):PA3"
 
-  # NFC/RFID readers (RC522 over SPI). Only gates 0 and 2 have a reader header, so
-  # gates 1 and 3 are off by default.
-  #
-  # All readers share SPI2 remapped to PB2/PB11/PB10. That is the only G0B1 SPI
-  # mapping whose pins are free on this board: spi1 (PA6/PA7/PA5) collides with the
-  # AHT3X environment sensors and spi1a (PB4/PB5/PB3) with the gear and selector
-  # drivers. Each reader still needs its own cs_pin.
-  #
-  # These only decide what you get once NFC is enabled - the ViViD does not ship
-  # with readers fitted, so MMU_HAS_NFC_READER is deliberately left off.
-  config MMU_HAS_PER_GATE_NFC_READERS
-    default y
-
-  config PARAM_NFC_READER_GATE_1
-    default n
-  config PARAM_NFC_READER_GATE_3
-    default n
-
-  config PARAM_NFC_READER_CS_PIN_0
-    default "$(MCU_NAME):PB14"
-  config PARAM_NFC_READER_SPI_BUS_0
-    default "spi2_PB2_PB11_PB10"
-
-  config PARAM_NFC_READER_CS_PIN_2
-    default "$(MCU_NAME):PA8"
-  config PARAM_NFC_READER_SPI_BUS_2
-    default "spi2_PB2_PB11_PB10"
 
   config PARAM_MISC_HARDWARE
     default "$(ml,\
@@ -142,6 +115,22 @@ stepper: mmu_stepper $(UNIT_NAME)_selector$(comma) mmu_stepper $(UNIT_NAME)_gear
 sensor_pin: $(MCU_NAME):PA4\n\
 sensor_type: Generic 3950\n\
 pullup_resistor: 2200\n\
+\n\
+# NFC reader gates 0/1\n\
+[mmu_nfc_reader unit1_nfc01]\n\
+reader_type           : rc522\n\
+cs_pin                : $(MCU_NAME):PB14\n\
+spi_bus               : spi2_PB2_PB11_PB10\n\
+spi_speed             : 1000000\n\
+debug                 : n\n\
+\n\
+# NFC reader gates 2/3\n\
+[mmu_nfc_reader unit1_nfc23]\n\
+reader_type           : rc522\n\
+cs_pin                : $(MCU_NAME):PA8\n\
+spi_bus               : spi2_PB2_PB11_PB10\n\
+spi_speed             : 1000000\n\
+debug                 : 0\n\
 )"
 
 

--- a/installer/mmu_types/Kconfig.vvd
+++ b/installer/mmu_types/Kconfig.vvd
@@ -6,6 +6,8 @@ config MMU_TYPE_VVD_1_0
   select MMU_HAS_SENSOR_ENTRY
   select MMU_HAS_ENVIRONMENT_SENSOR
   select MMU_HAS_HEATER
+  select MMU_HAS_NFC_READER
+  select MMU_HAS_PER_GATE_NFC_READERS
   select UNSELECT_MMU_HAS_ESPOOLER        # Disable
   select UNSELECT_MMU_HAS_FILAMENT_BUFFER # Disable
 
@@ -51,6 +53,8 @@ if MMU_TYPE_VVD_1_0
   config CUSTOM_ENVIRONMENT_SENSOR_SETUP
     def_bool y
   config CUSTOM_HEATER_SETUP
+    def_bool y
+  config CUSTOM_NFC_READER_SETUP
     def_bool y
 
   if SHOW_MMU_ADDITIONS_WITH_TYPE
@@ -118,6 +122,15 @@ if MMU_TYPE_VVD_1_0
     default "$(UNIT_NAME)_heater"
   config PARAM_HEATER_MAX_TEMP
     default "75"
+
+  config PARAM_NFC_READER_0
+    default "$(UNIT_NAME)_nfc01"
+  config PARAM_NFC_READER_1
+    default "$(UNIT_NAME)_nfc01"
+  config PARAM_NFC_READER_2
+    default "$(UNIT_NAME)_nfc23"
+  config PARAM_NFC_READER_3
+    default "$(UNIT_NAME)_nfc23"
 
   comment "_"
 


### PR DESCRIPTION
## Summary
- Move the VVD board's NFC reader wiring from hardcoded defaults in `installer/boards/custom/Kconfig.vvd` into the standard `CUSTOM_NFC_READER_SETUP` mechanism (`installer/mmu_types/Kconfig.vvd`)
- Define `MMU_HAS_PER_GATE_NFC_READERS` earlier in `Kconfig.nfc_reader` so it can be explicitly selected, and switch its board-forced value from `bool`/`default` to `prompt` so custom setups can select it directly
- Adds `[mmu_nfc_reader]` sections for gates 0/1 and 2/3 directly in the VVD board macro instead of via Kconfig params

## Test plan
- [x] Run the Kconfig installer against the VVD board type and confirm NFC reader config renders correctly with no prompts for the now-forced settings