### PR TITLE
generated_default: fix override order, add %i/{...} math syntax

### DIFF
--- a/installer/Kconfig
+++ b/installer/Kconfig
@@ -20,18 +20,26 @@
 # 1. Dynamic defaults 'generated_default'
 #
 #   Syntax:
-#     generated_default "<template>" "<args>"
-#     generated_default "<template>" "<args>" <stop>
-#     generated_default "<template>" "<args>" <start> <stop>
+#     generated_default "<template>" "<args>" [<separator>] [[<start>] <stop>]
 #
-#   <args> is a space-separated list of Kconfig symbols used for %-formatting.
-#   {iter} is replaced by the iterator value when repeating.
+#   <args> is a space-separated list of Kconfig symbols. Inside <template>:
+#     %s, %d    - next arg from <args>, filled in left-to-right wherever it appears
+#                 (list a symbol twice in <args> to fill two placeholders with it)
+#     %i        - the current iterator value (only valid when <start>/<stop> given)
+#     %%        - a literal '%'
+#     {...}     - a basic arithmetic expression (+ - * / // % ** and parens),
+#                 evaluated AFTER %s/%d/%i substitution -- reference them by
+#                 writing the token inside the braces, e.g. "{%i % %d}"
+#   Without <start>/<stop>, the template is rendered once. With them, it's
+#   rendered once per value in range(start, stop) (start defaults to 0) and
+#   the results joined with <separator> (defaults to ", ").
 #
 # Examples:
 #   generated_default "%s_%d" "PARAM_ONE PARAM_TWO"
-#   generated_default "{iter}_%s" "PARAM_ONE" PARAM_STOP
-#   generated_default "%s_{iter}" "PARAM_VENDOR PARAM_VERSION" PARAM_START PARAM_STOP
-#   generated_default "neopixel:$(UNIT_NAME)_gate{iter}_leds (1-%d)" "PARAM_NUM_GATES" PARAM_NUM_GATES
+#   generated_default "%i_%s" "PARAM_ONE" PARAM_STOP
+#   generated_default "%s_%i" "PARAM_VENDOR PARAM_VERSION" PARAM_START PARAM_STOP
+#   generated_default "neopixel:$(UNIT_NAME)_gate%i_leds (1-%d)" "PARAM_NUM_GATES" PARAM_NUM_GATES
+#   generated_default "{(%i + 1) % %d}" "PARAM_NUM_GATES" ", " 0 PARAM_NUM_GATES
 #
 # 2. Added float type
 # 3. Option 'force_show'to force display even if dependency isn't met

--- a/installer/Kconfig.leds
+++ b/installer/Kconfig.leds
@@ -77,22 +77,22 @@ if MMU_HAS_LEDS
     config PARAM_EXIT_LEDS
       string
       array_editor ";"
-      default ""
+      default "" if CUSTOM_LED_SETUP
 
     config PARAM_ENTRY_LEDS
       string
       array_editor ";"
-      default ""
+      default "" if CUSTOM_LED_SETUP
 
     config PARAM_STATUS_LEDS
       string
       array_editor ";"
-      default ""
+      default "" if CUSTOM_LED_SETUP
 
     config PARAM_LOGO_LEDS
       string
       array_editor ";"
-      default ""
+      default "" if CUSTOM_LED_SETUP
 
     if !CUSTOM_LED_SETUP
 
@@ -112,7 +112,7 @@ if MMU_HAS_LEDS
 
       config PARAM_EXIT_LEDS
         prompt "Exit leds       "
-        generated_default "neopixel:_$(UNIT_NAME)_gate{iter}_leds (1-%d)" "PARAM_NUM_GATES" "; " 0 PARAM_NUM_GATES if MMU_HAS_PER_GATE_MCU
+        generated_default "neopixel:_$(UNIT_NAME)_gate%i_leds (1-%d)" "PARAM_NUM_GATES" "; " 0 PARAM_NUM_GATES if MMU_HAS_PER_GATE_MCU
         generated_default "neopixel:_$(UNIT_NAME)_leds (1-%d)" "PARAM_NUM_GATES"
 
       config PARAM_ENTRY_LEDS

--- a/installer/Kconfig.selector_stepper
+++ b/installer/Kconfig.selector_stepper
@@ -77,20 +77,24 @@ if MMU_HAS_SELECTOR_STEPPER
 
       config PARAM_SELECTOR_GATE_DIRECTIONS
         string "Selector gate directions  "
-        default "1, 1, 0, 0"
+        array_editor "," PARAM_NUM_GATES
+        generated_default "0" "" ", " 0 PARAM_NUM_GATES
         help
           An array with entry for each gate representing the direction of movement of the gear stepper
           when the gate is selected. This is used in the 3D-Chameleon design. E.g. "1, 1, 0, 0"
             0 = normal direction
             1 = reverse direction
