### PR TITLE
Fix inverted gate_parking_distance check in filament position recovery

### DIFF
--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -3252,7 +3252,7 @@ class MmuFilamentMovement:
             self.set_filament_pos_state(FILAMENT_POS_HOMED_ENTRY, silent=silent) # Allows for fast bowden unload move
 
         # Parked at gate (when parking distance is not a retract i.e. gs sensor expected to be triggered)
-        elif gs and filament_detected and u.p.gate_parking_distance <= 0:
+        elif gs and filament_detected and u.p.gate_parking_distance >= 0:
             self.set_filament_pos_state(FILAMENT_POS_UNLOADED, silent=silent)
 
         # Somewhere in bowden


### PR DESCRIPTION
## Summary
- `recover_filament_pos()` (used by `MMU_RECOVER` and other recovery paths) misread a triggered exit/gate sensor as "somewhere in the bowden" even when the gate's `gate_parking_distance` is non-negative, in which case the sensor being triggered is the expected resting state for filament parked at the gate (unloaded).
- The branch's own comment described the intended condition correctly ("parking distance is not a retract i.e. gs sensor expected to be triggered"), but the comparison was `gate_parking_distance <= 0` — the retract case — which is backwards.
- Fixed by flipping the comparison to `>= 0`, matching the sign convention documented in `mmu_unit_parameters.py` (negative = retraction off the sensor, positive = extrusion past the sensor) and already used correctly elsewhere (`mmu_sensor_manager.py`'s `is_parking_retract = (gate_parking_distance < 0)`).

## Test plan
- [x] Confirm `MMU_RECOVER` correctly reports UNLOADED (not IN_BOWDEN) for a gate configured with a non-negative `gate_parking_distance` when its exit sensor is triggered and filament is otherwise detected
- [x] Confirm gates with the default negative (retraction) `gate_parking_distance` still recover to IN_BOWDEN as before when the exit sensor is triggered