### PR TITLE
Stepper run current: model it in the simulator, and move it onto the objects that own the steppers

### DIFF
--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -70,7 +70,6 @@ class MmuController(MmuFilamentMovement):
         self.has_mmu_cutter = False             # Post unload cutting macro (like EREC)
         self.has_toolhead_cutter = False        # Form tip cutting macro (like _MMU_CUT_TIP)
         self._is_running_test = False           # True while running QA or soak tests
-        self.extruder_run_current_percent = 100 # Single value is fine - one shared toolhead extruder
         self._gear_run_current_depth = 0        # Nesting depth of wrap_gear_current(), which locks out changes
         self.p = mmu_machine.params             # Shared Parameters shortcut
 

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -70,9 +70,6 @@ class MmuController(MmuFilamentMovement):
         self.has_mmu_cutter = False             # Post unload cutting macro (like EREC)
         self.has_toolhead_cutter = False        # Form tip cutting macro (like _MMU_CUT_TIP)
         self._is_running_test = False           # True while running QA or soak tests
-        # Run current % per gear stepper, keyed by stepper name rather than gate: a multigear unit
-        # has one stepper per gate but a single-gear unit shares one across all of them
-        self.gear_run_current_percents = {}
         self.extruder_run_current_percent = 100 # Single value is fine - one shared toolhead extruder
         self._gear_run_current_depth = 0        # Nesting depth of wrap_gear_current(), which locks out changes
         self.p = mmu_machine.params             # Shared Parameters shortcut
@@ -153,10 +150,6 @@ class MmuController(MmuFilamentMovement):
         Ensure clean state on initialiaztion and after MMU enable/disable operation
         """
         self.is_enabled = True      # Whether Happy Hare is enabled or not
-
-        # Disable/enable restores every gear stepper to its configured default, so forget what we
-        # believed each was set to rather than carrying a stale record across the cycle
-        self.gear_run_current_percents.clear()
 
         self.filament_monitoring_enabled = False
         # Bracket the last suspend window and the last time we started handling a runout. Together

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -3679,6 +3679,13 @@ class MmuFilamentMovement:
         return self.drive(gate).run_current_percent()
 
 
+    def extruder_run_current(self):
+        """
+        Run current percentage believed to be applied to the selected unit's extruder.
+        """
+        return self.mmu_unit().extruder_wrapper.run_current_percent()
+
+
     def _adjust_gear_current(self, gate=None, percent=100, reason="", restore=False):
         """
         Apply a gear-stepper run-current percentage change when allowed.
@@ -3766,25 +3773,24 @@ class MmuFilamentMovement:
         Returns:
             int or float: Previously active or currently retained extruder-current percentage.
         """
-        u = self.mmu_unit()
-
-        current_percent = self.extruder_run_current_percent
+        wrapper = self.mmu_unit().extruder_wrapper
+        current_percent = wrapper.run_current_percent()
 
         if not (0 < percent < 200):
             return current_percent
-        if u.extruder_tmc_obj() is None:
+        if wrapper.extruder_tmc_obj() is None:
             return current_percent
-        if percent == self.extruder_run_current_percent:
+        if percent == current_percent:
             return current_percent
 
-        sname = u.extruder_name()
+        sname = wrapper.extruder_name()
         if restore:
             msg = "Restoring extruder stepper %s run current to %d%% ({}A)" % (sname, percent)
         else:
             msg = "Modifying extruder stepper %s run current to %d%% ({}A) %s" % (sname, percent, reason)
-        target_current = (u.extruder_default_current() * percent) / 100.0
+        target_current = (wrapper.extruder_default_current() * percent) / 100.0
         self._set_tmc_current(sname, target_current, msg)
-        self.extruder_run_current_percent = percent # Update global record of current %
+        wrapper.set_run_current_percent(percent)
         return current_percent
 
 

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -3676,10 +3676,7 @@ class MmuFilamentMovement:
         """
         Run current percentage believed to be applied to a gate's gear stepper.
         """
-        if gate is None:
-            gate = self.gate_selected
-        sname = self.mmu_unit(gate).gear_name(gate)
-        return self.gear_run_current_percents.get(sname, 100)
+        return self.drive(gate).run_current_percent()
 
 
     def _adjust_gear_current(self, gate=None, percent=100, reason="", restore=False):
@@ -3695,21 +3692,21 @@ class MmuFilamentMovement:
         Returns:
             int or float: Previously active or currently retained gear-current percentage.
         """
-        # Resolve the gate before naming the stepper - gear_name() cannot take None
+        # Resolve the gate before the drive - the accessors cannot take None
         if gate is None:
             gate = self.gate_selected
-        u = self.mmu_unit(gate)
-
         if gate < 0:
             return 100
-        sname = u.gear_name(gate)
-        current_percent = self.gear_run_current_percents.get(sname, 100)
+
+        drive = self.drive(gate)
+        sname = drive.get_name()
+        current_percent = drive.run_current_percent()
 
         if self._gear_run_current_depth:
             return current_percent
         if not (0 < percent < 200):
             return current_percent
