### PR TITLE
mmu_unit: refuse a foreign gate instead of resolving it to another gate's hardware

### DIFF
--- a/extras/mmu/mmu_unit.py
+++ b/extras/mmu/mmu_unit.py
@@ -682,6 +682,14 @@ class MmuUnit:
         return (self.first_gate <= gate < self.first_gate + self.num_gates)
 
 
+    def owns_gate(self, gate):
+        """
+        True only for a real gate on this unit. Unlike manages_gate() this excludes the
+        bypass/unknown sentinels, which have no slot in any per-gate array.
+        """
+        return isinstance(gate, int) and gate >= 0 and self.manages_gate(gate)
+
+
     def gate_bounds(self):
         return self.first_gate, self.first_gate + self.num_gates - 1
 
@@ -694,10 +702,12 @@ class MmuUnit:
         """
         Convert mmu_machine gate number to relative gate on mmu_unit
 
+        A gate this unit doesn't own has no local equivalent, so it raises. Callers that can
+        legitimately be asked about another unit's gate must test owns_gate() first.
+
         Args:
-          'force_physical' will default to local gate 0 if bypass/unknown and is safe for array
-           lookup, but only for those - a gate this unit doesn't manage has no local equivalent
-           and raises rather than silently resolving to another gate's hardware
+          'force_physical' will default to local gate 0 if bypass/unknown and is safe for
+           array lookup - but only for those sentinels
         """
         if not isinstance(gate, int):
             raise MmuError("Gate %s is not a gate number" % (gate,))
@@ -706,14 +716,9 @@ class MmuUnit:
             lgate = gate # bypass/unknown
         elif self.manages_gate(gate):
             lgate = gate - self.first_gate
-        elif force_physical:
+        else:
             raise MmuError("Gate %d is not managed by %s (range=%d-%d)"
                            % (gate, self.name, *self.gate_bounds()))
-        else:
-            # Only a decline now that anything wanting real hardware raises above, and callers
-            # that can be asked about another unit's gate treat it as one - so don't shout
-            self.mmu.log_debug("Gate %d is not managed by %s" % (gate, self.name))
-            lgate = TOOL_GATE_UNKNOWN
 
         return lgate if not force_physical else max(0, lgate)
 

--- a/extras/mmu/mmu_unit.py
+++ b/extras/mmu/mmu_unit.py
@@ -47,6 +47,7 @@ from .unit.selectors                    import SELECTOR_REGISTRY
 from .unit.selectors.mmu_base_selectors import VirtualSelector
 from .unit.mmu_environment_manager      import MmuEnvironmentManager
 from .unit.mmu_nfc_manager              import MmuNfcManager
+from .mmu_utils                         import MmuError
 
 
 # Default selector classes for known vendors
@@ -692,16 +693,26 @@ class MmuUnit:
     def local_gate(self, gate, force_physical=False):
         """
         Convert mmu_machine gate number to relative gate on mmu_unit
+
         Args:
-          'force_physical' will default to local gate 0 if bypass/unknown
-           and is safe for when using result for array lookup
+          'force_physical' will default to local gate 0 if bypass/unknown and is safe for array
+           lookup, but only for those - a gate this unit doesn't manage has no local equivalent
+           and raises rather than silently resolving to another gate's hardware
         """
-        if gate >= 0 and self.manages_gate(gate):
-            lgate = gate - self.first_gate
-        elif gate < 0:
+        if not isinstance(gate, int):
+            raise MmuError("Gate %s is not a gate number" % (gate,))
+
+        if gate < 0:
             lgate = gate # bypass/unknown
+        elif self.manages_gate(gate):
+            lgate = gate - self.first_gate
+        elif force_physical:
+            raise MmuError("Gate %d is not managed by %s (range=%d-%d)"
+                           % (gate, self.name, *self.gate_bounds()))
         else:
-            self.mmu.log_assertion("Fatal: Gate %d is not managed by %s" % (gate, self.name))
+            # Only a decline now that anything wanting real hardware raises above, and callers
+            # that can be asked about another unit's gate treat it as one - so don't shout
+            self.mmu.log_debug("Gate %d is not managed by %s" % (gate, self.name))
             lgate = TOOL_GATE_UNKNOWN
 
         return lgate if not force_physical else max(0, lgate)

