### PR TITLE
NFC/RFID pending-precedence fix, VVD config fixes, and misc private_v4 sync

### DIFF
--- a/extras/mmu/commands/mmu_sensor_insert.py
+++ b/extras/mmu/commands/mmu_sensor_insert.py
@@ -71,7 +71,6 @@ class MmuSensorInsertCommand(BaseCommand):
                     # The entry sensor is upstream of the gear, so an insert here is ALWAYS
                     # the user pushing filament in - the MMU cannot cause one. Record it.
                     mmu.gate_maps.set_gate_status(gate, GATE_UNKNOWN)
-                    mmu._check_pending_filament(gate)  # Have spool_id ready?
 
                     # Autoloading is a gate change, so never start one on top of an
                     # operation already in flight. On real Klipper this is belt-and-braces
@@ -81,10 +80,18 @@ class MmuSensorInsertCommand(BaseCommand):
                     # operation we would be interrupting is suppressed at source instead,
                     # by wrap_suspend_insert_events in _preload_gate / _jog_scan.
                     if mmu.action != ACTION_IDLE:
+                        # Nothing else will consume a pending shared-NFC result for this gate.
+                        mmu._check_pending_filament(gate)  # Have spool_id ready?
                         mmu.log_debug("Not autoloading gate %d: an MMU operation is already "
                                       "in progress" % gate)
                     elif not mmu.is_printing() and mmu.mmu_unit(gate).p.gate_autoload:
+                        # Leave any pending shared-NFC result live: MMU_PRELOAD already grabs
+                        # it up front (_grab_pending, before its own moves) so _preload_gate
+                        # can bypass its per-gate NFC reader and apply the resolved
+                        # spool_id/tag itself on success.
                         mmu.gcode.run_script_from_command("MMU_PRELOAD GATE=%d" % gate)
+                    else:
+                        mmu._check_pending_filament(gate)  # Have spool_id ready?
 
                 elif sensor == SENSOR_EXTRUDER_ENTRY:
                     if mmu.gate_selected != TOOL_GATE_BYPASS:

--- a/installer/Kconfig.nfc_reader
+++ b/installer/Kconfig.nfc_reader
@@ -84,9 +84,10 @@ config MMU_HAS_PER_GATE_NFC_READERS
 # NFC reader config
 # ------------------------------------
 
-if MMU_HAS_NFC_READER && ! CUSTOM_NFC_READER_SETUP
+if MMU_HAS_NFC_READER
 
   menu "NFC reader config"
+    depends on !CUSTOM_NFC_READER_SETUP
 
     # ------------------------------------
     # Single NFC: all settings on one page
@@ -137,11 +138,11 @@ if MMU_HAS_NFC_READER && ! CUSTOM_NFC_READER_SETUP
             and choose software I2C, which gives each reader its
             own bit-banged bus with no extra hardware.
 
-#       config CHOICE_NFC_READER_TYPE_PN532_SPI
-#         bool "PN532 [[DIM]]/ SPI[[/DIM]]"
-#         help
-#           PN532 NFC reader using SPI. Set the breakout board's mode pads to
-#           SEL0=0, SEL1=0.
+       config CHOICE_NFC_READER_TYPE_PN532_SPI
+         bool "PN532 [[DIM]]/ SPI[[/DIM]]"
+         help
+           PN532 NFC reader using SPI. Set the breakout board's mode pads to
+           SEL0=0, SEL1=0.
 
         config CHOICE_NFC_READER_TYPE_PN7160
           bool "PN7160 [[DIM]]/ I2C[[/DIM]]"
@@ -155,13 +156,13 @@ if MMU_HAS_NFC_READER && ! CUSTOM_NFC_READER_SETUP
         default "pn5180" if CHOICE_NFC_READER_TYPE_PN5180
         default "pn532"  if CHOICE_NFC_READER_TYPE_PN532
         default "pn532"  if CHOICE_NFC_READER_TYPE_PN532_UART