-        if u.gear_tmc_obj(gate) is None:
+        if drive.tmc_obj() is None:
             return current_percent
         if percent == current_percent:
             return current_percent
@@ -3718,9 +3715,9 @@ class MmuFilamentMovement:
             msg = "Restoring MMU %s run current to %d%% ({}A)" % (sname, percent)
         else:
             msg = "Modifying MMU %s run current to %d%% ({}A) %s" % (sname, percent, reason)
-        target_current = (u.gear_default_current(gate) * percent) / 100.0
+        target_current = (drive.default_current() * percent) / 100.0
         self._set_tmc_current(sname, target_current, msg)
-        self.gear_run_current_percents[sname] = percent
+        drive.set_run_current_percent(percent)
         return current_percent
 
 

--- a/extras/mmu/mmu_unit.py
+++ b/extras/mmu/mmu_unit.py
@@ -582,23 +582,11 @@ class MmuUnit:
     def handle_connect(self):
         self.mmu = self.mmu_machine.mmu_controller # Master MMU controller
 
-        # Find and record all gear steppers, controlling tmc chip (if available) and default current indexed by gate
-        self.mmu_gear_tmcs = []
-        self.mmu_gear_currents = []
-
-        for name in self.mmu_gear_names:
-            for chip in TMC_CHIPS:
-                c = self.printer.lookup_object("%s mmu_stepper %s" % (chip, name), None)
-                if c is not None:
-                    self.mmu_gear_tmcs.append(c)
-                    self.mmu_gear_currents.append(c.get_status(0).get("run_current"))
-                    break
-            else:
-                self.mmu_gear_tmcs.append(None)
-                self.mmu_gear_currents.append(None)
-
-        gates_with_tmc    = [i + self.first_gate for i, tmc in enumerate(self.mmu_gear_tmcs) if tmc is not None]
-        gates_without_tmc = [i + self.first_gate for i, tmc in enumerate(self.mmu_gear_tmcs) if tmc is None]
+        # Each drive resolved its own tmc chip and default current at connect. Report per gate:
+        # a single-gear unit shares one drive across all of them, so every gate is covered
+        gate_tmcs = [drive.tmc_obj() for drive in self.drives]
+        gates_with_tmc    = [i + self.first_gate for i, tmc in enumerate(gate_tmcs) if tmc is not None]
+        gates_without_tmc = [i + self.first_gate for i, tmc in enumerate(gate_tmcs) if tmc is None]
 
         if gates_with_tmc:
             self.mmu.log_debug(
@@ -743,12 +731,10 @@ class MmuUnit:
         return self.drives[lgate]
 
     def gear_tmc_obj(self, gate):
-        lgate = self.local_gate(gate, True)
-        return self.mmu_gear_tmcs[lgate]
+        return self.drive_obj(gate).tmc_obj()
 
     def gear_default_current(self, gate):
-        lgate = self.local_gate(gate, True)
-        return self.mmu_gear_currents[lgate]
+        return self.drive_obj(gate).default_current()
 
 
     # Parallel accessors extruder stepper to match MMU gear stepper accessors

--- a/extras/mmu/mmu_unit.py
+++ b/extras/mmu/mmu_unit.py
@@ -301,8 +301,11 @@ class MmuUnit:
                             logging.info("MMU: Loaded: [%s]" % alt_tmc_section)
                             break
 
-        # Now load the mmu_steppers and create control wrappers
+        # Now load the mmu_steppers and create control wrappers.
+        # 'drives' is gate-indexed and repeats the same object on a single-gear unit, so
+        # 'drives_unique' exists for anything that must touch each drive exactly once
         self.drives = []
+        self.drives_unique = []
         drive = None
         for i, sname in enumerate(self.mmu_gear_names):
             if drive is None or self.multigear:
@@ -313,6 +316,7 @@ class MmuUnit:
                 self.printer.add_object(c.get_name(), gear)
                 logging.info(f"MMU: Loaded: [{section}]")
                 drive = MmuDrive(config, self, gear, self.extruder_wrapper.homing_extruder_stepper)
+                self.drives_unique.append(drive)
 
             logging.info(f"MMU: Created: MmuDrive for gate {self.first_gate + i} using mmu_stepper {sname}")
             self.drives.append(drive)
@@ -619,6 +623,10 @@ class MmuUnit:
 
 
     def reinit(self):
+        # Drives are not subcomponents (shared objects deliberately are not), so walk them here
+        for drive in self.drives_unique:
+            drive.reinit()
+
         for obj in self.subcomponents:
             if obj is not None:
                 method = getattr(obj, "reinit", None)

--- a/extras/mmu/mmu_unit.py
+++ b/extras/mmu/mmu_unit.py
@@ -623,9 +623,12 @@ class MmuUnit:
 
 
     def reinit(self):
-        # Drives are not subcomponents (shared objects deliberately are not), so walk them here
+        # Drives and the extruder wrapper are not subcomponents (shared objects deliberately are
+        # not), so walk them here. The wrapper may be shared with another unit, but its reset is
+        # idempotent so reaching it once per unit costs nothing
         for drive in self.drives_unique:
             drive.reinit()
+        self.extruder_wrapper.reinit()
 
         for obj in self.subcomponents:
             if obj is not None:

--- a/extras/mmu/unit/mmu_drive.py
+++ b/extras/mmu/unit/mmu_drive.py
@@ -40,6 +40,7 @@ class MmuDrive():
         # Resolved at connect. None until then, and None for a stepper with no TMC
         self._tmc = None
         self._default_current = None
+        self._run_current_percent = 100
 
         # Event handlers
         self.printer.register_event_handler('klippy:connect', self.handle_connect)
@@ -58,12 +59,27 @@ class MmuDrive():
                 break
 
 
+    def reinit(self):
+        # Record only. Runs during config load, before handle_connect, so nothing here may
+        # touch self.mmu. Enable/disable restores the driver to its configured default, so
+        # forgetting what we believed is the whole job
+        self._run_current_percent = 100
+
+
     def tmc_obj(self):
         return self._tmc
 
 
     def default_current(self):
         return self._default_current
+
+
+    def run_current_percent(self):
+        return self._run_current_percent
+
+
+    def set_run_current_percent(self, percent):
+        self._run_current_percent = percent
 
 
     def sync_mode(self, mode):

--- a/extras/mmu/unit/mmu_drive.py
+++ b/extras/mmu/unit/mmu_drive.py
@@ -37,12 +37,33 @@ class MmuDrive():
         self._sync_mode = DRIVE_UNSYNCED
         self._driving_stepper = self.mmu_gear_stepper
 
+        # Resolved at connect. None until then, and None for a stepper with no TMC
+        self._tmc = None
+        self._default_current = None
+
         # Event handlers
         self.printer.register_event_handler('klippy:connect', self.handle_connect)
 
 
     def handle_connect(self):
         self.mmu = self.mmu_machine.mmu_controller # Master MMU controller
+
+        # Our own driver, found by stepper name. Runs before MmuUnit.handle_connect, so the
+        # unit's per-gate accessors read back through here rather than resolving separately
+        for chip in TMC_CHIPS:
+            c = self.printer.lookup_object("%s mmu_stepper %s" % (chip, self.name), None)
+            if c is not None:
+                self._tmc = c
+                self._default_current = c.get_status(0).get("run_current")
+                break
+
+
+    def tmc_obj(self):
+        return self._tmc
+
+
+    def default_current(self):
+        return self._default_current
 
 
     def sync_mode(self, mode):

--- a/extras/mmu/unit/mmu_extruder_wrapper.py
+++ b/extras/mmu/unit/mmu_extruder_wrapper.py
@@ -36,6 +36,9 @@ class MmuExtruderWrapper():
         self.filament_remaining = 0.            # The amount of filament remaining in extruder hotend
         self.filament_remaining_color = UNKNOWN_FILAMENT_COLOR # Color of remaining filament
 
+        # Per physical extruder, not per machine: units on different extruders each have their own
+        self._run_current_percent = 100
+
         # Build homing extruder stepper if option enabled ---------------------------------------------------
 
         self.homing_extruder_stepper = None
@@ -149,6 +152,20 @@ class MmuExtruderWrapper():
 
     def extruder_default_current(self):
         return self._extruder_current
+
+
+    def run_current_percent(self):
+        return self._run_current_percent
+
+
+    def set_run_current_percent(self, percent):
+        self._run_current_percent = percent
+
+
+    def reinit(self):
+        # Record only, and safe pre-connect. Enable/disable restores the driver to its
+        # configured default, so all we do is forget what we believed
+        self._run_current_percent = 100
 
 
     def set_filament_remaining(self, length, color=UNKNOWN_FILAMENT_COLOR):

--- a/test/console.py
+++ b/test/console.py
@@ -857,8 +857,8 @@ class Console:
         """
         Unknown commands are recorded and ignored (gcode.py:230), so a typo produces no
         output whatsoever. Only warn about the line the user actually typed: Happy Hare
-        legitimately emits M104/M117/SET_TMC_CURRENT into the same list, which is why
-        strict mode is not the answer here.
+        legitimately emits M104/M117 into the same list, which is why strict mode is not
+        the answer here.
         """
         typed = line.strip().split(None, 1)[0].upper() if line.strip() else ''
         for raw in self.hh.gcode.unhandled[mark:]:
@@ -925,6 +925,7 @@ class Console:
         if bowden >= 0:
             extra.append('bowden=%d%%' % bowden)
         extra.append('t=%+.2fs' % (self.hh.reactor.monotonic() - 1000.))
+        extra.extend(self._current_cells(gate))
         # Only when pacing is ON. 0 is the default and means "moves are instant", which is
         # the absence of a mode rather than a mode - and a permanent 'realtime=0%' would just
         # be a row of noise on every prompt. Shown next to the clock because that is the
@@ -938,6 +939,36 @@ class Console:
             out.append(paint('  PAUSED: %s  (MMU_UNLOCK / MMU_RECOVER)'
                              % (st.get('reason_for_pause') or 'unknown'), '1;31', self.color))
         return out
+
+    def _current_cells(self, gate):
+        """
+        Stepper run current, as HH believes it and as the modelled driver holds it. Shown
+        always: watching the number move is the point, and a cell that only appears when
+        off-default hides the resting state. Amps come from the TMC so a divergence between
+        HH's percentage and the driver is visible rather than inferred.
+        """
+        mmu = self.hh.mmu
+        cells = []
+        for label, pct, tmc in (
+            ('gear', mmu.gear_run_current(gate), self._tmc_for_gate(gate)),
+            ('ext', mmu.extruder_run_current_percent, self._extruder_tmc()),
+        ):
+            amps = tmc.get_status().get('run_current') if tmc else None
+            cells.append('%s=%d%%' % (label, pct) if amps is None
+                         else '%s=%d%% %.2fA' % (label, pct, amps))
+        return cells
+
+    def _tmc_for_gate(self, gate):
+        try:
+            return self.hh.mmu.mmu_unit(gate).gear_tmc_obj(gate)
+        except Exception:
+            return None # No TMC on this gate, or too early to resolve one
+
+    def _extruder_tmc(self):
+        try:
+            return self.hh.mmu.mmu_unit().extruder_tmc_obj()
+        except Exception:
+            return None
 
     def _hdr_sensors(self, st):
         # NOT status['sensors']: that is only the selected gate's sensors and it carries

--- a/test/console.py
+++ b/test/console.py
@@ -951,7 +951,7 @@ class Console:
         cells = []
         for label, pct, tmc in (
             ('gear', mmu.gear_run_current(gate), self._tmc_for_gate(gate)),
-            ('ext', mmu.extruder_run_current_percent, self._extruder_tmc()),
+            ('ext', mmu.extruder_run_current(), self._extruder_tmc()),
         ):
             amps = tmc.get_status().get('run_current') if tmc else None
             cells.append('%s=%d%%' % (label, pct) if amps is None

--- a/test/hh/klippy_root/extras/tmc.py
+++ b/test/hh/klippy_root/extras/tmc.py
@@ -1,13 +1,15 @@
 # Fake Klipper extras/tmc.py (+ per-chip shims) for the Happy Hare test harness.
 #
-# Two jobs:
+# Three jobs:
 #
-# 1. get_status() must expose 'run_current'. That is the ONLY field HH reads
-#    (extras/mmu/mmu_unit.py:593, extras/mmu/unit/mmu_extruder_wrapper.py:109).
-#    Current CHANGES go out as SET_TMC_CURRENT gcode
-#    (extras/mmu/mmu_filament_movement.py:3489), so no setter is needed.
+# 1. get_status() must expose 'run_current'. HH snapshots it once at connect as each
+#    stepper's default (extras/mmu/mmu_unit.py, extras/mmu/unit/mmu_extruder_wrapper.py).
 #
-# 2. It must register a pin chip named "<chip>_<stepper>" exposing 'virtual_endstop',
+# 2. It must model SET_TMC_CURRENT, so run_current actually tracks what HH asked for.
+#    Without the handler the command falls through gcode.py's ignore-unknown path and the
+#    modelled current never moves - the console shows HH's intent with nothing behind it.
+#
+# 3. It must register a pin chip named "<chip>_<stepper>" exposing 'virtual_endstop',
 #    mirroring Klipper's TMCVirtualPinHelper. The rendered BoxTurtle config relies on
 #    this: [mmu_stepper unit0_gear] has
 #        extra_endstops: mmu_gear_touch=tmc2209_unit0_gear:virtual_endstop
@@ -34,12 +36,40 @@ class TMCCommandHelper:
         self.diag_pin = config.get('diag_pin', None)
         self.mcu_tmc = mcu_tmc
         self.echeck_helper = None
+        self.max_current = config.getfloat('max_current', 2.0, above=0.)
         self.current_changes = []       # test assertion surface
+
+        # Keyed on STEPPER= exactly as real Klipper's TMCCommandHelper does. HH changes gear
+        # and extruder current by emitting this gcode, so without the handler the modelled
+        # driver never moves and any test or panel reading it is reading the config default.
+        self.printer.lookup_object('gcode').register_mux_command(
+            'SET_TMC_CURRENT', 'STEPPER', self.stepper_name,
+            self._cmd_SET_TMC_CURRENT,
+            desc='Set the current of a TMC driver')
+
+    def get_current(self):
+        return self.run_current, self.hold_current, self.hold_current, self.max_current
 
     def set_current(self, run_current, hold_current, print_time):
         self.run_current = run_current
         self.hold_current = hold_current
         self.current_changes.append((print_time, run_current, hold_current))
+
+    def _cmd_SET_TMC_CURRENT(self, gcmd):
+        # Mirrors real Klipper: both args optional, a bare call is a query, and the reported
+        # value is re-read after applying so it is the applied current, not the requested one.
+        run_current = gcmd.get_float('CURRENT', None, minval=0., maxval=self.max_current)
+        hold_current = gcmd.get_float('HOLDCURRENT', None, above=0., maxval=self.max_current)
+
+        if run_current is not None or hold_current is not None:
+            prev_run, _prev_hold, req_hold, _max = self.get_current()
+            toolhead = self.printer.lookup_object('toolhead')
+            self.set_current(prev_run if run_current is None else run_current,
+                             req_hold if hold_current is None else hold_current,
+                             toolhead.get_last_move_time())
+
+        gcmd.respond_info("Run Current: %0.2fA Hold Current: %0.2fA"
+                          % (self.run_current, self.hold_current))
 
     def get_status(self, eventtime=None):
         return {
@@ -86,6 +116,8 @@ class TMC:
         # HH reads run_current straight off get_status()
         self.get_status = self.cmd_helper.get_status
         self.set_current = self.cmd_helper.set_current
+        self.get_current = self.cmd_helper.get_current
+        self.current_changes = self.cmd_helper.current_changes
 
     def get_phase_offset(self):
         return None, 256

--- a/test/hh/klippy_root/gcode.py
+++ b/test/hh/klippy_root/gcode.py
@@ -18,7 +18,7 @@
 # CANCEL_PRINT (extras/mmu/mmu_controller.py:245-252).
 #
 # Unknown commands are recorded and ignored by default (HH legitimately issues
-# M104/M117/M220/SET_TMC_CURRENT/... owned by Klipper modules we do not fake), with
+# M104/M117/M220/... owned by Klipper modules we do not fake), with
 # strict=True to turn them into errors for targeted tests. `unhandled` is asserted on
 # in one test so the set stays visible and changes get reviewed.
 #

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -476,12 +476,51 @@ ERCF_VVD = Profile(
     ],
     description='ERCF 1.1sb (9 gates) + ViViD 1.0 (4 gates) - the only multi-unit profile')
 
+# The only machine whose two units drive DIFFERENT physical extruders. Everything else, including
+# ercf_vvd itself, leaves both on the default one and so shares a single MmuExtruderWrapper - which
+# hides anything that treats extruder state as machine-wide. Needs [extruder1] and its mandatory
+# TMC section added to the printer stub; see EXTRA_EXTRUDER_STUB.
+ERCF_VVD_DUAL_EXTRUDER = ERCF_VVD.derive(
+    'ercf_vvd_dual_extruder',
+    units=[
+        ERCF_VVD.units[0],
+        ERCF_VVD.units[1].derive(syms={'PARAM_EXTRUDER_NAME': 'extruder1'}),
+    ],
+    description='ercf_vvd with each unit on its own extruder')
+
+# Appended to bootstrap.PRINTER_STUB by tests using the profile above. The TMC section is not
+# optional - MmuExtruderWrapper raises without one for the extruder it is given.
+EXTRA_EXTRUDER_STUB = """
+[extruder1]
+step_pin: mcu:PB1
+dir_pin: mcu:PB2
+enable_pin: !mcu:PB3
+microsteps: 16
+full_steps_per_rotation: 200
+rotation_distance: 22.0
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: mcu:PB4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: mcu:PB5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 300
+
+[tmc2209 extruder1]
+uart_pin: mcu:PB6
+run_current: 0.6
+"""
+
 PROFILES = {p.name: p for p in (BOXTURTLE, TRADRACK, CHAMELEON, EMU, ENCODER, NFC_SINGLE,
                                 NFC_PER_GATE, NFC_PN5180, NFC_PN5180_PER_GATE,
                                 NFC_PN532, NFC_PN532_SW_I2C,
                                 NFC_PN532_UART, NFC_PN532_UART_PER_GATE,
                                 NFC_SPOOLMAN, NFC_SPOOLMAN_SHARED,
-                                ERCF_VVD)}
+                                ERCF_VVD, ERCF_VVD_DUAL_EXTRUDER)}
 
 
 def get(name):

