### PR TITLE
sync-feedback: apply tangle prevention current to the stepper it was meant for

### DIFF
--- a/extras/mmu/commands/mmu_status.py
+++ b/extras/mmu/commands/mmu_status.py
@@ -103,7 +103,7 @@ class MmuStatusCommand(BaseCommand):
             lines.append(". Toolhead position saved")
 
         lines.append(
-            f"\nMMU gear stepper at {mmu.gear_run_current_percent}% current and is "
+            f"\nMMU gear stepper at {mmu.gear_run_current()}% current and is "
             f"{'SYNCED' if mmu.drive().is_synced_to_extruder() else 'NOT SYNCED'} "
             f"to extruder"
         )

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -70,9 +70,11 @@ class MmuController(MmuFilamentMovement):
         self.has_mmu_cutter = False             # Post unload cutting macro (like EREC)
         self.has_toolhead_cutter = False        # Form tip cutting macro (like _MMU_CUT_TIP)
         self._is_running_test = False           # True while running QA or soak tests
-        self.gear_run_current_percent = 100     # Current run percentage of active gear stepper
-        self.extruder_run_current_percent = 100 # Current run percentage of active extruder
-        self._gear_run_current_locked = False   # True if changes to gear current is currently locked by wrap_gear_current()
+        # Run current % per gear stepper, keyed by stepper name rather than gate: a multigear unit
+        # has one stepper per gate but a single-gear unit shares one across all of them
+        self.gear_run_current_percents = {}
+        self.extruder_run_current_percent = 100 # Single value is fine - one shared toolhead extruder
+        self._gear_run_current_depth = 0        # Nesting depth of wrap_gear_current(), which locks out changes
         self.p = mmu_machine.params             # Shared Parameters shortcut
 
         self.kalico = bool(self.printer.lookup_object('danger_options', False))
@@ -151,6 +153,10 @@ class MmuController(MmuFilamentMovement):
         Ensure clean state on initialiaztion and after MMU enable/disable operation
         """
         self.is_enabled = True      # Whether Happy Hare is enabled or not
+
+        # Disable/enable restores every gear stepper to its configured default, so forget what we
+        # believed each was set to rather than carrying a stale record across the cycle
+        self.gear_run_current_percents.clear()
 
         self.filament_monitoring_enabled = False
         # Bracket the last suspend window and the last time we started handling a runout. Together

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -3658,13 +3658,28 @@ class MmuFilamentMovement:
         Yields:
             self while the temporary gear-current override is active.
         """
-        prev_percent = self._adjust_gear_current(percent=percent, reason=reason)
-        self._gear_run_current_locked = True
+        # Bind the stepper at entry so a block that changes selection still restores the one it
+        # changed. Only the outermost wrap applies and restores; inner ones are locked out
+        gate = self.gate_selected
+        outermost = self._gear_run_current_depth == 0
+        prev_percent = self._adjust_gear_current(gate=gate, percent=percent, reason=reason) if outermost else None
+        self._gear_run_current_depth += 1
         try:
             yield self
         finally:
-            self._gear_run_current_locked = False
-            self._restore_gear_current(percent=prev_percent)
+            self._gear_run_current_depth -= 1
+            if self._gear_run_current_depth == 0:
+                self._restore_gear_current(gate=gate, percent=prev_percent)
+
+
+    def gear_run_current(self, gate=None):
+        """
+        Run current percentage believed to be applied to a gate's gear stepper.
+        """
+        if gate is None:
+            gate = self.gate_selected
+        sname = self.mmu_unit(gate).gear_name(gate)
+        return self.gear_run_current_percents.get(sname, 100)
 
 
     def _adjust_gear_current(self, gate=None, percent=100, reason="", restore=False):