-#       default "pn532"  if CHOICE_NFC_READER_TYPE_PN532_SPI
+        default "pn532"  if CHOICE_NFC_READER_TYPE_PN532_SPI
         default "pn7160" if CHOICE_NFC_READER_TYPE_PN7160
 
       config PARAM_NFC_READER_INTERFACE
         string
         default "uart" if CHOICE_NFC_READER_TYPE_PN532_UART
-        default "spi"  if CHOICE_NFC_READER_TYPE_RC522 || CHOICE_NFC_READER_TYPE_PN5180 # || CHOICE_NFC_READER_TYPE_PN532_SPI
+        default "spi"  if CHOICE_NFC_READER_TYPE_RC522 || CHOICE_NFC_READER_TYPE_PN5180 || CHOICE_NFC_READER_TYPE_PN532_SPI
         default "i2c"
 
       if CHOICE_NFC_READER_TYPE_PN532_UART
@@ -184,7 +185,7 @@ if MMU_HAS_NFC_READER && ! CUSTOM_NFC_READER_SETUP
             raising it needs a SetSerialBaudRate command the driver does not send.
       endif
 
-      if CHOICE_NFC_READER_TYPE_RC522 || CHOICE_NFC_READER_TYPE_PN5180 # || CHOICE_NFC_READER_TYPE_PN532_SPI
+      if CHOICE_NFC_READER_TYPE_RC522 || CHOICE_NFC_READER_TYPE_PN5180 || CHOICE_NFC_READER_TYPE_PN532_SPI
         config PARAM_NFC_READER_CS_PIN
           string "CS pin            "
           default "$(MCU_NAME):pin"
@@ -353,79 +354,85 @@ if MMU_HAS_NFC_READER && ! CUSTOM_NFC_READER_SETUP
 
            if PARAM_NFC_READER_GATE_$(i)
 
-            config PARAM_NFC_READER_$(i)
-              string "Gate $(i) reader name       "
-              default "$(UNIT_NAME)_nfc$(i)"
-              help
-                Name of the NFC reader for this gate in the printer config.
-                E.g., "unit0_nfc0".
+             config PARAM_NFC_READER_$(i)
+               string "Gate $(i) reader name       "
+               default "$(UNIT_NAME)_nfc$(i)"
+               help
+                 Name of the NFC reader for this gate in the printer config.
+                 E.g., "unit0_nfc0".
 
-            choice CHOICE_NFC_READER_TYPE_$(i)
-              prompt "Gate $(i) reader type       "
-              default CHOICE_NFC_READER_TYPE_RC522_$(i)
-              help
-                Select the type of NFC reader being used for this gate.
+             choice CHOICE_NFC_READER_TYPE_$(i)
+               prompt "Gate $(i) reader type       "
+               default CHOICE_NFC_READER_TYPE_RC522_$(i)
+               help
+                 Select the type of NFC reader being used for this gate.
 
-              config CHOICE_NFC_READER_TYPE_RC522_$(i)
-                bool "RC522 [[DIM]]/ SPI[[/DIM]]"
+               config CHOICE_NFC_READER_TYPE_RC522_$(i)
+                 bool "RC522 [[DIM]]/ SPI[[/DIM]]"
 
-              config CHOICE_NFC_READER_TYPE_PN5180_$(i)
-                bool "PN5180 [[DIM]]/ SPI[[/DIM]]"
+               config CHOICE_NFC_READER_TYPE_PN5180_$(i)
+                 bool "PN5180 [[DIM]]/ SPI[[/DIM]]"
 
-              config CHOICE_NFC_READER_TYPE_PN532_$(i)
-                bool "PN532 [[DIM]]/ I2C[[/DIM]]"
+               config CHOICE_NFC_READER_TYPE_PN532_$(i)
+                 bool "PN532 [[DIM]]/ I2C[[/DIM]]"
 
-              config CHOICE_NFC_READER_TYPE_PN532_UART_$(i)
-                bool "PN532 [[DIM]]/ UART[[/DIM]]"
+               config CHOICE_NFC_READER_TYPE_PN532_UART_$(i)
+                 bool "PN532 [[DIM]]/ UART[[/DIM]]"
+                 help
+                   PN532 in HSU mode on a USB serial adapter plugged into the HOST, not into
+                   an MCU. Needs its OWN adapter - a port cannot be shared with another reader.
+
+                   For a reader on every gate this means one USB adapter per gate. Software I2C
+                   is usually the better answer there: it gives each reader its own bit-banged
+                   bus off the MMU MCU with no extra hardware. Pick UART per gate only if you
+                   actually have the adapters.
+
+              config CHOICE_NFC_READER_TYPE_PN532_SPI_$(i)
+                bool "PN532 [[DIM]]/ SPI[[/DIM]]"
                 help