--- a/test/test_mmu_current_nesting.py
+++ b/test/test_mmu_current_nesting.py
@@ -1,0 +1,105 @@
+# Happy Hare test harness - the two stepper-current nesting policies.
+#
+# wrap_gear_current and wrap_extruder_current look identical at the call site and behave
+# differently on purpose:
+#
+#   gear      outermost wins. The depth counter also acts as a global lockout on ALL gear current
+#             traffic, which is what stops move_filament - it re-asserts current on every move -
+#             and the async sync-feedback timer from clobbering a wrapped block.
+#   extruder  fully re-entrant. Nothing contends for it, so an inner wrap exits back to the
+#             outer's percentage rather than being ignored.
+#
+# Nothing pinned that until now: the only test touching either wrapper asserts "did not throw".
+# This file is a characterisation pin, written ahead of a refactor that moves the current record
+# onto the per-stepper objects. Its job is to fail if that refactor quietly unifies the policies.
+#
+# A characterisation test passes on current code by construction, so its value rests entirely on
+# having been mutation-checked: giving the gear wrapper the extruder's policy must take the gear
+# count from 2 to 4.
+#
+# 'emu' because the wrappers only emit when a gate is selected (a negative gate short-circuits
+# before the stepper is named) and because its sync_gear_current differs from the driver default.
+#
+# Known-uncovered adjacency, recorded here because this is where someone will look: the selector
+# calibration command nests wrap_gear_current INSIDE wrap_sync_gear_to_extruder. Exits run
+# innermost-first, so the gear wrap clears the depth before the sync re-apply runs. Reverse that
+# nesting and the sync re-apply is silently swallowed by the lockout.
+#
+#   ./venv/bin/python -m unittest test.test_mmu_current_nesting
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+import unittest
+
+from test.hh import session
+
+logging.getLogger().setLevel(logging.CRITICAL)
+
+
+class CurrentNestingTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.hh = session('emu')
+        self.hh.boot()
+        self.assertEqual(self.hh.errors, [], 'bootup was not clean')
+        self.mmu = self.hh.mmu
+        self.unit = self.mmu.mmu_unit()
+        # A negative gate short-circuits before a stepper is named, so a pin written without
+        # this counts zero emissions against zero and proves nothing
+        self.assertEqual(self.mmu.gate_selected, 0, 'no gate selected - the gear wrap cannot emit')
+
+    def tearDown(self):
+        self.hh.close()
+
+    def currents(self):
+        return [line for line in self.hh.gcode.executed if line.startswith('SET_TMC_CURRENT')]
+
+
+class TestGearIsOutermostWins(CurrentNestingTestCase):
+
+    def test_a_nested_gear_wrap_emits_only_the_outer_pair(self):
+        default = self.unit.gear_default_current(0)
+        tmc = self.unit.gear_tmc_obj(0)
+        mark, changes = len(self.currents()), len(tmc.current_changes)
+
+        with self.mmu.wrap_gear_current(percent=80, reason="outer"):
+            with self.mmu.wrap_gear_current(percent=40, reason="inner"):
+                pass
+
+        emitted = self.currents()[mark:]
+        self.assertEqual(len(emitted), 2, 'expected apply+restore only, got %s' % emitted)
+        for line in emitted:
+            self.assertIn('STEPPER=%s' % self.unit.gear_name(0), line)
+
+        applied = [run for _t, run, _h in tmc.current_changes[changes:]]
+        self.assertEqual(len(applied), 2)
+        self.assertAlmostEqual(applied[0], default * 0.80, places=3)
+        self.assertAlmostEqual(applied[1], default, places=3)
+        self.assertEqual(self.mmu.gear_run_current(0), 100)
+
+
+class TestExtruderNestsFully(CurrentNestingTestCase):
+
+    def test_a_nested_extruder_wrap_emits_every_level(self):
+        default = self.unit.extruder_default_current()
+        tmc = self.unit.extruder_tmc_obj()
+        mark, changes = len(self.currents()), len(tmc.current_changes)
+
+        with self.mmu.wrap_extruder_current(percent=80, reason="outer"):
+            with self.mmu.wrap_extruder_current(percent=40, reason="inner"):
+                pass
+
+        emitted = self.currents()[mark:]
+        self.assertEqual(len(emitted), 4, 'expected both levels to apply and restore, got %s' % emitted)
+        for line in emitted:
+            self.assertIn('STEPPER=%s' % self.unit.extruder_name(), line)
+
+        applied = [run for _t, run, _h in tmc.current_changes[changes:]]
+        self.assertEqual([round(a / default, 2) for a in applied], [0.80, 0.40, 0.80, 1.00],
+                         'inner wrap must restore to the outer percentage, not to the default')
+        self.assertEqual(self.mmu.extruder_run_current_percent, 100)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_mmu_current_nesting.py
+++ b/test/test_mmu_current_nesting.py
@@ -98,7 +98,7 @@ class TestExtruderNestsFully(CurrentNestingTestCase):
         applied = [run for _t, run, _h in tmc.current_changes[changes:]]
         self.assertEqual([round(a / default, 2) for a in applied], [0.80, 0.40, 0.80, 1.00],
                          'inner wrap must restore to the outer percentage, not to the default')