@@ -3680,31 +3695,32 @@ class MmuFilamentMovement:
         Returns:
             int or float: Previously active or currently retained gear-current percentage.
         """
-        u = self.mmu_unit(gate)
-
-        current_percent = self.gear_run_current_percent
-
-        if self._gear_run_current_locked:
-            return current_percent
+        # Resolve the gate before naming the stepper - gear_name() cannot take None
         if gate is None:
             gate = self.gate_selected
+        u = self.mmu_unit(gate)
+
         if gate < 0:
+            return 100
+        sname = u.gear_name(gate)
+        current_percent = self.gear_run_current_percents.get(sname, 100)
+
+        if self._gear_run_current_depth:
             return current_percent
         if not (0 < percent < 200):
             return current_percent
         if u.gear_tmc_obj(gate) is None:
             return current_percent
-        if percent == self.gear_run_current_percent:
+        if percent == current_percent:
             return current_percent
 
-        sname = u.gear_name(gate)
         if restore:
             msg = "Restoring MMU %s run current to %d%% ({}A)" % (sname, percent)
         else:
             msg = "Modifying MMU %s run current to %d%% ({}A) %s" % (sname, percent, reason)
         target_current = (u.gear_default_current(gate) * percent) / 100.0
         self._set_tmc_current(sname, target_current, msg)
-        self.gear_run_current_percent = percent # Update global record of current %
+        self.gear_run_current_percents[sname] = percent
         return current_percent
 
 

--- a/extras/mmu/unit/mmu_sync_feedback.py
+++ b/extras/mmu/unit/mmu_sync_feedback.py
@@ -72,13 +72,24 @@ class MmuSyncFeedback:
         # Initial flowguard status (when using sync-feedback controller)
         self.flowguard_status = {'trigger': '', 'reason': '', 'level': 0.0, 'max_clog': 0.0, 'max_tangle': 0.0, 'active': False, 'enabled': False}
 
-        # Tangle prevention - gear current boost on high tension (spool resistance)
-        self._tangle_prevention_boosted = False # Gear current currently boosted to 100%
-        self._tangle_prevention_active  = False # Armed (only while filament monitoring is active, not during load/unload)
+        # Tangle prevention - gear current boost on high tension (spool resistance).
+        # 'requested' is the hysteresis intent, 'boosted' is what actually reached the driver;
+        # they differ whenever a change is deferred, refused or superseded
+        self._tangle_prevention_active    = False # Armed (only while filament monitoring is active, not during load/unload)
+        self._tangle_prevention_requested = False
+        self._tangle_prevention_boosted   = False
+        self._tangle_prevention_gate      = None  # Gate whose stepper is boosted
+        self._pending_tangle              = None  # Latest coalesced (gate, percent, boost, msg)
+        self._tangle_cb_scheduled         = False
 
 
     def reinit(self):
-        pass
+        self._tangle_prevention_active    = False
+        self._tangle_prevention_requested = False
+        self._tangle_prevention_boosted   = False
+        self._tangle_prevention_gate      = None
+        self._pending_tangle              = None
+        self._tangle_cb_scheduled         = False
 
 
     def handle_connect(self):
@@ -214,21 +225,67 @@ class MmuSyncFeedback:
         if self._tangle_prevention_active:
             self._tangle_prevention_active = False
             self.mmu.log_debug("Tangle Prevention: Disarmed")
-        self._restore_tangle_prevention_current(eventtime, "disarmed")
+        self._invalidate_tangle_prevention("disarmed")
 
 
-    def _reset_tangle_prevention(self, eventtime):
+    def _reset_tangle_prevention(self, eventtime=None):
         # Disarm and restore boosted current on unsync
         self._tangle_prevention_active = False
-        self._restore_tangle_prevention_current(eventtime, "reset")
+        self._invalidate_tangle_prevention("reset")
 
 
-    def _restore_tangle_prevention_current(self, eventtime, reason):
+    def _invalidate_tangle_prevention(self, reason):
+        """
+        Drop any deferred change and put the boosted stepper back. Dropping first matters: a queued
+        boost must not land after the restore. The restore itself stays synchronous because a
+        deferred one could arrive after an unrelated operation legitimately raised that stepper.
+        """
+        self._pending_tangle = None
+        self._tangle_prevention_requested = False
+
         if self._tangle_prevention_boosted:
+            gate = self._tangle_prevention_gate
             self._tangle_prevention_boosted = False
+            self._tangle_prevention_gate = None
             restore_percent = self.p.sync_gear_current
             self.mmu.log_debug("Tangle Prevention: Restoring gear current to %d%%" % restore_percent)
-            self.mmu._adjust_gear_current(percent=restore_percent, reason="tangle prevention %s" % reason)
+            self.mmu._adjust_gear_current(gate=gate, percent=restore_percent,
+                                          reason="tangle prevention %s" % reason, restore=True)
+
+
+    def _schedule_tangle_current(self, gate, percent, boost, msg):
+        # Coalesce to the latest intent behind a single callback
+        self._pending_tangle = (gate, percent, boost, msg)
+        if self._tangle_cb_scheduled: return
+        self._tangle_cb_scheduled = True
+        self.mmu.reactor.register_callback(self._apply_pending_tangle)
+
+
+    def _apply_pending_tangle(self, eventtime):
+        """
+        Apply the deferred current change against the gate captured when it was decided, not
+        whatever is selected now. Re-validated here because the selection and the armed state can
+        both move while this sits queued.
+        """
+        pending, self._pending_tangle = self._pending_tangle, None
+        self._tangle_cb_scheduled = False
+        if pending is None: return
+
+        gate, percent, boost, msg = pending
+        if not (self.mmu.is_enabled and self.active and self._tangle_prevention_active):
+            self._tangle_prevention_requested = self._tangle_prevention_boosted
+            return
+
+        self.mmu.log_info(msg) # Logged on apply so we never announce a change that got refused
+        self.mmu._adjust_gear_current(gate=gate, percent=percent, restore=not boost,
+                                      reason="for tangle prevention" if boost else "tangle prevention release")
+
+        if self.mmu.gear_run_current(gate) == percent:
+            self._tangle_prevention_boosted = boost
+            self._tangle_prevention_gate = gate if boost else None
+        else:
+            # Refused, so realign intent with reality and let the next tick retry
+            self._tangle_prevention_requested = self._tangle_prevention_boosted
 
 
     def _check_tangle_prevention(self, eventtime):
@@ -242,21 +299,21 @@ class MmuSyncFeedback:
         # Tension is the negative half of the sensor range; work with abs value
         tension_level = -self._get_sensor_state()
 
-        if not self._tangle_prevention_boosted:
+        if not self._tangle_prevention_requested:
             if tension_level >= self.p.tangle_prevention_threshold:
-                self._tangle_prevention_boosted = True
-                self.mmu.log_info("Tangle Prevention: High tension detected (%.0f%%), boosting gear current to 100%%" % (tension_level * 100.))
-                # Defer current change to its own greenlet so SET_TMC_CURRENT's get_last_move_time()
-                # doesn't flush the lookahead in this timer-driven path (risking a move stall)
-                self.mmu.reactor.register_callback(
-                    lambda pt: self.mmu._adjust_gear_current(percent=100, reason="for tangle prevention"))
+                self._tangle_prevention_requested = True
+                msg = "Tangle Prevention: High tension detected (%.0f%%), boosting gear current to 100%%" % (tension_level * 100.)
+                # Defer the current change to its own greenlet so SET_TMC_CURRENT's
+                # get_last_move_time() doesn't flush the lookahead here (risking a move stall)
+                self._schedule_tangle_current(self.mmu.gate_selected, 100, True, msg)
         else:
             if tension_level <= self.p.tangle_prevention_release:
-                self._tangle_prevention_boosted = False
+                self._tangle_prevention_requested = False
                 restore_percent = self.p.sync_gear_current
-                self.mmu.log_info("Tangle Prevention: Tension eased (%.0f%%), restoring gear current to %d%%" % (tension_level * 100., restore_percent))
-                self.mmu.reactor.register_callback(
-                    lambda pt, p=restore_percent: self.mmu._adjust_gear_current(percent=p, reason="tangle prevention release"))
+                gate = self._tangle_prevention_gate
+                if gate is None: gate = self.mmu.gate_selected
+                msg = "Tangle Prevention: Tension eased (%.0f%%), restoring gear current to %d%%" % (tension_level * 100., restore_percent)
+                self._schedule_tangle_current(gate, restore_percent, False, msg)
 
 
     def adjust_filament_tension(self, use_gear_motor=True, max_move=None):
@@ -408,6 +465,10 @@ class MmuSyncFeedback:
         # Ignore event if not for this unit
         if not self.mmu_unit.manages_gate(self.mmu.gate_selected): return
 
+        # Ahead of the early return below: a boosted stepper has to come back down even when the
+        # feature was switched off while it was boosted, or it stays high for the rest of the print
+        self._invalidate_tangle_prevention("unsynced")
+
         if not (self.mmu.is_enabled and self.p.sync_feedback_enabled and self.active): return
         if eventtime is None: eventtime = self.mmu.reactor.monotonic()
 
@@ -445,6 +506,10 @@ class MmuSyncFeedback:
         """
         if not self.mmu_unit.has_buffer(): return
         self._invalidate_rd_scheduler()