+          The length should match the number of gates
 
       config PARAM_SELECTOR_RELEASE_GATES
         string "Selector release gates    "
-        default "2, 3, 0, 1"
+        array_editor "," PARAM_NUM_GATES
+        generated_default "{(%i + 1) % %d}" "PARAM_NUM_GATES" ", " 0 PARAM_NUM_GATES
         help
           An array with entry for each gate representing which gate to select to release the filament in
           the designated gate. (Only works if 'filament_always_gripped: 0').
           E.g. "2, 3, 0, 1" to release gate 0, select gate 2, to release gate 1, select gate 3, etc.
+          The length should match the number of gates
     endif
 
 
@@ -105,11 +109,13 @@ if MMU_HAS_SELECTOR_STEPPER
 
       config PARAM_SELECTOR_GATE_ORDER
         string "Selector gate order       "
-        default "0, 3, 1, 2"
+        array_editor "," PARAM_NUM_GATES
+        generated_default "%i" "" ", " 0 PARAM_NUM_GATES
         help
           Comma separated list representing the order of gates when selector is moving in a forward
           direction. This allows for efficient gate selection. Can also be automatically calibrated
-          with the MMU_CALIBRATE_SELECTOR_INDEXES command
+          with the MMU_CALIBRATE_SELECTOR_INDEXES command.
+          The length should match the number of gates
 
       config PARAM_SELECTOR_ENDSTOP_WIDTH
         float "Selector endstop width    "

--- a/installer/lib/kconfiglib/kconfiglib.py
+++ b/installer/lib/kconfiglib/kconfiglib.py
@@ -555,6 +555,8 @@ import os
 import re
 import sys
 import math # Happy Hare: Added
+import ast # Happy Hare: Added
+import operator # Happy Hare: Added
 
 # Get rid of some attribute lookups. These are obvious in context.
 from glob import iglob
@@ -4884,19 +4886,13 @@ class Symbol(object):
                 # If the symbol is visible and has a user value, use that
                 val = self.user_value
             else:
-                # Happy Hare: Added else block
-                for template, args, separator, start_sym, stop_sym, cond in self.generated_defaults:
-                    if expr_value(cond):
-                        val = _generated_default_value(template, args, separator, start_sym, stop_sym)
-                        self._write_to_conf = True
-                        break
-                else:
-                    # Otherwise, look at defaults
-                    for sym, cond in self.defaults:
-                        if expr_value(cond):
-                            val = sym.str_value
-                            self._write_to_conf = True
-                            break
+                # Happy Hare: 'default' and 'generated_default' are resolved
+                # together, in declaration order, so either can override the
+                # other depending on which Kconfig file is parsed later
+                found_val, found = self._node_ordered_string_default()
+                if found:
+                    val = found_val
+                    self._write_to_conf = True
 
         elif self.orig_type is FLOAT: # Happy Hare: Added
             if vis and self.user_value is not None:
@@ -5444,17 +5440,41 @@ class Symbol(object):
 
             return TRI_TO_STR[val]
 
-        if self.orig_type:  # STRING/INT/HEX
-            # Happy Hare: Added (favor generated defaults)
-            for template, args, separator, start_sym, stop_sym, cond in self.generated_defaults:
-                if expr_value(cond):
-                    return _generated_default_value(template, args, separator, start_sym, stop_sym)
+        if self.orig_type is STRING:
+            # Happy Hare: 'default' and 'generated_default' are resolved
+            # together, in declaration order -- see _node_ordered_string_default()
+            val, found = self._node_ordered_string_default()
+            if found:
+                return val
+            return ""
 
+        if self.orig_type:  # INT/HEX
             for default, cond in self.defaults:
                 if expr_value(cond):
                     return default.str_value
 
         return ""
+
+    def _node_ordered_string_default(self):
+        # Happy Hare: Added. Resolves 'default' and 'generated_default'
+        # together, walking self.nodes in source-parse order and checking
+        # each node's own generated_defaults/defaults before moving to the
+        # next node. This mirrors how multiple plain 'default's across
+        # Kconfig files already override each other (first satisfied
+        # condition, in declaration order), so a 'generated_default' in one
+        # file can be overridden by a plain 'default' in another file parsed
+        # later, and vice versa -- rather than 'generated_default' always
+        # taking priority regardless of file order.
+        for node in self.nodes:
+            for template, args, separator, start_sym, stop_sym, cond in node.generated_defaults:
+                if expr_value(cond):
+                    return _generated_default_value(template, args, separator, start_sym, stop_sym), True
+
+            for sym, cond in node.defaults:
+                if expr_value(cond):
+                    return sym.str_value, True
+
+        return None, False
 
     def _warn_select_unsatisfied_deps(self):
         # Helper for printing an informative warning when a symbol with