-        self.assertEqual(self.mmu.extruder_run_current_percent, 100)
+        self.assertEqual(self.mmu.extruder_run_current(), 100)
 
 
 if __name__ == '__main__':

--- a/test/test_mmu_stepper_current.py
+++ b/test/test_mmu_stepper_current.py
@@ -1,0 +1,102 @@
+# Happy Hare test harness - stepper run current, modelled end to end.
+#
+# HH changes gear and extruder current by emitting SET_TMC_CURRENT gcode, which real Klipper
+# handles in its TMC module. The harness used to have no handler, so the command fell through the
+# ignore-unknown path: HH's own log line appeared, the driver never moved, and any assertion about
+# the resulting current was really asserting the config default.
+#
+# So these tests are about the SIMULATION being faithful, not about HH's logic. They pin the three
+# things that make a current change observable: the modelled driver tracks it, the change is
+# recorded, and Klipper's own acknowledgment reaches the console alongside HH's line.
+#
+# 'emu' because its sync_gear_current is 52 rather than 100 - on a machine where it equals the
+# driver default every change is suppressed as a no-op and nothing is observable at all.
+#
+#   ./venv/bin/python -m unittest test.test_mmu_stepper_current
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+import unittest
+
+from test.hh import session
+
+logging.getLogger().setLevel(logging.CRITICAL)
+
+
+class StepperCurrentTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.hh = session('emu')
+        self.hh.boot()
+        self.assertEqual(self.hh.errors, [], 'bootup was not clean')
+        self.mmu = self.hh.mmu
+        self.unit = self.mmu.mmu_unit()
+        self.tmc = self.unit.gear_tmc_obj(0)
+        self.default = self.unit.gear_default_current(0)
+        self.assertTrue(self.default, 'profile has no TMC on gate 0 - nothing to model')
+
+    def tearDown(self):
+        self.hh.close()
+
+
+class TestModelledDriver(StepperCurrentTestCase):
+
+    def test_a_current_change_moves_the_modelled_driver(self):
+        self.assertAlmostEqual(self.tmc.get_status()['run_current'], self.default, places=3)
+
+        self.mmu._adjust_gear_current(gate=0, percent=50, reason="test")
+
+        self.assertAlmostEqual(self.tmc.get_status()['run_current'], self.default * 0.5, places=3)
+
+    def test_the_change_is_recorded_for_assertion(self):
+        mark = len(self.tmc.current_changes)
+        self.mmu._adjust_gear_current(gate=0, percent=50, reason="test")
+
+        recorded = self.tmc.current_changes[mark:]
+        self.assertEqual(len(recorded), 1)
+        _print_time, run_current, _hold = recorded[0]
+        self.assertAlmostEqual(run_current, self.default * 0.5, places=3)
+
+    def test_each_stepper_is_modelled_independently(self):
+        other = self.unit.gear_tmc_obj(1)
+        self.assertIsNot(other, self.tmc, 'profile is not multigear - test is vacuous')
+
+        self.mmu._adjust_gear_current(gate=0, percent=50, reason="test")
+
+        self.assertAlmostEqual(self.tmc.get_status()['run_current'], self.default * 0.5, places=3)
+        self.assertAlmostEqual(other.get_status()['run_current'],
+                               self.unit.gear_default_current(1), places=3)
+
+    def test_the_command_is_no_longer_unhandled(self):
+        self.mmu._adjust_gear_current(gate=0, percent=50, reason="test")
+        self.assertEqual([c for c in self.hh.gcode.unhandled if 'SET_TMC_CURRENT' in c], [])
+
+    def test_a_bare_call_is_a_query(self):
+        self.mmu._adjust_gear_current(gate=0, percent=50, reason="test")
+        before = self.tmc.get_status()['run_current']
+
+        self.hh.run_gcode('SET_TMC_CURRENT STEPPER=%s' % self.unit.gear_name(0))
+
+        self.assertAlmostEqual(self.tmc.get_status()['run_current'], before, places=3)
+
+
+class TestConsoleOutput(StepperCurrentTestCase):
+
+    def test_both_the_intent_and_the_acknowledgment_are_reported(self):
+        """
+        HH's line says what it asked for; Klipper's says what the driver ended up at. Seeing
+        only the first is how a change that never reached the driver used to look correct.
+        """
+        mark = len(self.hh.console)
+        self.mmu._adjust_gear_current(gate=0, percent=50, reason="for testing")
+
+        emitted = self.hh.console[mark:]
+        self.assertTrue(any('run current to 50%' in line for line in emitted),
+                        'HH did not report its intent: %s' % emitted)
+        self.assertTrue(any(line.startswith('Run Current:') for line in emitted),
+                        'driver did not acknowledge the change: %s' % emitted)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_mmu_stepper_current.py
+++ b/test/test_mmu_stepper_current.py
@@ -98,5 +98,57 @@ class TestConsoleOutput(StepperCurrentTestCase):
                         'driver did not acknowledge the change: %s' % emitted)
 
 