+
+        # Usually a no-op because the unsync ahead of the gate change already restored, but it
+        # covers the paths where that handler bails early (feature toggled off mid-boost)
+        self._invalidate_tangle_prevention("gate change")
 
 
     def _handle_extruder_movement(self, eventtime, move):

--- a/test/test_mmu_tangle_prevention.py
+++ b/test/test_mmu_tangle_prevention.py
@@ -1,0 +1,255 @@
+# Happy Hare test harness - tangle prevention and the gear-current bookkeeping it rides on.
+#
+# Tangle prevention boosts the gear stepper to 100% when the buffer reports high tension (the gear
+# is struggling to pull from the spool) and restores it to sync_gear_current once tension eases.
+#
+# WHY THIS NEEDS ITS OWN SUITE
+#
+# The current change is DEFERRED to a reactor callback, deliberately: issuing SET_TMC_CURRENT from
+# the timer that detects the tension would flush the toolhead lookahead and risk a move stall. That
+# deferral is also where it went wrong - the callback used to capture no gate, and the gear stepper
+# is resolved from the CURRENT selection at apply time, so a boost decided for one lane could
+# program another and leave the first stuck at 100% for the rest of the print.
+#
+# THE PROFILE MATTERS. 'emu' is the only one that is simultaneously multigear (5 distinct gear
+# steppers, so a wrong target is observable) and fitted with a proportional buffer sensor (so the
+# feature can arm at all). It also has sync_gear_current=52; on a machine where that equals the
+# driver default, every SET_TMC_CURRENT is suppressed as a no-op and these tests prove nothing.
+#
+# Tension is driven by stubbing _get_sensor_state and the check is called directly rather than
+# waiting on the 0.5s extruder-movement timer. The timer is what PRODUCES the race; it is not what
+# needs asserting, and driving it would make these tests nondeterministic.
+#
+#   ./venv/bin/python -m unittest test.test_mmu_tangle_prevention
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+import unittest
+
+from test.hh import session
+
+logging.getLogger().setLevel(logging.CRITICAL)
+
+
+class TanglePreventionTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.hh = session('emu')
+        self.hh.boot()
+        self.assertEqual(self.hh.errors, [], 'bootup was not clean')
+        self.mmu = self.hh.mmu
+        self.unit = self.mmu.mmu_unit()
+        self.sf = self.unit.sync_feedback
+        self.sync_percent = self.unit.p.sync_gear_current
+        self.assertNotEqual(self.sync_percent, 100,
+                            'profile sync_gear_current == 100 makes every current change a no-op')
+
+        # Stand in for the buffer: tension is the negative half of the sensor range
+        self._tension = 0.0
+        self.sf._get_sensor_state = lambda: -self._tension
+
+        # Arm as a synced, monitored print would
+        self.sf.active = True
+        self.sf._tangle_prevention_active = True
+
+    def tearDown(self):
+        self.hh.close()
+
+    # -- helpers ------------------------------------------------------------
+    def currents(self):
+        return [line for line in self.hh.gcode.executed if line.startswith('SET_TMC_CURRENT')]
+
+    def stepper(self, gate):
+        return self.unit.gear_name(gate)
+
+    def tick(self, tension, drain=True):
+        """Run one tension sample through the check, then let the deferred change land."""
+        self._tension = tension
+        self.sf._check_tangle_prevention(self.hh.reactor.monotonic())
+        if drain:
+            self.hh.settle(0.)
+
+    def synced_baseline(self, gate=0):
+        """Put a stepper at sync_gear_current, as syncing to the extruder does."""
+        self.mmu._adjust_gear_current(gate=gate, percent=self.sync_percent, reason="test baseline")
+
+
+class TestBoostAndRelease(TanglePreventionTestCase):
+
+    def test_boost_and_release_reach_the_selected_stepper(self):
+        """
+        Positive control. Without it, a race test that passes because the callback never drained
+        looks identical to one that passes because the targeting was fixed.
+        """
+        self.synced_baseline(0)
+        mark = len(self.currents())
+
+        self.tick(0.9)
+        boost = self.currents()[mark:]
+        self.assertEqual(len(boost), 1, 'expected one current change, got %s' % boost)
+        self.assertIn('STEPPER=%s' % self.stepper(0), boost[0])
+        self.assertTrue(self.sf._tangle_prevention_boosted)
+        self.assertEqual(self.mmu.gear_run_current(0), 100)
+
+        mark = len(self.currents())
+        self.tick(0.0)
+        release = self.currents()[mark:]
+        self.assertEqual(len(release), 1, 'expected one current change, got %s' % release)
+        self.assertIn('STEPPER=%s' % self.stepper(0), release[0])
+        self.assertFalse(self.sf._tangle_prevention_boosted)
+        self.assertEqual(self.mmu.gear_run_current(0), self.sync_percent)
+
+    def test_re_arming_after_a_disarm_can_boost_again(self):
+        """
+        Guards the split between hysteresis intent and applied state: if intent leaks across a
+        disarm, the check takes the release branch forever and the feature is silently dead.
+        """
+        self.synced_baseline(0)
+        self.tick(0.9)
+        self.assertTrue(self.sf._tangle_prevention_boosted)
+
+        self.sf.deactivate_tangle_prevention(self.hh.reactor.monotonic())
+        self.sf.activate_tangle_prevention(self.hh.reactor.monotonic())
+        self.assertTrue(self.sf._tangle_prevention_active, 're-arm did not take')
+
+        mark = len(self.currents())
+        self.tick(0.9)
+        self.assertTrue(self.sf._tangle_prevention_boosted, 'second boost never happened')
+        self.assertTrue(self.currents()[mark:])
+
+
+class TestDeferredTargeting(TanglePreventionTestCase):
+
+    def test_boost_lands_on_the_gate_it_was_decided_for(self):
+        """
+        The reported bug. The selection moves between deciding to boost and the deferred change
+        landing, which is routine because a toolchange blocks on toolhead waits and reactor
+        callbacks interleave there.
+        """
+        self.synced_baseline(0)
+        mark = len(self.currents())
+
+        self.tick(0.9, drain=False)      # decided for gate 0
+        self.mmu.gate_selected = 3       # selection moves underneath
+        self.hh.settle(0.)               # now the deferred change lands
+
+        applied = self.currents()[mark:]
+        self.assertTrue(applied, 'boost never applied at all')
+        for line in applied:
+            self.assertNotIn('STEPPER=%s' % self.stepper(3), line,
+                             'boost programmed the stepper that happened to be selected')
+            self.assertIn('STEPPER=%s' % self.stepper(0), line)
+        self.assertEqual(self.sf._tangle_prevention_gate, 0)
+
+    def test_release_returns_the_boosted_stepper_not_the_selected_one(self):
+        self.synced_baseline(0)
+        self.tick(0.9)
+        self.assertEqual(self.mmu.gear_run_current(0), 100)
+
+        self.mmu.gate_selected = 3       # moved on while still boosted
+        mark = len(self.currents())
+        self.tick(0.0)
+
+        released = self.currents()[mark:]
+        self.assertTrue(released, 'release never applied')
+        for line in released:
+            self.assertIn('STEPPER=%s' % self.stepper(0), line)
+        self.assertEqual(self.mmu.gear_run_current(0), self.sync_percent,
+                         'boosted stepper left high')
+
+    def test_a_refused_change_is_not_recorded_as_applied(self):
+        """
+        A blocking operation owns the gear current while it runs. A boost that lands then is
+        dropped, and claiming it was applied would mean the matching release never fires.
+        """
+        self.synced_baseline(0)
+        self.mmu._gear_run_current_depth = 1   # stand in for an operation holding the current
+        mark = len(self.currents())
+
+        self.tick(0.9)
+        self.assertEqual(self.currents()[mark:], [])
+        self.assertFalse(self.sf._tangle_prevention_boosted, 'claimed a boost that was refused')
+
+        self.mmu._gear_run_current_depth = 0
+        self.tick(0.9)
+        self.assertTrue(self.sf._tangle_prevention_boosted, 'boost never retried once free')
+
+
+class TestPerStepperAccounting(TanglePreventionTestCase):
+
+    def test_a_change_to_one_stepper_does_not_suppress_another(self):
+        """
+        Current was tracked as one value for the whole machine, so a stepper already sitting at the
+        wanted percentage suppressed the change to a different one - which is what left a boosted
+        lane stuck high after the selection moved.
+        """
+        mark = len(self.currents())
+        self.mmu._adjust_gear_current(gate=0, percent=60, reason="test")
+        self.mmu._adjust_gear_current(gate=1, percent=60, reason="test")
+
+        applied = self.currents()[mark:]
+        self.assertEqual(len(applied), 2, 'second stepper was suppressed: %s' % applied)
+        self.assertIn('STEPPER=%s' % self.stepper(0), applied[0])
+        self.assertIn('STEPPER=%s' % self.stepper(1), applied[1])
+        self.assertEqual(self.mmu.gear_run_current(0), 60)
+        self.assertEqual(self.mmu.gear_run_current(1), 60)
+
+    def test_reinit_forgets_stale_current_records(self):
+        self.mmu._adjust_gear_current(gate=0, percent=60, reason="test")
+        self.assertEqual(self.mmu.gear_run_current(0), 60)
+
+        self.mmu.reinit()
+        self.assertEqual(self.mmu.gear_run_current(0), 100)
+
+
+class TestWrapNesting(TanglePreventionTestCase):
+
+    def test_inner_wrap_exit_does_not_unlock_the_outer_block(self):
+        """
+        The lock says "an operation owns the gear current". Releasing it when a nested block exits
+        leaves the rest of the outer operation exposed to changes it meant to shut out.
+        """
+        self.synced_baseline(0)
+        with self.mmu.wrap_gear_current(percent=80, reason="outer"):
+            with self.mmu.wrap_gear_current(percent=40, reason="inner"):
+                pass
+
+            mark = len(self.currents())
+            self.mmu._adjust_gear_current(gate=0, percent=99, reason="should be locked out")
+            self.assertEqual(self.currents()[mark:], [],
+                             'outer block was left unlocked by the inner exit')
+
+        self.assertEqual(self.mmu.gear_run_current(0), self.sync_percent)
+
+    def test_a_wrap_restores_the_stepper_it_changed(self):
+        self.synced_baseline(0)
+        with self.mmu.wrap_gear_current(percent=80, reason="outer"):
+            self.mmu.gate_selected = 3   # selection moves inside the block
+
+        self.assertEqual(self.mmu.gear_run_current(0), self.sync_percent,
+                         'wrap restored a different stepper than it changed')
+
+
+class TestDisableWhileBoosted(TanglePreventionTestCase):
+
+    def test_disabling_the_feature_while_boosted_still_restores(self):
+        """
+        The unsync handler bails early when sync feedback is switched off, which used to skip the
+        restore and leave the stepper at 100% for the rest of the print.
+        """
+        self.synced_baseline(0)
+        self.tick(0.9)
+        self.assertEqual(self.mmu.gear_run_current(0), 100)
+
+        self.unit.p.sync_feedback_enabled = 0
+        mark = len(self.currents())
+        self.sf._handle_mmu_unsynced()
+
+        self.assertTrue(self.currents()[mark:], 'nothing restored the boosted stepper')
+        self.assertFalse(self.sf._tangle_prevention_boosted)
+        self.assertEqual(self.mmu.gear_run_current(0), self.sync_percent)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## The bug