-                  PN532 in HSU mode on a USB serial adapter plugged into the HOST,
-                  not into an MCU. Needs its OWN adapter - a port cannot be shared
-                  with another reader.
-
-                  For a reader on every gate this means one USB adapter per gate.
-                  Software I2C is usually the better answer there: it gives each
-                  reader its own bit-banged bus off the MMU MCU with no extra
-                  hardware. Pick UART per gate only if you actually have the
-                  adapters.
+                  PN532 NFC reader using SPI. Set the breakout board's mode pads to
+                  SEL0=0, SEL1=0.
 
               config CHOICE_NFC_READER_TYPE_PN7160_$(i)
                 bool "PN7160 [[DIM]]/ I2C[[/DIM]]"
-            endchoice
 
-            config PARAM_NFC_READER_TYPE_$(i)
-              string
-              default "rc522"  if CHOICE_NFC_READER_TYPE_RC522_$(i)
-              default "pn5180" if CHOICE_NFC_READER_TYPE_PN5180_$(i)
-              default "pn532"  if CHOICE_NFC_READER_TYPE_PN532_$(i)
-              default "pn532"  if CHOICE_NFC_READER_TYPE_PN532_UART_$(i)
-              default "pn7160" if CHOICE_NFC_READER_TYPE_PN7160_$(i)
+             endchoice
 
-            config PARAM_NFC_READER_INTERFACE_$(i)
-              string
-              default "uart" if CHOICE_NFC_READER_TYPE_PN532_UART_$(i)
-              default "spi"  if CHOICE_NFC_READER_TYPE_RC522_$(i) || CHOICE_NFC_READER_TYPE_PN5180_$(i) # || CHOICE_NFC_READER_TYPE_PN532_$(i)
-              default "i2c"
+             config PARAM_NFC_READER_TYPE_$(i)
+               string
+               default "rc522"  if CHOICE_NFC_READER_TYPE_RC522_$(i)
+               default "pn5180" if CHOICE_NFC_READER_TYPE_PN5180_$(i)
+               default "pn532"  if CHOICE_NFC_READER_TYPE_PN532_$(i)
+               default "pn532"  if CHOICE_NFC_READER_TYPE_PN532_UART_$(i)
+               default "pn532"  if CHOICE_NFC_READER_TYPE_PN532_SPI_$(i)
+               default "pn7160" if CHOICE_NFC_READER_TYPE_PN7160_$(i)
 
-            if CHOICE_NFC_READER_TYPE_PN532_UART_$(i)
-              config PARAM_NFC_READER_SERIAL_$(i)
-                string "Gate $(i) serial device     "
-                default "-enter-device-path-"
-                help
-                  Path of the USB serial adapter for THIS gate's reader. Every gate
-                  needs a different one; reusing a port is rejected at startup.
-                  List them with: ls /dev/serial/by-id/
-                  Use the by-id form - /dev/ttyUSB0 is not stable across replugs.
+             config PARAM_NFC_READER_INTERFACE_$(i)
+               string
+               default "uart" if CHOICE_NFC_READER_TYPE_PN532_UART_$(i)
+               default "spi"  if CHOICE_NFC_READER_TYPE_RC522_$(i) || CHOICE_NFC_READER_TYPE_PN5180_$(i) || CHOICE_NFC_READER_TYPE_PN532_SPI_$(i)
+               default "i2c"
 