--- a/extras/mmu/unit/mmu_calibrator.py
+++ b/extras/mmu/unit/mmu_calibrator.py
@@ -169,9 +169,10 @@ class MmuCalibrator:
         """
         if gate is None:
             gate = self.mmu.gate_selected
-        lgate = self.mmu_unit.local_gate(gate)
-
-        ref_gate = lgate if lgate >= 0 and self.mmu_unit.variable_bowden_lengths else 0
+        # Another unit's gate has no entry here, so fall back to this unit's reference gate
+        ref_gate = 0
+        if self.mmu_unit.owns_gate(gate) and self.mmu_unit.variable_bowden_lengths:
+            ref_gate = self.mmu_unit.local_gate(gate)
         return self._bowden_lengths[ref_gate]
 
 
@@ -184,11 +185,10 @@ class MmuCalibrator:
             gate = self.mmu.gate_selected
         mmu = self.mmu
         mmu_unit = self.mmu_unit
-        lgate = mmu_unit.local_gate(gate)
-
-        if lgate < 0:
-            mmu.log_debug("Assertion failure: cannot save bowden length for gate: %s" % mmu.selected_gate_string(gate))
+        if not mmu_unit.owns_gate(gate):
+            mmu.log_debug("Cannot save bowden length for gate: %s" % mmu.selected_gate_string(gate))
             return
+        lgate = mmu_unit.local_gate(gate)
 
         all_gates = not mmu_unit.variable_bowden_lengths
 
@@ -266,12 +266,9 @@ class MmuCalibrator:
         """
         if gate is None:
             gate = self.mmu.gate_selected
-        lgate = self.mmu_unit.local_gate(gate)
-
-        if lgate >= 0:
-            return self._bowden_lengths[lgate] >= 0
-
-        return True
+        if not self.mmu_unit.owns_gate(gate):
+            return True
+        return self._bowden_lengths[self.mmu_unit.local_gate(gate)] >= 0
 
 
     # -----------------------------------------------------------------------------------------------------------
@@ -313,10 +310,9 @@ class MmuCalibrator:
         """
         if gate is None:
             gate = self.mmu.gate_selected
-        lgate = self.mmu_unit.local_gate(gate)
-
-        idx = lgate if lgate >= 0 else 0
-        rd = self.rotation_distances[lgate] if lgate >= 0 else self._default_rotation_distances[0]
+        owned = self.mmu_unit.owns_gate(gate)
+        idx = self.mmu_unit.local_gate(gate) if owned else 0
+        rd = self.rotation_distances[idx] if owned else self._default_rotation_distances[0]
 
         if rd <= 0:
             rd = self._default_rotation_distances[idx]
@@ -331,9 +327,7 @@ class MmuCalibrator:
         """
         if gate is None:
             gate = self.mmu.gate_selected
-        lgate = self.mmu_unit.local_gate(gate)
-
-        lgate = max(0, lgate)
+        lgate = self.mmu_unit.local_gate(gate) if self.mmu_unit.owns_gate(gate) else 0
         return self._default_rotation_distances[lgate]
 
 
@@ -344,9 +338,8 @@ class MmuCalibrator:
         """
         if gate is None:
             gate = self.mmu.gate_selected
-        lgate = self.mmu_unit.local_gate(gate)
-
-        lgate = max(0, lgate)
+        if not self.mmu_unit.owns_gate(gate):
+            return
         rd = self.get_gear_rd(gate)
         mcu_stepper = self.mmu_unit.drive_obj(gate).mmu_gear_stepper.stepper
         if (
@@ -364,9 +357,7 @@ class MmuCalibrator:
         """
         if gate is None:
             gate = self.mmu.gate_selected
-        lgate = self.mmu_unit.local_gate(gate)
-
-        if rd and lgate >= 0:
+        if rd and self.mmu_unit.owns_gate(gate):
             self.mmu.log_trace("Set stepper for gate %d gear motor rotation distance: %.4f" % (gate, rd))
             mcu_stepper = self.mmu_unit.drive_obj(gate).mmu_gear_stepper.stepper
             mcu_stepper.set_rotation_distance(rd)
@@ -382,11 +373,10 @@ class MmuCalibrator:
 
         if gate is None:
             gate = mmu.gate_selected
-        lgate = mmu_unit.local_gate(gate)
-
-        if lgate < 0:
-            mmu.log_debug("Assertion failure: cannot save gear rotation_distance for gate: %d" % gate)
+        if not mmu_unit.owns_gate(gate):
+            mmu.log_debug("Cannot save gear rotation_distance for gate: %s" % mmu.selected_gate_string(gate))
             return