+class TestPerExtruderAccounting(unittest.TestCase):
+    """
+    Two units on DIFFERENT physical extruders. Every other profile leaves both on the default one,
+    so they share a wrapper and nothing distinguishes per-extruder state from machine-wide state.
+    """
+
+    def setUp(self):
+        from test.hh.bootstrap import PRINTER_STUB
+        from test.hh.profiles import EXTRA_EXTRUDER_STUB
+        self.hh = session('ercf_vvd_dual_extruder',
+                          printer_stub=PRINTER_STUB + EXTRA_EXTRUDER_STUB)
+        self.hh.boot(calibrate=True)
+        self.assertEqual(self.hh.errors, [], 'bootup was not clean')
+        self.mmu = self.hh.mmu
+        self.unit0 = self.mmu.mmu_machine.get_mmu_unit_by_index(0)
+        self.unit1 = self.mmu.mmu_machine.get_mmu_unit_by_index(1)
+        self.assertIsNot(self.unit0.extruder_wrapper, self.unit1.extruder_wrapper,
+                         'units share a wrapper - fixture is not doing its job')
+
+    def tearDown(self):
+        self.hh.close()
+
+    def currents(self):
+        return [line for line in self.hh.gcode.executed if line.startswith('SET_TMC_CURRENT')]
+
+    def test_one_extruder_does_not_suppress_the_other(self):
+        """
+        The record used to be one machine-wide value, so setting extruder A then asking for the
+        same percentage on B was refused as a no-op - and A was never restored either.
+        """
+        self.mmu.select_gate(0)
+        self.mmu._adjust_extruder_current(60, "test")
+        mark = len(self.currents())
+
+        self.mmu.select_gate(9) # unit1, a different extruder
+        self.mmu._adjust_extruder_current(60, "test")
+
+        applied = self.currents()[mark:]
+        self.assertEqual(len(applied), 1, 'second extruder was suppressed: %s' % applied)
+        self.assertIn('STEPPER=%s' % self.unit1.extruder_name(), applied[0])
+        self.assertEqual(self.unit0.extruder_wrapper.run_current_percent(), 60)
+        self.assertEqual(self.unit1.extruder_wrapper.run_current_percent(), 60)
+
+    def test_the_record_is_forgotten_on_reinit(self):
+        self.mmu.select_gate(0)
+        self.mmu._adjust_extruder_current(60, "test")
+        self.assertEqual(self.mmu.extruder_run_current(), 60)
+
+        self.mmu.reinit()
+        self.assertEqual(self.mmu.extruder_run_current(), 100)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Rebased onto v4 now that #1020 and #1021 have merged, so this is the remaining five commits only. `make test` clean at every one: **948 tests, skipped=1, expected failures=4.**