Tangle prevention boosts gear current on high buffer tension and restores it when tension eases. Both changes are deferred to a reactor callback on purpose — issuing `SET_TMC_CURRENT` from the timer that detects the tension would flush the toolhead lookahead and risk a move stall.

That deferral was also the bug. The callback captured no gate, and the gear stepper is resolved from the *current* selection when the change is applied. A toolchange blocks on toolhead waits and reactor callbacks interleave there, so a boost decided for one lane could program another and leave the first sitting at 100% for the rest of the print.

Reproduced against the unfixed code: a boost decided for gate 0 emits `SET_TMC_CURRENT STEPPER=unit0_gear_3`.

## The fix

The pending change now carries the gate it was decided for, is coalesced behind a single callback, and is re-validated when it lands. Hysteresis intent is separated from applied state, and the applied flag is set from what actually reached the driver rather than optimistically before the call — so a change refused by a blocking operation is retried on the next tick instead of being silently assumed. The announcement moved to the apply, so the console no longer reports a boost that was dropped.

**Targeting alone would not have worked.** Gear run current was tracked as one value for the whole machine while the steppers are per gate, and the equality guard uses it: with `sync_gear_current` equal to the driver default, no `SET_TMC_CURRENT` was emitted at all across two toolchanges. A correctly targeted restore of a boosted lane was therefore suppressed whenever another stepper had already reached that percentage. The record is now per stepper — keyed by name, not gate, because a single-gear unit shares one stepper across every gate — and it is forgotten on reinit, which never reset it before.