+        lgate = mmu_unit.local_gate(gate)
 
         all_gates = not mmu_unit.variable_rotation_distances
 
@@ -449,12 +439,9 @@ class MmuCalibrator:
         """
         if gate is None:
             gate = self.mmu.gate_selected
-        lgate = self.mmu_unit.local_gate(gate)
-
-        if lgate >= 0:
-            return self.rotation_distances[lgate] >= 0
-
-        return True
+        if not self.mmu_unit.owns_gate(gate):
+            return True
+        return self.rotation_distances[self.mmu_unit.local_gate(gate)] >= 0
 
 
     # -----------------------------------------------------------------------------------------------------------

--- a/extras/mmu/unit/mmu_environment_manager.py
+++ b/extras/mmu/unit/mmu_environment_manager.py
@@ -416,11 +416,16 @@ class MmuEnvironmentManager:
     # Both of these run from the environment timer. A gate this unit doesn't own has no slot here,
     # and a negative index would quietly read or overwrite the last gate's state instead
 
+    def _local_slot(self, gate):
+        # -1 for a gate this unit doesn't own, so the callers' existing bounds checks reject it
+        return self.mmu_unit.local_gate(gate) if self.mmu_unit.owns_gate(gate) else -1
+
+
     def _state_get(self, gate):
         """
         Get drying state for a global (logical) gate.
         """
-        if not self.mmu_unit.manages_gate(gate) or gate < 0:
+        if not self.mmu_unit.owns_gate(gate):
             return DRYING_STATE_NONE
         return self._drying_state[self.mmu_unit.local_gate(gate)]
 
@@ -429,7 +434,7 @@ class MmuEnvironmentManager:
         """
         Set drying state for a global (logical) gate.
         """
-        if not self.mmu_unit.manages_gate(gate) or gate < 0:
+        if not self.mmu_unit.owns_gate(gate):
             return
         self._drying_state[self.mmu_unit.local_gate(gate)] = state
 
@@ -766,7 +771,7 @@ class MmuEnvironmentManager:
             return
 
         heaters = self.mmu_unit.filament_heaters
-        lgate = self.mmu_unit.local_gate(gate)
+        lgate = self._local_slot(gate)
         if lgate < 0 or lgate >= len(heaters) or not heaters[lgate]:
             self.mmu.log_warning("MmuEnvironmentManager: No heater configured for gate %d" % gate)
             return
@@ -797,7 +802,7 @@ class MmuEnvironmentManager:
             return
 
         heaters = self.mmu_unit.filament_heaters
-        lgate = self.mmu_unit.local_gate(gate)
+        lgate = self._local_slot(gate)
         if lgate < 0 or lgate >= len(heaters) or not heaters[lgate]:
             return
         _,target = self._get_heater_status(gate)
@@ -824,7 +829,7 @@ class MmuEnvironmentManager:
             heater_name = self.mmu_unit.filament_heater
         else:
             heaters = self.mmu_unit.filament_heaters
-            lgate = self.mmu_unit.local_gate(gate)
+            lgate = self._local_slot(gate)
             if lgate < 0 or lgate >= len(heaters) or not heaters[lgate]:
                 return (None, None)
             heater_name = heaters[lgate]
@@ -846,7 +851,7 @@ class MmuEnvironmentManager:
             sensor = self.mmu_unit.environment_sensor
         else:
             sensors = self.mmu_unit.environment_sensors
-            lgate = self.mmu_unit.local_gate(gate)
+            lgate = self._local_slot(gate)
             if lgate < 0 or lgate >= len(sensors) or not sensors[lgate]:
                 return None, None
             sensor = sensors[lgate]

--- a/extras/mmu/unit/mmu_environment_manager.py
+++ b/extras/mmu/unit/mmu_environment_manager.py
@@ -413,10 +413,15 @@ class MmuEnvironmentManager:
         self.reinit()
 
 
+    # Both of these run from the environment timer. A gate this unit doesn't own has no slot here,
+    # and a negative index would quietly read or overwrite the last gate's state instead
+
     def _state_get(self, gate):
         """
         Get drying state for a global (logical) gate.
         """
+        if not self.mmu_unit.manages_gate(gate) or gate < 0:
+            return DRYING_STATE_NONE
         return self._drying_state[self.mmu_unit.local_gate(gate)]
 
 
@@ -424,6 +429,8 @@ class MmuEnvironmentManager:
         """
         Set drying state for a global (logical) gate.
         """
+        if not self.mmu_unit.manages_gate(gate) or gate < 0:
+            return
         self._drying_state[self.mmu_unit.local_gate(gate)] = state
 
 

--- a/extras/mmu/unit/mmu_nfc_manager.py
+++ b/extras/mmu/unit/mmu_nfc_manager.py
@@ -179,8 +179,10 @@ class MmuNfcManager:
         nfc_readers = self.mmu_unit.nfc_readers
         if not nfc_readers:
             return False
+        if not self.mmu_unit.owns_gate(gate):
+            return False
         lgate = self.mmu_unit.local_gate(gate)
-        return 0 <= lgate < len(nfc_readers) and bool(nfc_readers[lgate])
+        return lgate < len(nfc_readers) and bool(nfc_readers[lgate])
 
 
     def allow_reread(self):
@@ -525,8 +527,10 @@ class MmuNfcManager:
         """
         if gate is None:
             return None