-              config PARAM_NFC_READER_BAUD_$(i)
-                int "Gate $(i) baud rate         "
-                default 115200
-                range 9600 1288000
-                help
-                  Serial speed. Leave at 115200: that is what the PN532 powers up at,
-                  and raising it needs a command the driver does not send.
-            endif
+             if CHOICE_NFC_READER_TYPE_PN532_UART_$(i)
+               config PARAM_NFC_READER_SERIAL_$(i)
+                 string "Gate $(i) serial device     "
+                 default "-enter-device-path-"
+                 help
+                   Path of the USB serial adapter for THIS gate's reader. Every gate
+                   needs a different one; reusing a port is rejected at startup.
+                   List them with: ls /dev/serial/by-id/
+                   Use the by-id form - /dev/ttyUSB0 is not stable across replugs.
 
-            if CHOICE_NFC_READER_TYPE_RC522_$(i) || CHOICE_NFC_READER_TYPE_PN5180_$(i)
+               config PARAM_NFC_READER_BAUD_$(i)
+                 int "Gate $(i) baud rate         "
+                 default 115200
+                 range 9600 1288000
+                 help
+                   Serial speed. Leave at 115200: that is what the PN532 powers up at,
+                   and raising it needs a command the driver does not send.
+             endif
+
+            if CHOICE_NFC_READER_TYPE_RC522_$(i) || CHOICE_NFC_READER_TYPE_PN5180_$(i) || CHOICE_NFC_READER_TYPE_PN532_SPI_$(i)
               config PARAM_NFC_READER_CS_PIN_$(i)
                 string "Gate $(i) CS pin            "
                 default "$(MCU_NAME):pin"

--- a/installer/boards/custom/Kconfig.vvd
+++ b/installer/boards/custom/Kconfig.vvd
@@ -122,7 +122,7 @@ reader_type           : rc522\n\
 cs_pin                : $(MCU_NAME):PB14\n\
 spi_bus               : spi2_PB2_PB11_PB10\n\
 spi_speed             : 1000000\n\
-debug                 : n\n\
+debug                 : 0\n\
 \n\
 # NFC reader gates 2/3\n\
 [mmu_nfc_reader unit1_nfc23]\n\

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -347,10 +347,12 @@ ENCODER = BOXTURTLE.derive(
 #     gates 9-12), and sensors qualified per unit
 #   - IndexedSelector, a third selector class - and one that self-calibrates and
 #     self-homes at handle_ready (mmu_indexed_selector.py:137-140)
-#   - a SPARSE per-gate list. The ViViD fits NFC readers on gates 0 and 2 only
-#     (boards/custom/Kconfig.vvd:57-58), so nfc_readers renders as
-#     'unit1_nfc0, , unit1_nfc2,'. Every other profile populates every gate, which is why
-#     the harness's own getlist could drop blanks unnoticed for so long.
+#   - a common reader coexisting with a per-gate list, on DIFFERENT units. unit0 has a
+#     shared PN532 (nfc_reader='unit0_nfc') through the generic wiring prompts; unit1's
+#     CUSTOM_NFC_READER_SETUP hides that menu entirely and hand-writes two custom readers
+#     instead (boards/custom/Kconfig.vvd), one per adjacent gate pair, so nfc_readers
+#     renders DENSE - 'unit1_nfc01, unit1_nfc01, unit1_nfc23, unit1_nfc23' - with no
+#     common reader of its own (nfc_reader is blank).
 #   - a machine whose filament_heater must resolve, i.e. the heater_generic fake
 #   - LEDs on a chain declared OUTSIDE Happy Hare's own config (unit0 points at
 #     'neopixel:cabinet_leds' from the user's printer.cfg - see bootstrap.PRINTER_STUB)
@@ -448,6 +450,14 @@ ERCF_VVD = Profile(
             'MMU_HAS_SENSOR_BUFFER_PROPORTIONAL': True,
             'PIN_BUFFER_ANALOG': 'PF6',
             'CHOICE_EXTRUDER_HOMING_ENDSTOP_ENCODER': True,
+            # A shared PN532 over host serial - the only NFC transport that is not
+            # MCU-mediated. Lives on unit0 (generic wiring prompts) rather than unit1: VVD's
+            # CUSTOM_NFC_READER_SETUP hides that whole menu and hand-writes its own per-gate
+            # readers instead (boards/custom/Kconfig.vvd), so it has no common reader at all.
+            'MMU_HAS_NFC_READER': True,
+            'MMU_HAS_COMMON_NFC_READER': True,
+            'CHOICE_NFC_READER_TYPE_PN532_UART': True,
+            'PARAM_NFC_READER_SERIAL': '/dev/serial/shared_nfc',
         }),
         # ViViD 1.0. Its buffer lives on a SECOND mcu (OPTION_VVD_BUFFER selects
         # MMU_HAS_BUFFER_MCU), so this unit alone renders two [mcu] sections.