## What started it

A tester hit `!! Happy Hare Assertion: Late sensor runout event on mmu_exit_1. Ignored`. Chasing it led through the runout filter, per-unit sensor arming and gate numbering — all merged in #1020 and #1021 — and finally to how stepper run current is tracked, which is what remains here.

## The commits

**Simulator** (`harness: model stepper run current…`)

The harness had no `SET_TMC_CURRENT` handler, so the modelled driver never moved off its config value — HH's log line appeared with nothing behind it. The fake TMC now registers the command as Klipper does, and the console's machine line carries a live cell per stepper:

```
Modifying MMU unit0_gear run current to 50% (0.45A) Development Test
Run Current: 0.45A Hold Current: 0.10A
Restoring MMU unit0_gear run current to 100% (0.90A)
Run Current: 0.90A Hold Current: 0.10A
  print=initialized  t=+10.52s  gear=100% 0.90A  ext=100% 0.50A  realtime=50%
```

Note the console defaults to a profile whose `sync_gear_current` is 100, where every sync-driven change is a no-op; use `--profile emu`.

**The move** (`test: pin the two nesting policies`, `mmu_drive:` ×2, `extruder:`)

Current state lived on the shared controller. `MmuDrive` owns each physical gear stepper and its name *is* the `SET_TMC_CURRENT` mux key, so the controller's dict was already a per-drive map in disguise. The bigger win was deleting `mmu_gear_tmcs`/`mmu_gear_currents` — a second, gate-indexed resolution of hardware the drive already owns.

The depth counter deliberately stayed on the controller: it is a machine-global lockout, and it is what stops filament moves and the async sync-feedback timer from clobbering a wrapped block.

## Review notes

- **The two `wrap_*_current` nesting policies differ on purpose** and are now pinned by a characterisation test: gear is outermost-wins with a global lockout because it is contended; the extruder is uncontended and nests fully. That test was mutation-checked — unifying them takes the gear count from 2 to 4.
- **The refactor commits changed no test file.** `test_mmu_tangle_prevention` and `test_mmu_local_gate` passed unmodified through both, which is the no-behaviour-delta proof.
- **Emission counts do not increase.** Replaying six real toolchanges (84 requests) through the old and new guards gives 11 emissions either way. They diverge only where the old one was working from worse information.
- The boot-log line naming which gates have a driver was verified byte-identical across single-gear, multigear and multi-unit profiles.

## Still open from the earlier work

The two rotary-selector fixes that merged in #1021 remain untested: the only rotary profile is single-unit starting at gate 0, where the local/machine gate conversion is an identity, so there is nothing to observe. Closing that needs a profile expressing a rotary selector on a later unit — the same shape of fixture work this PR does for the dual-extruder case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