+        if not self.mmu_unit.owns_gate(gate):
+            return None
         lgate = self.mmu_unit.local_gate(gate)
-        return lgate if 0 <= lgate < len(self.gate_readers) else None
+        return lgate if lgate < len(self.gate_readers) else None
 
 
     def _reader_for(self, shared=False, gate=None):

--- a/extras/mmu/unit/selectors/mmu_rotary_selector.py
+++ b/extras/mmu/unit/selectors/mmu_rotary_selector.py
@@ -251,8 +251,10 @@ class RotarySelector(PhysicalSelector):
         self._position(pos)
         self.grip_state = state
 
-        # Ensure gate filament drive is in the correct direction
-        self.mmu_unit.drive_obj(lgate).set_gear_direction(self.p.selector_gate_directions[lgate])
+        # Ensure gate filament drive is in the correct direction. drive_obj() takes a machine gate
+        # but everything here is unit-local, so convert rather than hand it a local index
+        self.mmu_unit.drive_obj(self.mmu_unit.logical_gate(lgate)).set_gear_direction(
+            self.p.selector_gate_directions[lgate])
         self.mmu.movequeue_wait()
 
 
@@ -553,7 +555,13 @@ class MmuCalibrateRotarySelectorCommand(BaseCommand):
         save = gcmd.get_int('SAVE', 1, minval=0, maxval=1)
         single = gcmd.get_int('SINGLE', 0, minval=0, maxval=1)
         quick = gcmd.get_int('QUICK', 0, minval=0, maxval=1)
-        gate = gcmd.get_int('GATE', 0, minval=0, maxval=mmu_unit.num_gates - 1)
+        # GATE is a machine-wide number, so range it against the machine and check ownership -
+        # a unit-local range silently addresses the wrong gate on any unit that isn't first
+        min_gate, max_gate = mmu_unit.gate_bounds()
+        gate = gcmd.get_int('GATE', min_gate, minval=0, maxval=mmu.num_gates - 1)
+        if not mmu_unit.manages_gate(gate):
+            raise gcmd.error("Gate %d is not managed by %s (range=%d-%d)"
+                             % (gate, mmu_unit.name, min_gate, max_gate))
 
         try:
             mmu.calibrating = True

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -1094,8 +1094,10 @@ class Session:
         from extras.mmu.mmu_constants import VARS_MMU_SELECTOR_OFFSETS
         mmu_unit = self.mmu.mmu_machine.units[unit]
         offsets = self.mmu.var_manager.get(VARS_MMU_SELECTOR_OFFSETS, None, namespace=mmu_unit.name)
+        if not mmu_unit.owns_gate(gate):
+            return None
         lgate = mmu_unit.local_gate(gate)
-        if not offsets or not 0 <= lgate < len(offsets):
+        if not offsets or lgate >= len(offsets):
             return None
         return offsets[lgate]
 