@@ -6887,6 +6907,85 @@ def _strcmp(s1, s2):
 
     return (s1 > s2) - (s1 < s2)
 
+# Happy Hare: Added. Matches a single non-nested '{...}' block in a
+# generated_default template.
+_generated_default_brace_re = re.compile(r"\{([^{}]*)\}")
+
+# Happy Hare: Added. %s/%d/%i/%% tokens -- any other '%' (e.g. used as
+# the modulo operator inside a '{...}' block) is left as literal text.
+_generated_default_token_re = re.compile(r"%[sdi%]")
+
+# Happy Hare: Added. Whitelisted operators for the restricted-arithmetic
+# evaluator used inside generated_default '{...}' blocks.
+_generated_default_binops = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+_generated_default_unaryops = {
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
+}
+
+# Happy Hare: Added
+def _eval_generated_default_expr(node):
+    # Evaluates an already-parsed AST node from a '{...}' block as a
+    # whitelist-only numeric expression. By the time this runs, %s/%d/%i
+    # substitution has already replaced every placeholder with a literal
+    # number, so a bare identifier here means the author put a
+    # non-numeric %s value inside {...} -- treated as an error like
+    # anything else disallowed.
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, bool) or not isinstance(node.value, (int, float)):
+            raise ValueError("only numeric literals are allowed in {...}")
+        return node.value
+
+    if isinstance(node, ast.BinOp):
+        op = _generated_default_binops.get(type(node.op))
+        if op is None:
+            raise ValueError("operator not allowed in {...}: %s" % type(node.op).__name__)
+        return op(_eval_generated_default_expr(node.left),
+                  _eval_generated_default_expr(node.right))
+
+    if isinstance(node, ast.UnaryOp):
+        op = _generated_default_unaryops.get(type(node.op))
+        if op is None:
+            raise ValueError("unary operator not allowed in {...}: %s" % type(node.op).__name__)
+        return op(_eval_generated_default_expr(node.operand))
+
+    raise ValueError("disallowed syntax in {...}: %s" % type(node).__name__)
+
+# Happy Hare: Added
+def _render_generated_default(template, base_args, iter_value):
+    # One full render of a generated_default template: substitutes
+    # %s/%d/%i/%% (wherever they appear, inside or outside braces), then
+    # evaluates each '{...}' block -- now pure number/operator text -- as
+    # arithmetic.
+    args_iter = iter(base_args)
+
+    def token_repl(m):
+        tok = m.group(0)
+        if tok == "%%":
+            return "%"
+        if tok == "%i":
+            if iter_value is None:
+                raise ValueError("%i used without iteration")
+            return str(iter_value)
+        return tok % next(args_iter)  # %s or %d
+
+    substituted = _generated_default_token_re.sub(token_repl, template)
+    for _ in args_iter:
+        raise ValueError("not all arguments converted")  # extra unused args
+
+    return _generated_default_brace_re.sub(
+        lambda m: str(_eval_generated_default_expr(
+            ast.parse(m.group(1).strip(), mode="eval").body)),
+        substituted)
+
 # Happy Hare: Added
 def _generated_default_value(template, args, separator=", ", start_sym=None, stop_sym=None):
     def sym_val(sym):
