### PR TITLE
v4 NFC - PN7160 failed reads during homing - fixes

### DIFF
--- a/extras/mmu/unit/nfc/pn7160_driver.py
+++ b/extras/mmu/unit/nfc/pn7160_driver.py
@@ -33,6 +33,32 @@ NCI_RF_DISCOVER_NFCA_NFCV_CMD = [
 NCI_RF_DEACTIVATE_IDLE_CMD = [0x21, 0x06, 0x01, 0x00]
 PN7160_RF_DEACTIVATE_GUARD_TIME = 0.025
 
+# NCI discovery period (RF config parameter TOTAL_DURATION, ID 0x00). The NFCC
+# interrogates the field once per period then idles for the remainder, so this - not
+# the host probe tick - bounds how fast a MOVING tag can be caught. Never sent before,
+# which left the NXP firmware default (measured in the hundreds of ms) in force, and
+# CORE_RESET with clear-config re-wipes it on every full setup.
+#
+# Why it matters: detection is probabilistic, P(catch) ~ dwell / period. A ~15-20mm
+# readable zone at 100mm/s is 150-200ms of dwell, so a ~500ms period catches the tag
+# on roughly one pass in three - which is exactly the hit rate seen on hardware, with
+# 500mm sweeps running their full length undetected in between. At 50ms the field is
+# interrogated every 5mm at 100mm/s, comfortably inside the zone.
+#
+# Tune with the millisecond value; the frame is built from it at import time.
+PN7160_TOTAL_DURATION_MS = 50
+NCI_CORE_SET_TOTAL_DURATION_CMD = [
+    0x20, 0x02, 0x05,       # CORE_SET_CONFIG, 5 payload octets
+    0x01,                   # one parameter follows
+    0x00, 0x02,             # TOTAL_DURATION, value is 2 octets
+    PN7160_TOTAL_DURATION_MS & 0xFF,         # uint16, little-endian
+    (PN7160_TOTAL_DURATION_MS >> 8) & 0xFF,
+]
+NCI_CORE_GET_TOTAL_DURATION_CMD = [
+    0x20, 0x03, 0x02,       # CORE_GET_CONFIG, 2 payload octets
+    0x01, 0x00,             # one parameter: TOTAL_DURATION
+]
+
 NCI_GID_CORE = 0x00
 NCI_GID_RF = 0x01
 NCI_MT_DATA = 0x00
@@ -1063,6 +1089,55 @@ class PN7160Handler:
         return [rsp] + extra
 
 
+    def _log_current_total_duration(self):
+        """
+        Read back TOTAL_DURATION before overwriting it, so the firmware default is
+        recorded rather than assumed. debug >= 3 only - this costs an NCI round trip
+        and its whole value is diagnostic.
+
+        CORE_GET_CONFIG_RSP payload: status, numParams, then ID/Len/Value triples.
+        """
+        try:
+            rsp, _extra = self.command(
+                NCI_CORE_GET_TOTAL_DURATION_CMD, NCI_GID_CORE, 0x03, timeout=1.0)
+        except Exception as e:
+            self._core_info("TOTAL_DURATION read-back unavailable: %s", e)
+            return
+        # 40 03 <len> <status> <numParams> <id> <len> <lo> <hi>
+        if len(rsp) >= 9 and rsp[3] == NCI_STATUS_OK and rsp[5] == 0x00:
+            self._core_info("TOTAL_DURATION was %dms (firmware default)",
+                            rsp[7] | (rsp[8] << 8))
+        else:
+            self._core_info("TOTAL_DURATION read-back unparsed: %s", _hex(rsp))
+
+
+    def configure_total_duration(self):
+        """
+        Set the NCI discovery period (see PN7160_TOTAL_DURATION_MS).
+
+        Must run while the NFCC is IDLE - after CORE_INIT, before RF_DISCOVER - as NCI
+        does not allow configuration changes once discovery is running.
+
+        Non-fatal: a chip that rejects the parameter still reads tags, just at the old
+        default, so warn and carry on rather than failing bring-up over a tuning knob.
+        """
+        # NB: on the HANDLER 'debug' is the level and '_debug' is the log method - the
+        # reverse of PN7160Driver, where '_debug' holds the level.
+        if self.debug >= 3:
+            self._log_current_total_duration()
+        try:
+            rsp, extra = self.command(
+                NCI_CORE_SET_TOTAL_DURATION_CMD, NCI_GID_CORE, 0x02, timeout=1.0)
+        except Exception as e:
+            logger.warning("[%s pn7160] TOTAL_DURATION=%dms rejected (%s) - discovery "
+                           "stays at the firmware default, so a tag crossing the "
+                           "antenna during a move may not be caught",
+                           self._name, PN7160_TOTAL_DURATION_MS, e)
+            return []
+        self._core_info("TOTAL_DURATION set to %dms", PN7160_TOTAL_DURATION_MS)
+        return [rsp] + extra
+
+
     def start_discovery(self):
         rsp, extra = self.command(
             NCI_RF_DISCOVER_NFCA_NFCV_CMD, NCI_GID_RF, 0x03, timeout=1.0,
@@ -1269,6 +1344,7 @@ class PN7160Driver:
         # Non-blocking presence probe (homing) state
         self._probe_active = False
         self._probe_errors = 0
+        self._probe_transport_errors = 0
 
         # Advanced PN7160 tuning options are intentionally hidden from the
         # default config templates.  Users can still override them in a specific
@@ -1350,6 +1426,12 @@ class PN7160Driver:
             full = self._needs_full_setup
         if full:
             self._handler.connect_nci(reset=True, keep_config=False)
+            # Order is load-bearing: the clear-config CORE_RESET above is what wipes
+            # TOTAL_DURATION, and NCI only accepts config changes while IDLE, so this
+            # has to sit after the reset and before any RF_DISCOVER. Full setup only -
+            # probe_start()'s keep-config path is the homing critical path, and a
+            # keep-config reset preserves the value anyway.
+            self._handler.configure_total_duration()
             self._handler.configure_discovery_map()
         else:
             self._handler.connect_nci(reset=False, keep_config=True)
@@ -1403,7 +1485,13 @@ class PN7160Driver:
     # to remove. read_target() does the full discover-and-activate afterwards, once
     # the machine is stationary.
 
-    _PROBE_MAX_FRAME_ERRORS = 3  # Consecutive torn frames before a resync
+    _PROBE_MAX_FRAME_ERRORS = 3      # Consecutive torn frames before a resync
+    _PROBE_MAX_TRANSPORT_ERRORS = 5  # Consecutive Klipper/MCU comms faults before
+                                     # the reader is declared gone. Higher than the
+                                     # frame cap on purpose: a torn frame means the
+                                     # NFCC misbehaved, while these mean the host bus
+                                     # was busy, which is both likelier and more
+                                     # obviously transient during a fast move.
 
     def probe_supported(self):
         """
@@ -1446,6 +1534,7 @@ class PN7160Driver:
             self._handler.start_discovery()
             self._discovery_active = True
             self._probe_errors = 0
+            self._probe_transport_errors = 0
             self._probe_active = True
             if self._debug >= 3:
                 logger.info("[%s pn7160] probe_start took %.3fs", self._name,
@@ -1509,6 +1598,7 @@ class PN7160Driver:
                 # anything - no teardown, no restart, no not-alive.
                 return None
             self._probe_errors = 0
+            self._probe_transport_errors = 0
             if handler.is_tag_present_ntf(frame):
                 # Presence is all we need. Do NOT go on to select/activate here -
                 # that path blocks on an NCI command; read_target() does it later.
@@ -1523,13 +1613,43 @@ class PN7160Driver:
             # stream is out of step.
             return self._probe_frame_error(e)
         except Exception as e:
-            logger.warning("[%s pn7160] probe_poll failed: %s", self._name, e)
-            self._probe_active = False
-            self._alive = False
-            self._handler.initialized = False
-            self._needs_full_setup = True
-            self._clear_current_card()
-            return False
+            # A HOST-side transport fault, not a reader fault - see
+            # _probe_transport_error for why that distinction has to be made here.
+            return self._probe_transport_error(e)
+
+
+    def _probe_transport_error(self, detail):
+        """
+        Count a Klipper/MCU transport fault, which says nothing about the PN7160.
+
+        A 20ms polled tick is an I2C round trip to an MCU that, on a CAN toolhead,
+        is simultaneously carrying step data. Missing a response deadline there
+        surfaces as Klipper's "Unable to obtain 'i2c_response' response" (or a bare
+        ('i2c_response', N) tuple) and is transient by nature.
+
+        Treating one as a dead reader is what turned a single hiccup into a lost
+        scan: it set _needs_full_setup, so the caller's restart paid a VEN toggle
+        plus a complete NCI bring-up (~124ms with discovery DOWN, 12mm of travel at
+        100mm/s), and the repeated hardware resets then provoked I2C START_NACKs
+        whose recovery ran to 1.7-2.1s each. Tolerate a short run of them instead.
+
+        Escalation past the cap is unchanged - a reader that really has gone away
+        must still be marked not-alive rather than polled forever.
+        """
+        self._probe_transport_errors += 1
+        if self._probe_transport_errors < self._PROBE_MAX_TRANSPORT_ERRORS:
+            if self._debug >= 3:
+                logger.info("[%s pn7160] probe transport error %d (tolerated): %s",
+                            self._name, self._probe_transport_errors, detail)
+            return None
+        logger.warning("[%s pn7160] probe_poll failed after %d consecutive transport "
+                       "errors: %s", self._name, self._probe_transport_errors, detail)
+        self._probe_active = False
+        self._alive = False
+        self._handler.initialized = False
+        self._needs_full_setup = True
+        self._clear_current_card()
+        return False
 
 
     def _probe_frame_error(self, detail):

--- a/extras/mmu/unit/nfc/pn7160_driver.py
+++ b/extras/mmu/unit/nfc/pn7160_driver.py
@@ -1268,7 +1268,6 @@ class PN7160Driver:
         self._clear_current_card()
         # Non-blocking presence probe (homing) state
         self._probe_active = False
-        self._probe_deadline = 0.0
         self._probe_errors = 0
 
         # Advanced PN7160 tuning options are intentionally hidden from the
@@ -1381,11 +1380,21 @@ class PN7160Driver:
     # IRQ is still preferred where it exists, and probe_supported() short-circuits to
     # it: a free question beats a cheap one.
     #
-    # The two modes differ in one place - the watchdog. With IRQ, prolonged silence
-    # means discovery has stalled and is worth a teardown/restart. In polled mode
-    # silence is simply the answer on every tick until the tag arrives, and a restart
-    # means paying probe_start()'s blocking NCI setup mid-move, so polled mode has no
-    # silence watchdog and recovers via the consecutive-frame-error count instead.
+    # NEITHER mode has a silence watchdog, and that is deliberate. Silence is simply
+    # the answer on every tick until the tag arrives - in BOTH modes - so a time-based
+    # teardown cannot tell "the NFCC is wedged" from "the tag has not reached the
+    # reader yet". A sweep is routinely longer than any such timeout: a 500mm
+    # nfc_gate_jog_scan_window at 100mm/s is 5 seconds of entirely normal silence, and
+    # tearing down partway through costs probe_start()'s blocking NCI setup (a VEN
+    # toggle plus full bring-up, ~124ms = 12mm of travel at that speed) with discovery
+    # DOWN for all of it. Worse, a restart storm destabilises the chip: repeated
+    # hardware resets provoke I2C START_NACKs, whose recovery is slower again.
+    #
+    # Note this is NOT the same situation as pn532_driver's watchdog, which is correct
+    # for that chip: there an InListPassiveTarget command is outstanding and the chip
+    # OWES a response, so silence really does mean a wedged exchange. PN7160 discovery
+    # is autonomous and owes nothing until a tag appears. Both modes recover instead
+    # via the consecutive-frame-error count, which counts real faults rather than time.
     #
     # The probe reports PRESENCE and stops there - it never selects or activates the
     # tag. That is not just a simplification: activation goes through
@@ -1394,7 +1403,6 @@ class PN7160Driver:
     # to remove. read_target() does the full discover-and-activate afterwards, once
     # the machine is stationary.
 
-    _PROBE_WATCHDOG = 2.0        # Stalled-discovery restart, seconds (IRQ mode only)
     _PROBE_MAX_FRAME_ERRORS = 3  # Consecutive torn frames before a resync
 
     def probe_supported(self):
@@ -1437,7 +1445,6 @@ class PN7160Driver:
             self._setup_for_read()
             self._handler.start_discovery()
             self._discovery_active = True
-            self._probe_deadline = self._handler.reactor.monotonic() + self._PROBE_WATCHDOG
             self._probe_errors = 0
             self._probe_active = True
             if self._debug >= 3:
@@ -1460,8 +1467,13 @@ class PN7160Driver:
         """
         Collect at most one pending NCI frame.
 
-        Returns True (a tag is in the field), False (discovery failed or stalled - the
+        Returns True (a tag is in the field), False (discovery genuinely failed - the
         caller should restart) or None (nothing pending yet).
+
+        False is reserved for real faults. Silence is NOT one: it is the expected
+        answer on every tick until the tag reaches the reader, in both IRQ and polled
+        mode, and answering False to it makes MmuNfcManager restart discovery mid-move
+        (see _homing_poll) with the reader blind throughout the rebuild.
 
         With irq_pin, a tick with no IRQ pending does no bus I/O and no waiting at
         all; in polled mode it costs one 3-byte I2C transfer and still no pause. On
@@ -1475,14 +1487,11 @@ class PN7160Driver:
         handler = self._handler
         try:
             if handler.irq_enabled and not handler.irq_state:
-                # Nothing pending, and asking cost nothing. The watchdog applies HERE
-                # ONLY: silence with an IRQ line means discovery has stalled, so tear
-                # down and let the caller restart on a clean NFCC. In polled mode
-                # silence is the normal answer and a 2s restart storm mid-move would
-                # be worse than the shim this replaces.
-                if handler.reactor.monotonic() > self._probe_deadline:
-                    self._probe_stop_discovery()
-                    return False
+                # Nothing pending, and asking cost nothing. NO time-based teardown
+                # here: silence means "no tag yet", which is the normal answer for the
+                # whole sweep until the tag arrives. Restarting on it blinds the reader
+                # for the duration of probe_start()'s NCI setup, which is how a healthy
+                # scan turned into a restart storm that found nothing.
                 return None
 
             frame = handler.read_frame_if_pending()

--- a/test/test_mmu_nfc_probe.py
+++ b/test/test_mmu_nfc_probe.py
@@ -535,6 +535,87 @@ class TestPn7160SilentTick(unittest.TestCase):
                          'a garbage header must not be followed by a payload read')
 
 
+class TestPn7160TransportErrors(unittest.TestCase):
+    """
+    A Klipper/MCU comms fault is not a dead PN7160. On a CAN toolhead a 20ms polled
+    tick competes with step data, so "Unable to obtain 'i2c_response' response" happens
+    under load and is transient. Escalating one straight to not-alive forced a full
+    re-init (VEN toggle + NCI bring-up, ~124ms blind, 12mm of travel at 100mm/s) whose
+    repeated hardware resets then provoked I2C START_NACKs costing 1.7-2.1s each.
+    """
+
+    KLIPPER_TIMEOUT = Exception("Unable to obtain 'i2c_response' response")
+
+    def test_one_transport_error_is_tolerated(self):
+        """THE regression. One hiccup must not cost the scan."""
+        drv, _i2c, _reactor = pn7160(raises=self.KLIPPER_TIMEOUT)
+        self.assertIsNone(drv.probe_poll(),
+                          'a transient MCU timeout must answer None, not False - '
+                          'False makes MmuNfcManager rebuild discovery mid-sweep')
+        self.assertTrue(drv.is_alive(), 'the reader is fine; the host bus was busy')
+        self.assertFalse(drv._needs_full_setup,
+                         'forcing full setup is what made the next restart cost 124ms')
+        self.assertTrue(drv._probe_active, 'the probe must stay armed')
+
+    def test_a_sustained_run_still_escalates(self):
+        """Tolerance is not blindness - a reader that has really gone must be caught."""
+        drv, _i2c, _reactor = pn7160(raises=self.KLIPPER_TIMEOUT)
+        results = [drv.probe_poll() for _ in range(drv._PROBE_MAX_TRANSPORT_ERRORS)]
+        self.assertEqual(results[:-1], [None] * (drv._PROBE_MAX_TRANSPORT_ERRORS - 1))
+        self.assertIs(results[-1], False, 'the cap must still escalate')
+        self.assertFalse(drv.is_alive())
+        self.assertTrue(drv._needs_full_setup)
+
+    def test_a_good_frame_clears_the_transport_count(self):
+        """
+        Consecutive is the whole point: scattered hiccups across a long sweep must
+        never accumulate into a teardown.
+        """
+        drv, _i2c, _reactor = pn7160([RF_DISCOVER_NTF[:3], RF_DISCOVER_NTF[3:]])
+        drv._probe_transport_errors = drv._PROBE_MAX_TRANSPORT_ERRORS - 1
+        self.assertTrue(drv.probe_poll(), 'a real detection must still report True')
+        self.assertEqual(drv._probe_transport_errors, 0,
+                         'a good frame proves the transport recovered')
+
+
+class TestPn7160TotalDuration(unittest.TestCase):
+    """
+    TOTAL_DURATION is the NCI discovery period: the NFCC interrogates the field once
+    per period then idles. Never sent before, so the firmware default (hundreds of ms)
+    stood, making detection of a moving tag probabilistic - P(catch) ~ dwell / period.
+    """
+
+    def test_the_set_frame_encodes_the_period_little_endian(self):
+        """
+        Hand-encoded NCI. A byte wrong here is a silently wrong period, which shows up
+        only as flaky detection on hardware - exactly the bug being fixed.
+        """
+        cmd = pn7160_driver.NCI_CORE_SET_TOTAL_DURATION_CMD
+        self.assertEqual(cmd[:3], [0x20, 0x02, 0x05],
+                         'CORE_SET_CONFIG (GID CORE, OID 0x02) with 5 payload octets')
+        self.assertEqual(cmd[3:6], [0x01, 0x00, 0x02],
+                         'one parameter: TOTAL_DURATION (0x00), 2 octets long')
+        self.assertEqual(len(cmd), 3 + cmd[2],
+                         'the length octet must match the real payload length')
+        ms = cmd[6] | (cmd[7] << 8)
+        self.assertEqual(ms, pn7160_driver.PN7160_TOTAL_DURATION_MS,
+                         'NCI multi-octet values are little-endian - a byte-swapped '
+                         '50ms becomes 12800ms, which is worse than the default')
+
+    def test_the_period_is_short_enough_for_a_moving_tag(self):
+        """
+        Pins the REASON for the value. At 100mm/s the readable zone is ~15-20mm, so a
+        period much above ~100ms makes detection a coin flip rather than a certainty.
+        """
+        self.assertLessEqual(pn7160_driver.PN7160_TOTAL_DURATION_MS, 100)
+        self.assertGreater(pn7160_driver.PN7160_TOTAL_DURATION_MS, 0)
+
+    def test_the_get_frame_asks_for_total_duration(self):
+        cmd = pn7160_driver.NCI_CORE_GET_TOTAL_DURATION_CMD
+        self.assertEqual(cmd, [0x20, 0x03, 0x02, 0x01, 0x00],
+                         'CORE_GET_CONFIG for one parameter, TOTAL_DURATION')
+
+
 class TestPn7160Detection(unittest.TestCase):
     """Presence only: the probe must never select or activate the tag."""
 
@@ -622,7 +703,15 @@ class TestPn7160ErrorTaxonomy(unittest.TestCase):
         self.assertEqual(drv._probe_errors, 0)
 
     def test_a_real_transport_failure_still_escalates(self):
+        """
+        A SUSTAINED transport failure must still be reported. Escalation is now on the
+        consecutive count rather than the first fault, because a single one is usually
+        just a busy host bus (see TestPn7160TransportErrors) - but a reader that has
+        genuinely gone must not be polled forever.
+        """
         drv, _i2c, _reactor = pn7160(raises=RuntimeError('mcu is gone'))
+        for _ in range(drv._PROBE_MAX_TRANSPORT_ERRORS - 1):
+            self.assertIsNone(drv.probe_poll(), 'below the cap: tolerated')
         self.assertFalse(drv.probe_poll())
         self.assertFalse(drv.is_alive())
         self.assertTrue(drv._needs_full_setup,
@@ -675,9 +764,11 @@ class TestPn7160ProbeStartCost(unittest.TestCase):
     point of no_irq_fast_poll is to bring that down to something a move can absorb.
     """
 
-    # RSPs the setup sequence waits for: CORE_RESET, CORE_INIT, RF_DISCOVER_MAP, RF_DISCOVER
+    # RSPs the setup sequence waits for, in order: CORE_RESET, CORE_INIT,
+    # CORE_SET_CONFIG (TOTAL_DURATION), RF_DISCOVER_MAP, RF_DISCOVER
     SETUP_RSPS = ([0x40, 0x00, 0x03, 0x00, 0x11, 0x01],
                   [0x40, 0x01, 0x01, 0x00],
+                  [0x40, 0x02, 0x02, 0x00, 0x00],
                   [0x41, 0x00, 0x01, 0x00],
                   [0x41, 0x03, 0x01, 0x00])
 

--- a/test/test_mmu_nfc_probe.py
+++ b/test/test_mmu_nfc_probe.py
@@ -407,7 +407,6 @@ def pn7160(script=(), status_support=True, irq=False, raises=None, **opts):
     drv._needs_full_setup = False        # _setup_for_read() cleared it
     drv._probe_active = True
     drv._discovery_active = True
-    drv._probe_deadline = reactor.monotonic() + drv._PROBE_WATCHDOG
     i2c.transcript.clear()
     reactor.strict = True
     return drv, i2c, reactor
@@ -483,9 +482,10 @@ class TestPn7160SilentTick(unittest.TestCase):
 
     def test_silence_never_triggers_a_discovery_restart(self):
         """
-        Pins the watchdog asymmetry. In polled mode silence is normal, and a teardown
-        (RF_DEACTIVATE) plus probe_start() mid-move is blocking NCI work - worse than
-        the shim this replaces. 4s here is twice _PROBE_WATCHDOG.
+        Silence is "no tag yet", not a stall, and must never tear discovery down. A
+        teardown (RF_DEACTIVATE) plus probe_start() mid-move is blocking NCI work -
+        worse than the shim this replaces. 4s here is longer than any watchdog this
+        driver used to carry.
         """
         drv, i2c, reactor = pn7160([NACK] * 200)
         for _tick in range(200):
@@ -493,10 +493,28 @@ class TestPn7160SilentTick(unittest.TestCase):
             self.assertIsNone(drv.probe_poll())
         self.assertEqual(i2c.writes(), [],
                          'a write during a run of silence means silence tore discovery '
-                         'down - the polled probe has no time-based watchdog')
-        self.assertIsInstance(drv._probe_deadline, float,
-                              'the IRQ branch compares against _probe_deadline, so it '
-                              'must stay a number even when polled mode ignores it')
+                         'down - the probe has no time-based watchdog')
+
+    def test_irq_silence_never_triggers_a_discovery_restart(self):
+        """
+        THE 500mm SWEEP REGRESSION. A 2s watchdog here used to answer False on normal
+        silence, so MmuNfcManager restarted discovery (_homing_poll) partway through
+        every sweep longer than 2s - a 500mm window at 100mm/s is 5s of legitimate
+        silence. Each restart blinded the reader for probe_start()'s full NCI bring-up
+        (~124ms, 12mm of travel), and the repeated hardware resets provoked I2C
+        START_NACKs that made recovery slower still. Silence must stay None forever.
+        """
+        drv, i2c, reactor = pn7160([], irq=True)
+        drv._handler.irq_state = 0                  # IRQ low: nothing pending
+        for _tick in range(500):                    # 10s at a 20ms tick
+            reactor.now += 0.020
+            self.assertIsNone(drv.probe_poll(),
+                              'IRQ-mode silence must answer None - False restarts '
+                              'discovery mid-sweep and loses the tag')
+        self.assertTrue(drv._probe_active,
+                        'a silent sweep must leave the probe armed')
+        self.assertEqual(i2c.writes(), [],
+                         'an IRQ-low tick must cost no bus traffic at all')
 
     def test_status_less_reply_is_silence_not_an_error(self):
         """


### PR DESCRIPTION
## PN7160: fix missed tag reads during NFC homing sweeps

### Problem

`MMU_NFC_SCAN` frequently failed to read a tag on a PN7160 reader, and got worse
as `gear_homing_speed` rose. On hardware at 100 mm/s the tag was detected on
roughly **one forward sweep in three**; the other two ran the full 500 mm window
without ever tripping the reader, then reported `no tag found`. Slow jogs worked,
which made it look like an RF range problem. It was not.

Three separate defects in the driver combined to produce it:

1. **The NCI discovery period was never configured.** `TOTAL_DURATION` (RF config
   parameter `0x00`) governs how often the NFCC energises the antenna and
   interrogates the field; between interrogations it idles. The driver never sent
   `CORE_SET_CONFIG`, so the NXP firmware default (~500 ms, confirmed by read-back)
   stood — and `CORE_RESET` with clear-config re-wiped it on every full setup.

   This makes detection of a *moving* tag probabilistic: `P(catch) ≈ dwell / period`.
   A ~15–20 mm readable zone at 100 mm/s is 150–200 ms of dwell against a 500 ms
   period — about one pass in three, exactly the observed hit rate.

2. **A silence watchdog tore down healthy scans.** `_PROBE_WATCHDOG = 2.0` treated
   prolonged silence as a stalled NFCC. But silence is the *expected* answer for the
   whole sweep until the tag arrives, and a 500 mm window at 100 mm/s is 5 s of
   entirely legitimate silence. Each spurious teardown cost `probe_start()`'s full
   NCI bring-up (~124 ms with discovery down — 12 mm of travel).

   This premise was inherited from `pn532_driver`, where it is correct: there an
   `InListPassiveTarget` command is outstanding and the chip owes a response, so
   silence really does mean a wedged exchange. PN7160 discovery is autonomous and
   owes nothing until a tag appears. The pattern did not transfer.

3. **Transient host-bus faults were treated as reader death.** A 20 ms polled tick is
   an I²C round trip to an MCU that, on a CAN toolhead, is simultaneously carrying
   step data. Missing a response deadline surfaces as Klipper's
   `Unable to obtain 'i2c_response' response`. The broad `except Exception` in
   `probe_poll()` marked the reader not-alive and set `_needs_full_setup`, so the
   caller's restart paid a VEN toggle plus complete NCI bring-up. The repeated
   hardware resets then provoked I²C `START_NACK`s, and recovery escalated to
   **1.7–2.1 s per restart** — longer than the sweep itself.

### Changes

All in `extras/mmu/unit/nfc/pn7160_driver.py`.

**Module constants**
- Added `PN7160_TOTAL_DURATION_MS = 50` and `NCI_CORE_SET_TOTAL_DURATION_CMD`, the
  frame built from it at import time (uint16 little-endian). Kept as a constant
  rather than a runtime builder, matching how every other NCI command in the file is
  declared; tuning is one integer.
- Added `NCI_CORE_GET_TOTAL_DURATION_CMD` for the diagnostic read-back.
- Removed `_PROBE_WATCHDOG`; added `_PROBE_MAX_TRANSPORT_ERRORS = 5` (higher than the
  frame-error cap of 3 — a torn frame means the NFCC misbehaved, a transport fault
  means the host bus was busy, which is likelier and more obviously transient).

**`PN7160Handler`**
- New `configure_total_duration()` — issues `CORE_SET_CONFIG`. Non-fatal on rejection:
  a chip that refuses the parameter still reads tags, just at the old default.
- New `_log_current_total_duration()` — at `debug >= 3`, reads the value back *before*
  overwriting it, so the firmware default is recorded rather than assumed.

**`PN7160Driver`**
- `_setup_for_read()` — calls `configure_total_duration()` in the `full` branch only,
  after the clear-config `CORE_RESET` that wipes it and before `RF_DISCOVER_MAP`
  (NCI only accepts configuration changes while IDLE). Full-setup only, because
  `probe_start()`'s keep-config path is the homing critical path and a keep-config
  reset preserves the value.
- `probe_start()` — no longer arms a watchdog deadline; resets the transport counter.
- `probe_poll()` — removed the time-based teardown from the IRQ branch (silence now
  always answers `None`); the broad `except Exception` now routes to the new handler
  below instead of immediately declaring the reader dead.
- New `_probe_transport_error()` — counts *consecutive* Klipper/MCU transport faults,
  answering `None` below the cap and escalating to the previous not-alive behaviour
  past it. The count clears on any good frame, so scattered hiccups across a long
  sweep cannot accumulate into a teardown.
- Removed `_probe_deadline` state; added `_probe_transport_errors`.
- Rewrote the probe design commentary, which previously asserted the incorrect premise
  that silence implies a stall, and now records the PN532 contrast.

`rc522_driver` and `pn532_driver` watchdogs are deliberately left untouched — both
bound a genuine outstanding exchange.

### Testing

**Unit tests** — `test/test_mmu_nfc_probe.py`, six added:
- `TestPn7160TransportErrors` (3): one fault tolerated and the reader stays alive and
  armed; a sustained run still escalates; a good frame clears the count.
- `TestPn7160TotalDuration` (3): the `CORE_SET_CONFIG` frame encodes header, TLV and a
  **little-endian** period (a byte-swapped 50 ms becomes 12800 ms — worse than the
  default), the length octet matches the payload, the period is short enough for a
  moving tag, and the `GET` frame is well formed.
- `test_irq_silence_never_triggers_a_discovery_restart`: ticks 500 times (10 s of
  simulated silence) asserting `None` throughout, the probe stays armed, and no bus
  traffic occurs. Verified this test genuinely catches the bug by temporarily
  reinstating the watchdog — it fails with `False is not None`, then passes once
  removed.

Two existing tests updated, both legitimately:
- `test_a_real_transport_failure_still_escalates` pinned the old escalate-on-first-fault
  contract; it now drives past the cap.
- `TestPn7160ProbeStartCost.SETUP_RSPS` needed the `CORE_SET_CONFIG` response added.
  **Its 200 ms budget assertion still passes at 0.160 s**, confirming the added command
  does not regress the homing critical path (~30 ms, full-setup path only).

Full suite: `failures=3, errors=74` — byte-identical to the clean-tree baseline on this
branch, verified by stashing and re-running. NFC suite: 204 pass.

**Live on hardware** (PN7160 on `unit0_nfc4`, CAN toolhead, 500 mm scan window,
`MMU_TEST_CONFIG gear_homing_speed=N` then `MMU_NFC_SCAN GATE=4`):

| `gear_homing_speed` | Result | Detected at |
|---|---|---|
| 100 mm/s | tag read | 270.3 mm |
| 150 mm/s | tag read | 276.8 mm |
| 200 mm/s | tag read | 297.3 mm |

3 of 3, including at double the speed that previously failed. Before the change the
same 100 mm/s scan succeeded roughly one time in three, and the detection point varied
widely; it is now stable at ~270–300 mm across a 2× speed range, consistent with the
much shorter discovery period.

No `probe_poll failed`, no `START_NACK`, and no mid-sweep re-init appears in any of the
three runs.

**Read-back confirms the root cause** — with `debug >= 3` the driver now logs:

debugging fixes and PR description was Claude Opus 4.7 medium thinking assisted