--- a/test/test_mmu_local_gate.py
+++ b/test/test_mmu_local_gate.py
@@ -1,0 +1,188 @@
+# Happy Hare test harness - machine gate to unit-local gate conversion.
+#
+# On a multi-unit machine gate numbers are machine-wide and contiguous (unit0 owns 0-8, unit1 owns
+# 9-12), while every per-unit array - steppers, drives, TMCs, offsets, drying state - is indexed
+# locally. MmuUnit.local_gate() is the only bridge between the two, so a mistake there does not
+# raise: it hands back a plausible index and the caller quietly operates the wrong hardware.
+#
+# THE TWO CASES ARE NOT THE SAME. Bypass (-2) and unknown (-1) are passed through deliberately, and
+# with force_physical they resolve to local gate 0 so array lookups work - that is a documented
+# default several callers rely on. A POSITIVE gate belonging to another unit is a different thing
+# entirely: there is no correct local index, so demanding physical hardware for one now raises
+# instead of silently clamping to this unit's gate 0.
+#
+# Default mode still returns -1 for a foreign gate, because roughly sixteen callers treat that as a
+# "not mine, use a default" signal (mmu_calibrator, mmu_environment_manager, mmu_nfc_manager) and
+# some of them sit on a reactor timer, in get_status, or in a toolhead lookahead callback where
+# raising would be far worse than declining.
+#
+# Uses 'ercf_vvd', the only multi-unit profile - on a single-unit machine a foreign gate cannot be
+# expressed at all, so none of this is testable.
+#
+#   ./venv/bin/python -m unittest test.test_mmu_local_gate
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+import unittest
+
+from test.hh import session
+
+logging.getLogger().setLevel(logging.CRITICAL)
+
+TOOL_GATE_UNKNOWN = -1
+TOOL_GATE_BYPASS = -2
+
+# The four accessors that resolve real hardware, and so pass force_physical=True
+HARDWARE_ACCESSORS = ('gear_name', 'drive_obj', 'gear_tmc_obj', 'gear_default_current')
+
+
+class MultiUnitTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.hh = session('ercf_vvd')
+        # Imported after the session reroutes 'extras' to the harness tree
+        from extras.mmu.mmu_utils import MmuError
+        self.MmuError = MmuError
+
+        self.hh.boot(calibrate=True)
+        self.assertEqual(self.hh.errors, [], 'bootup was not clean')
+        self.mmu = self.hh.mmu
+        self.unit0 = self.mmu.mmu_machine.get_mmu_unit_by_index(0)
+        self.unit1 = self.mmu.mmu_machine.get_mmu_unit_by_index(1)
+
+        self.assertEqual(self.unit0.gate_bounds(), (0, 8))
+        self.assertEqual(self.unit1.gate_bounds(), (9, 12))
+        self.foreign = 9  # Owned by unit1, so foreign to unit0
+
+    def tearDown(self):
+        self.hh.close()
+
+
+class TestForeignGate(MultiUnitTestCase):
+
+    def test_hardware_accessors_refuse_a_gate_the_unit_does_not_own(self):
+        """
+        The whole point. Clamping a foreign gate to local 0 handed the caller another gate's
+        stepper, which is how a mis-addressed request turned into silently driving the wrong lane.
+        """
+        for name in HARDWARE_ACCESSORS:
+            with self.subTest(accessor=name):
+                with self.assertRaises(self.MmuError) as ctx:
+                    getattr(self.unit0, name)(self.foreign)
+                self.assertIn('not managed by unit0', str(ctx.exception))
+                self.assertIn('range=0-8', str(ctx.exception))
+
+    def test_each_unit_still_resolves_its_own_gates(self):
+        self.assertEqual(self.unit0.gear_name(0), 'unit0_gear')
+        self.assertEqual(self.unit1.gear_name(self.foreign), 'unit1_gear')
+        self.assertIsNot(self.unit0.drive_obj(0), self.unit1.drive_obj(self.foreign))
+
+    def test_default_mode_still_declines_rather_than_raising(self):
+        """
+        Callers on reactor timers, in get_status and in a toolhead lookahead callback branch on
+        this -1 instead of guarding up front. Raising here would reach Klipper's flush path.
+        """
+        self.assertEqual(self.unit0.local_gate(self.foreign), TOOL_GATE_UNKNOWN)
+
+    def test_a_non_gate_is_rejected_as_such(self):
+        with self.assertRaises(self.MmuError):
+            self.unit0.local_gate(None)
+
+
+class TestBypassAndUnknownPassThrough(MultiUnitTestCase):
+    """The negative sentinels are a supported input, not an error - several callers depend on it."""
+
+    def test_sentinels_pass_through_in_default_mode(self):
+        self.assertEqual(self.unit0.local_gate(TOOL_GATE_BYPASS), TOOL_GATE_BYPASS)
+        self.assertEqual(self.unit0.local_gate(TOOL_GATE_UNKNOWN), TOOL_GATE_UNKNOWN)
+
+    def test_sentinels_still_resolve_to_local_gate_zero_for_hardware(self):
+        for gate in (TOOL_GATE_BYPASS, TOOL_GATE_UNKNOWN):
+            with self.subTest(gate=gate):
+                self.assertEqual(self.unit0.gear_name(gate), self.unit0.gear_name(0))
+                self.assertIs(self.unit0.drive_obj(gate), self.unit0.drive_obj(0))
+
+
+class TestRoundTrip(MultiUnitTestCase):
+    """
+    logical_gate/local_gate are inverses, and code holding a local index has to convert back before
+    calling a machine-gate API. Only visible on a unit that doesn't start at gate 0, where the two
+    numbering schemes actually differ.
+    """
+
+    def test_conversion_is_reversible_on_a_later_unit(self):
+        for lgate in range(self.unit1.num_gates):
+            with self.subTest(lgate=lgate):
+                gate = self.unit1.logical_gate(lgate)
+                self.assertEqual(gate, lgate + 9)
+                self.assertEqual(self.unit1.local_gate(gate), lgate)
+
+    def test_a_local_index_used_as_a_machine_gate_is_caught(self):
+        """
+        The failure mode behind the rotary selector fix: local index 2 on unit1 means machine gate
+        11, but passed straight through it reads as gate 2 - another unit's, and it used to resolve
+        to this unit's gate 0 hardware instead of failing.
+        """
+        lgate = 2
+        with self.assertRaises(self.MmuError):
+            self.unit1.drive_obj(lgate)
+        self.assertIs(self.unit1.drive_obj(self.unit1.logical_gate(lgate)),
+                      self.unit1.drive_obj(11))
+
+
+class TestDryingState(MultiUnitTestCase):
+    """
+    Drying state is a per-unit array read and written from the environment timer. A negative index
+    is valid Python, so a foreign gate used to read and overwrite the last gate's slot in silence -
+    and the surrounding try/except never fired because nothing was raised.
+    """
+
+    def env(self):
+        return self.unit0.environment_manager
+
+    def test_a_foreign_gate_does_not_read_another_gates_slot(self):
+        self.assertEqual(self.env()._state_get(self.foreign), '')
+
+    def test_a_foreign_gate_does_not_overwrite_another_gates_slot(self):
+        before = list(self.env()._drying_state)
+        self.env()._state_set(self.foreign, 'active')
+        self.assertEqual(self.env()._drying_state, before,
+                         'writing a foreign gate corrupted this unit\'s state')
+
+    def test_owned_gates_still_round_trip(self):
+        self.env()._state_set(3, 'active')
+        self.assertEqual(self.env()._state_get(3), 'active')
+
+
+class TestHotPathsStayQuiet(MultiUnitTestCase):
+    """
+    The change only raises for hardware, precisely so the paths that cannot tolerate an exception
+    keep declining. This is the regression guard for that.
+    """
+
+    def test_status_polling_survives_a_foreign_selected_gate(self):
+        self.mmu.gate_selected = self.foreign     # unit1's gate, while unit0 objects still poll
+        eventtime = self.hh.reactor.monotonic()
+
+        self.mmu.get_status(eventtime)
+        self.unit0.get_status(eventtime)
+        self.unit0.environment_manager.get_status(eventtime)
+        self.unit0.sync_feedback.get_status(eventtime)
+
+        self.hh.settle(1.0)
+        self.assertEqual(self.hh.errors, [])
+
+    def test_a_deferred_rd_update_declines_instead_of_raising(self):
+        """
+        apply_gear_rd runs from a toolhead lookahead callback. It checks lgate >= 0 before touching
+        the stepper, so a foreign gate must still reach it as -1 rather than as an exception.
+        """
+        self.mmu.gate_selected = self.foreign
+        self.unit0.calibrator.apply_gear_rd(22.5)   # Must not raise
+        self.hh.settle(0.)
+        self.assertEqual(self.hh.errors, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_mmu_local_gate.py
+++ b/test/test_mmu_local_gate.py
@@ -11,10 +11,12 @@
 # entirely: there is no correct local index, so demanding physical hardware for one now raises
 # instead of silently clamping to this unit's gate 0.
 #
-# Default mode still returns -1 for a foreign gate, because roughly sixteen callers treat that as a
-# "not mine, use a default" signal (mmu_calibrator, mmu_environment_manager, mmu_nfc_manager) and
-# some of them sit on a reactor timer, in get_status, or in a toolhead lookahead callback where
-# raising would be far worse than declining.
+# The conversion refuses a foreign gate in BOTH modes. It used to return -1 in default mode, and
+# roughly sixteen callers branched on that as a "not mine, use a default" signal - several of them
+# on a reactor timer, in get_status, or in a toolhead lookahead callback where raising would be far
+# worse than declining. Those now test owns_gate() before converting, so the decision about what a
+# foreign gate means is made by the caller that knows, rather than smuggled through a return value
+# indistinguishable from a legitimate bypass.
 #
 # Uses 'ercf_vvd', the only multi-unit profile - on a single-unit machine a foreign gate cannot be
 # expressed at all, so none of this is testable.
@@ -78,12 +80,15 @@ class TestForeignGate(MultiUnitTestCase):
         self.assertEqual(self.unit1.gear_name(self.foreign), 'unit1_gear')
         self.assertIsNot(self.unit0.drive_obj(0), self.unit1.drive_obj(self.foreign))
 
-    def test_default_mode_still_declines_rather_than_raising(self):
+    def test_conversion_refuses_a_foreign_gate_in_both_modes(self):
         """
-        Callers on reactor timers, in get_status and in a toolhead lookahead callback branch on
-        this -1 instead of guarding up front. Raising here would reach Klipper's flush path.
+        Callers that can legitimately be handed another unit's gate now test owns_gate() up
+        front, so there is no longer a mode in which the conversion quietly returns something.
         """
-        self.assertEqual(self.unit0.local_gate(self.foreign), TOOL_GATE_UNKNOWN)
+        with self.assertRaises(self.MmuError):
+            self.unit0.local_gate(self.foreign)
+        with self.assertRaises(self.MmuError):
+            self.unit0.local_gate(self.foreign, force_physical=True)
 
     def test_a_non_gate_is_rejected_as_such(self):
         with self.assertRaises(self.MmuError):
@@ -102,6 +107,52 @@ class TestBypassAndUnknownPassThrough(MultiUnitTestCase):
             with self.subTest(gate=gate):
                 self.assertEqual(self.unit0.gear_name(gate), self.unit0.gear_name(0))
                 self.assertIs(self.unit0.drive_obj(gate), self.unit0.drive_obj(0))
+
+
+class TestCallersDeclineRatherThanConvert(MultiUnitTestCase):
+    """
+    Now that the conversion refuses a foreign gate, every caller that can be handed one has to
+    decide for itself. These are the paths that previously leaned on the -1 return, several of
+    them on a reactor timer, in get_status, or in a lookahead callback - so a raise escaping any
+    of them is worse than the bug being fixed.
+    """
+
+    def calibrator(self):
+        return self.unit0.calibrator
+
+    def test_calibrator_queries_fall_back_instead_of_raising(self):
+        cal = self.calibrator()
+        self.assertEqual(cal.get_bowden_length(self.foreign), cal.get_bowden_length(0))
+        self.assertEqual(cal.get_default_gear_rd(self.foreign), cal.get_default_gear_rd(0))
+        self.assertTrue(cal.is_bowden_length_calibrated(self.foreign))
+        self.assertTrue(cal.is_gear_rd_calibrated(self.foreign))
+        self.assertGreater(cal.get_gear_rd(self.foreign), 0)
+
+    def test_calibrator_mutations_decline_quietly(self):
+        cal = self.calibrator()
+        bowden_before = list(cal._bowden_lengths)
+        rd_before = list(cal.rotation_distances)
+
+        cal.update_bowden_length(123.4, gate=self.foreign)
+        cal.update_gear_rd(22.5, gate=self.foreign)
+        cal.apply_gear_rd(22.5, gate=self.foreign)
+        cal.restore_gear_rd(gate=self.foreign)
+
+        self.assertEqual(cal._bowden_lengths, bowden_before, 'wrote a foreign gate\'s bowden length')
+        self.assertEqual(cal.rotation_distances, rd_before, 'wrote a foreign gate\'s rotation distance')
+        self.assertEqual(self.hh.errors, [])
+
+    def test_nfc_predicates_answer_no_rather_than_throwing(self):
+        nfc = self.unit0.nfc_manager
+        self.assertFalse(nfc.has_gate_nfc_reader(self.foreign))
+        self.assertIsNone(nfc._local_index(self.foreign))
+        self.assertIsNone(nfc._local_index(None))
+
+    def test_environment_lookups_report_nothing_configured(self):
+        env = self.unit0.environment_manager
+        self.assertEqual(env._get_environment_status(self.foreign), (None, None))
+        self.assertEqual(env._get_heater_status(self.foreign), (None, None))
+        self.assertEqual(self.hh.errors, [])
 
 
 class TestRoundTrip(MultiUnitTestCase):

--- a/test/test_mmu_selector.py
+++ b/test/test_mmu_selector.py
@@ -600,10 +600,8 @@ class TestPersistedPositionRestore(unittest.TestCase):
         this path at all - so a boot-level assertion about "the other unit" would pass even with
         the guard deleted.
 
-        The errors assertion is the part that bites. Without the guard the answer is STILL None,
-        because local_gate() refuses too - but it refuses via log_assertion("Fatal: Gate 12 is
-        not managed by unit0"), so every boot of a multi-unit machine would carry a fatal-looking
-        line about nothing being wrong.
+        The guard is now load-bearing rather than cosmetic: local_gate() raises for a gate the
+        unit does not own, so without the ownership check this would throw instead of declining.
         """
         from extras.mmu.mmu_constants import VARS_MMU_GATE_SELECTED
 


### PR DESCRIPTION
## The bug

`local_gate()` converts a machine-wide gate to a unit-local index. For a positive gate the unit does **not** manage it logged a `"Fatal:"` assertion that does not abort, returned `-1`, and then — under `force_physical` — clamped that to local gate **0**.

So asking a unit for hardware belonging to a gate it does not own handed back its own gate 0's stepper, drive, TMC or default current. That is the step that turns a bad gate number into plausible-looking hardware rather than a failure.

## Two commits

**1. Refuse a foreign gate for hardware.** The two negative cases are not the same thing: bypass and unknown are a supported input, and resolving them to local gate 0 is a documented default several callers rely on — untouched. A foreign *positive* gate has no correct local index.

**2. Make callers decide what a foreign gate means.** The first commit left default mode returning `-1`, which roughly sixteen callers branched on as a "not mine, use a default" signal — so a programming error and a legitimate decline arrived as the same number. It now raises in both modes, and every one of those callers tests ownership up front instead.

Adds `MmuUnit.owns_gate()`: a real gate on this unit, excluding the bypass/unknown sentinels that `manages_gate()` deliberately accepts. That is the predicate all sixteen sites wanted; most previously encoded it as `lgate < 0` after the fact, or tangled it into a genuine bounds check.

Converted: the nine calibrator entry points, the four environment-manager heater/sensor lookups plus the two drying-state accessors, both NFC predicates, and the harness's `selector_offset` helper. Behaviour at each is unchanged — queries fall back, mutations decline, predicates answer no — so the reactor timer, `get_status` and toolhead lookahead paths that reach these still cannot throw. **That was the condition for raising at all**, and each was probed with a foreign gate before the suite was run.

## Three call sites of the same family

- The rotary selector handed a unit-local index to `drive_obj()`, which takes a machine gate. On any unit that does not start at gate 0 this already selected the wrong drive and logged on every grip.
- Rotary selector calibration parsed `GATE` against the unit's gate count but used it as a machine gate, so on a later unit it wrote the last gate's offset and persisted it. The linear selector already ranges against the machine and checks ownership; this now matches.
- Drying state was indexed with an unguarded local gate, so a foreign one silently read and overwrote the last gate's slot. The surrounding `try/except` never fired because negative indices are perfectly valid.

Also removes a dead `lgate` in `restore_gear_rd()` that was computed, clamped, and never read — it was hiding a foreign gate that then threw one line later once `drive_obj()` started raising.

## Testing

`make test` — 928 tests, skipped=1, expected failures=4 (the documented clean baseline).

Adds `test/test_mmu_local_gate.py`, 17 tests on `ercf_vvd`, the only multi-unit profile — on a single-unit machine a foreign gate cannot be expressed at all. Seven fail against the tree before commit 1; the decline tests fail against a tree with the new raise but the old guards, which is precisely the intermediate state commit 2 exists to avoid.

**Not covered:** the two rotary fixes. The only rotary profile is single-unit and starts at gate 0, where the conversion is an identity, so there is nothing to observe. The round-trip they depend on is tested on a unit that does not start at gate 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)