### PR TITLE
self_update.sh: warn when stashed changes are left behind

### DIFF
--- a/installer/self_update.sh
+++ b/installer/self_update.sh
@@ -56,6 +56,16 @@ self_update() {
         git_version=$(git describe --tags)
         echo "${C_NOTICE}Already on the latest version: ${git_version}${C_OFF}"
     fi
+
+    # Stashes are never popped automatically, here or anywhere else -- a stash from this
+    # run, or a forgotten one from a previous run, will otherwise sit invisible until
+    # something (e.g. a hand-edited Kconfig file) mysteriously looks like it reverted
+    stash_count=$(git stash list | wc -l | tr -d ' ')
+    if [ "${stash_count}" -gt 0 ]; then
+        echo "${C_WARNING}WARNING: you have ${stash_count} stashed change(s) in this repo." \
+            "self_update never restores these automatically." \
+            "Run 'git stash list' to see them and 'git stash pop' to restore the most recent.${C_OFF}"
+    fi
 }
 
 self_update


### PR DESCRIPTION
## Summary
- `self_update.sh` stashes any locally-modified tracked file (e.g. a hand-edited Kconfig) before pulling, but nothing anywhere in the codebase ever pops that stash -- a local edit can silently look like it reverted.
- Now prints a loud warning with the exact stash count after every run, whether the stash was just created or left over from a previous run, with the commands to inspect/restore it.
- Also checked whether `.mmu_config`/`.mmu_config.old`/`.mmu_config_*` could be lost the same way -- they're already covered by existing `.gitignore` entries and confirmed ignored (not untracked), so no change was needed there.

## Test plan
- [x] Exercised in a throwaway clone: silent on a clean tree with no stashes
- [x] Fires with the correct count when a tracked file is dirtied and gets stashed
- [x] Keeps firing on subsequent runs until the stash is actually popped
- [x] `sh -n` syntax check passes; no test coverage touches this script

🤖 Generated with [Claude Code](https://claude.com/claude-code)