## Two adjacent faults, fixed here rather than left to strand a lane

- The wrap that temporarily overrides gear current cleared its lock unconditionally on exit, so a nested block unlocked the outer one while it was still running, and it resolved the stepper separately at entry and exit so a block that changed selection restored the wrong one. It now depth-counts and binds the stepper once.
- Switching sync feedback off while boosted meant the later unsync bailed out before restoring, stranding that stepper high.

Extruder current stays a single value: there is one shared toolhead extruder, so the asymmetry with the gear path is deliberate.

## Emission count

`SET_TMC_CURRENT` is issued on sync and unsync (a pair per toolchange), on entry and exit of the wrap that temporarily overrides current (extruder collision homing, bowden tightening, selector calibration), on a synced `move_filament`, and on tangle boost/release.

Replaying every request from six real toolchanges (84 requests) through both guards gives **11 emissions either way** — the normal flow is unchanged. The two policies only diverge where the old one was working from worse information:

| sequence | old (one global) | new (per-stepper) |
|---|---|---|
| 6 toolchanges, 84 requests | 11 | 11 |
| boost lane A, gate moves to B, restore A | 3 | 4 |
| re-request a value a stepper already holds | 3 | 1 |

The extra emission in the middle row is the restore the old code suppressed, leaving that lane at 100% — it is the bug being fixed. The bottom row is a redundant write the old code made because the global disagreed with the stepper's actual state; per-stepper accounting skips it. So this is not a systematic increase in driver traffic in either direction.

## Testing

`make test` — 921 tests, skipped=1, expected failures=4 (the documented clean baseline).

Adds `test/test_mmu_tangle_prevention.py`; nothing covered this feature before. Ten tests on the `emu` profile, the only one that is both multigear and proportional-sensor equipped, and whose `sync_gear_current` differs from the driver default so changes are not silently no-ops. **Nine of the ten fail against the unfixed code.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