@@ -457,14 +467,6 @@ ERCF_VVD = Profile(
             'OPTION_VVD_BUFFER': True,
             # Explicit, because the derived default from UNIT_INDEX would be 'VVD-1'
             'PARAM_DISPLAY_NAME': 'VVD-11',
-            # A shared PN532 over host serial - the only NFC transport that is not
-            # MCU-mediated. Note the board ALSO defaults MMU_HAS_PER_GATE_NFC_READERS on
-            # (gates 0 and 2), so this unit renders a common reader AND a sparse per-gate
-            # list. That combination is what the getlist fix exists for.
-            'MMU_HAS_NFC_READER': True,
-            'MMU_HAS_COMMON_NFC_READER': True,
-            'CHOICE_NFC_READER_TYPE_PN532_UART': True,
-            'PARAM_NFC_READER_SERIAL': '/dev/serial/shared_nfc',
             'MMU_HAS_EJECT_BUTTONS': True,
             'PIN_EJECT_BUTTON_0': 'unit1:pin0',
             'PIN_EJECT_BUTTON_1': 'unit1:pin1',

--- a/test/test_mmu_nfc_scan.py
+++ b/test/test_mmu_nfc_scan.py
@@ -260,6 +260,26 @@ class TestPreloadNfcCompound(NfcScanTestCase):
         self.assertIn('preloading gate 0...', said)
         self.assertNotIn('nfc:', said)
 
+    def test_pending_shared_uid_bypasses_the_per_gate_reader(self):
+        """
+        A shared-reader pending takes precedence over this gate's own NFC reader: the
+        autoload preload it triggers must skip the per-gate scan entirely and apply the
+        pending spool_id, rather than re-scan for (and not find) a tag of its own.
+
+        Regression test: the entry-insert handler used to consume the pending before
+        MMU_PRELOAD's _grab_pending() ever saw it (mmu_sensor_insert.py), so have_pending
+        was always False on the autoload path and the per-gate scan always ran.
+        """
+        self.hh.mmu.mmu_unit(0).p.gate_autoload = 1
+        self.hh.mmu.pending_spool_id = 7  # No tag attached to gate 0 - a scan would find none
+        at = len(self.hh.console)
+        self.hh.place_filament(0, position=self.fil.layout['mmu_entry'] + 10.0, quiet=False)
+        self.hh.settle()
+        banners = [l for l in self.hh.console[at:] if l.startswith('Preloading')]
+        self.assertEqual(banners, ['Preloading gate 0...'],
+                         'per-gate NFC scan ran despite a pending shared-reader UID')
+        self.assertEqual(self.hh.mmu.gate_maps.gate_spool_id[0], 7)
+
     def test_nfc_first_finishes_on_the_gate_and_parks_without_reverse_homing(self):
         """
         Reader stops the move, tag is read, homing CONTINUES to the gate switch - so the

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -197,25 +197,40 @@ class TestMultiUnitMachine(unittest.TestCase):
         self.assertFalse(by_name['unit0'].selector.is_homed,
                          'unit0 is uncalibrated in the harness, so it must NOT claim homed')
 
-    def test_sparse_per_gate_nfc_readers_survive_config_load(self):
+    def test_per_gate_nfc_readers_are_shared_across_a_gate_pair(self):
         """
-        THE regression test for blank-preserving getlist. The ViViD fits readers on gates 0
-        and 2 only (boards/custom/Kconfig.vvd:57-58), so nfc_readers renders as
-        'unit1_nfc0, , unit1_nfc2,'. Drop the blanks and it arrives as 2 entries where
-        mmu_unit.py:208-209 demands 0 or num_gates, and the whole machine fails to load.
+        The ViViD hand-writes two physical readers, each covering an adjacent gate pair
+        (boards/custom/Kconfig.vvd:120-133), so nfc_readers renders DENSE - every gate
+        populated, with gates 0/1 and 2/3 naming the SAME reader - rather than sparse.
+        mmu_nfc_manager._lookup_or_create_reader dedupes by name for exactly this case
+        ("Already created (e.g. shared between gates)").
+
+        unit1 has CUSTOM_NFC_READER_SETUP set, which hides the generic wiring menu
+        entirely (installer/Kconfig.nfc_reader), so it has no common reader of its own -
+        that lives on unit0 instead (test_a_common_reader_can_coexist_with_per_gate_ones).
         """
         from test.hh import cfg, profiles
         parser = cfg.assemble(cfg.render(profiles.get('ercf_vvd')))
         raw = dict(parser.items('mmu_unit unit1'))['nfc_readers']
         self.assertEqual([p.strip() for p in raw.split(',')],
-                         ['unit1_nfc0', '', 'unit1_nfc2', ''])
+                         ['unit1_nfc01', 'unit1_nfc01', 'unit1_nfc23', 'unit1_nfc23'])
 
         unit1 = {u.name: u for u in self.hh.mmu.mmu_machine.units}['unit1']
         self.assertEqual(len(unit1.nfc_readers), 4)
-        self.assertEqual([bool(r) for r in unit1.nfc_readers],
-                         [True, False, True, False])
-        # ...and the common reader coexists with them
-        self.assertEqual(unit1.nfc_reader, 'unit1_nfc')
+        self.assertEqual([bool(r) for r in unit1.nfc_readers], [True, True, True, True])
+        self.assertEqual(unit1.nfc_reader, '', 'unit1 must have no common reader')
+
+    def test_a_common_reader_can_coexist_with_per_gate_ones(self):
+        """
+        THE regression test for blank-preserving getlist, moved here from unit1 once
+        unit1's per-gate list stopped being sparse (see the test above). unit0 renders a
+        common reader (the generic wiring prompts, unaffected by CUSTOM_NFC_READER_SETUP)
+        alongside unit1's own per-gate list on the SAME multi-unit machine - two
+        different mechanisms coexisting without either one clobbering the other.
+        """
+        unit0 = {u.name: u for u in self.hh.mmu.mmu_machine.units}['unit0']
+        self.assertEqual(unit0.nfc_reader, 'unit0_nfc')
+        self.assertEqual(unit0.nfc_readers, [])
 
     def test_filament_heater_resolves(self):
         """


### PR DESCRIPTION
## Summary
- Preload now correctly lets a resolved shared-reader NFC pending (spool_id/tag) take precedence over a gate's own NFC reader when autoload fires, instead of the per-gate scan always running (`__MMU_SENSOR_INSERT` was consuming the pending before `MMU_PRELOAD` ever got to grab it).
- Fixes two boot-crashing installer bugs introduced by "Added nfc custom setup to VVD config": an overly-broad Kconfig guard that silently dropped `nfc_deep_read`/`nfc_gate_jog_scan_window`/`nfc_led_segment` defaults whenever `CUSTOM_NFC_READER_SETUP` was set, and a `debug : n` typo in VVD's hand-written per-gate NFC reader section.
- Adds PN532/SPI support to the per-gate NFC reader Kconfig, with two copy-paste default bugs from that addition also fixed.
- Test harness: moved the shared/common NFC reader in the `ercf_vvd` profile from VVD (which never actually had one) to ERCF, and updated the stale per-gate-reader test to match VVD's real paired-reader layout.
- Plus several other private_v4-only commits already ahead of `v4` (doc restructuring, tradrack rotary-selector cleanup, selector position/homing fixes, test suite timing/tty fixes).

## Test plan
- [x] `make ALL=1 test` - 900 tests, `skipped=1, expected failures=4` (documented clean baseline)
- [x] Targeted: `./venv/bin/python -m unittest test.test_mmu_nfc_scan test.test_mmu_motion test.test_mmu_profiles test.test_mmu_nfc_i2c test.test_mmu_console`

🤖 Generated with [Claude Code](https://claude.com/claude-code)