@@ -6922,7 +7021,7 @@ def _generated_default_value(template, args, separator=", ", start_sym=None, sto
 
     try:
         if stop_sym is None:
-            return template % tuple(base_args)
+            return _render_generated_default(template, base_args, None)
 
         start = int_val(start_sym, 0)
         stop = int_val(stop_sym, 0)
@@ -6930,13 +7029,8 @@ def _generated_default_value(template, args, separator=", ", start_sym=None, sto
         if stop <= start:
             return ""
 
-        out = []
-        for i in range(start, stop):
-            rendered = template.replace("{iter}", str(i))
-            rendered = rendered % tuple(base_args)
-            out.append(rendered)
-
-        return separator.join(out)
+        return separator.join(
+            _render_generated_default(template, base_args, i) for i in range(start, stop))
 
     except Exception:
         return ""

--- a/installer/mmu_types/Kconfig.3d_chameleon
+++ b/installer/mmu_types/Kconfig.3d_chameleon
@@ -45,9 +45,6 @@ if MMU_TYPE_3D_CHAMELEON_1_0
   config PARAM_SELECTOR_HOLD_CURRENT
     default 0.2
 
-  # Comma separated, NOT bracketed: these render straight into mmu_parameters.cfg and are read
-  # with Klipper's getintlist(), which rejects a literal '[1, 1, 0, 0]' with "Unable to parse
-  # option". The generic prompts they override (Kconfig.selector_stepper:80,89) get this right.
   config PARAM_SELECTOR_GATE_DIRECTIONS
     default "1, 1, 0, 0"
   config PARAM_SELECTOR_RELEASE_GATES

--- a/installer/mmu_types/Kconfig.emu
+++ b/installer/mmu_types/Kconfig.emu
@@ -121,24 +121,27 @@ if MMU_TYPE_EMU_1_0
   config PARAM_SYNC_GEAR_CURRENT
     default 52
 
+  config PARAM_NFC_GATE_JOG_SCAN_WINDOW
+    default "-100, 400"
+
   config PARAM_COLOR_ORDER
     default "GRBW"
   
   if BOARD_TYPE_SLB_1_0
     config PARAM_ENTRY_LEDS
-      generated_default "neopixel:_$(UNIT_NAME)_gate{iter}_box (1)" "" "; " PARAM_NUM_GATES
+      generated_default "neopixel:_$(UNIT_NAME)_gate%i_box (1)" "" "; " PARAM_NUM_GATES
 
     config PARAM_EXIT_LEDS
-      generated_default "neopixel:_$(UNIT_NAME)_gate{iter}_leds (1,2,3,4)" "" "; " PARAM_NUM_GATES
+      generated_default "neopixel:_$(UNIT_NAME)_gate%i_leds (1,2,3,4)" "" "; " PARAM_NUM_GATES
 
   endif
 
   if BOARD_TYPE_EBB_1_0
     config PARAM_ENTRY_LEDS
-      generated_default "neopixel:_$(UNIT_NAME)_gate{iter}_leds (5)" "" "; " PARAM_NUM_GATES
+      generated_default "neopixel:_$(UNIT_NAME)_gate%i_leds (5)" "" "; " PARAM_NUM_GATES
 
     config PARAM_EXIT_LEDS
-      generated_default "neopixel:_$(UNIT_NAME)_gate{iter}_leds (1,2,3,4)" "" "; " PARAM_NUM_GATES
+      generated_default "neopixel:_$(UNIT_NAME)_gate%i_leds (1,2,3,4)" "" "; " PARAM_NUM_GATES
     
   endif
 
@@ -155,7 +158,7 @@ if MMU_TYPE_EMU_1_0
     default 100
 
   config PARAM_FILAMENT_HEATERS 
-    generated_default "$(UNIT_NAME)_heater{iter}" "" PARAM_NUM_GATES
+    generated_default "$(UNIT_NAME)_heater%i" "" PARAM_NUM_GATES
 
   comment "_"
 

--- a/installer/mmu_types/Kconfig.mmx6
+++ b/installer/mmu_types/Kconfig.mmx6
@@ -41,6 +41,9 @@ if MMU_TYPE_MMX6_1_0
   config PARAM_GATE_HOMING_MAX
     default 1000
 
+  config PARAM_SELECTOR_RELEASE_GATES
+    default "1, 2, 3, 4, 5, 0"
+
   comment "_"
 
 endif 

--- a/installer/mmu_types/Kconfig.vvd
+++ b/installer/mmu_types/Kconfig.vvd
@@ -77,6 +77,9 @@ if MMU_TYPE_VVD_1_0
     default BOARD_TYPE_VVD_1_0
   endchoice
 
+  config PARAM_SELECTOR_GATE_ORDER
+    default "0, 3, 1, 2"
+
   config PARAM_GEAR_GEAR_RATIO
     default "1:1"
   config PARAM_GEAR_ROTATION_DISTANCE


### PR DESCRIPTION
## Summary
- `generated_default` no longer has absolute priority over a plain `default` for the same symbol -- the two now resolve in file/declaration order, so a type-specific `default` (e.g. VVD's `PARAM_SELECTOR_GATE_ORDER`) can override a generic `generated_default`, and vice versa.
- Fixes a shadowing bug this surfaced in `Kconfig.leds`: `PARAM_EXIT_LEDS`/`PARAM_ENTRY_LEDS`/`PARAM_STATUS_LEDS`/`PARAM_LOGO_LEDS` are each defined twice (a generic placeholder default, then the real per-board computed default) -- guarded the placeholder with `if CUSTOM_LED_SETUP` so it no longer shadows the real one for boards without their own LED override.
- Extends `generated_default` templates with a `%i` token (loop index) and `{...}` blocks for basic arithmetic (`+ - * / // % **`, unary `+`/`-`, parens), evaluated via a restricted AST whitelist (no `eval()`). Existing templates migrated from `{iter}` to `%i`.
- Updated the terse `generated_default` syntax doc in `installer/Kconfig`.

## Test plan
- [x] Unit-checked the new arithmetic pipeline directly against `_generated_default_value`, including the exact motivating example (`"{(%i + 1) % %d}"` -> `"1, 2, 3, 0"`)
- [x] Before/after symbol-value sweep across every profile in `test/hh/profiles.py` (single- and multi-unit) -- only the intended symbols changed
- [x] `make test` -- clean baseline (1 skipped, 4 expected failures, nothing new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)