### PR TITLE
Fix apply_initial_sensor_states unit collision + false IN_BOWDEN on forward-parked exit sensor

### DIFF
--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -809,6 +809,14 @@ class MmuController(MmuFilamentMovement):
                 return homed_segment(target_pos, sensor_label(sensor))
             return pad(target_pos, width)
 
+        def gate_segment():
+            # Forward-parked exit sensor: filament is UNLOADED but still sits at/past the
+            # gate sensor (positive gate_parking_distance), so render it as homed there
+            # rather than as not-yet-reached
+            if pos == FILAMENT_POS_UNLOADED and self.sensor_manager.check_sensor(gate_homing_endstop):
+                return home + sensor_label(gate_homing_endstop) + space
+            return optional_sensor(gate_homing_endstop, FILAMENT_POS_HOMED_GATE)
+
         def nozzle_segment():
             if pos >= FILAMENT_POS_LOADED:
                 return arrow + home + "Nz" + arrow * 2
@@ -891,7 +899,7 @@ class MmuController(MmuFilamentMovement):
             tool_text,
             past(FILAMENT_POS_UNLOADED) * 2,
 
-            optional_sensor(gate_homing_endstop, FILAMENT_POS_HOMED_GATE),
+            gate_segment(),
 
             (
                 "En" + past(encoder_ref_pos) * 2

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -3251,8 +3251,11 @@ class MmuFilamentMovement:
         elif es:
             self.set_filament_pos_state(FILAMENT_POS_HOMED_ENTRY, silent=silent) # Allows for fast bowden unload move
 
-        # Parked at gate (when parking distance is not a retract i.e. gs sensor expected to be triggered)
-        elif gs and filament_detected and u.p.gate_parking_distance >= 0:
+        # Parked at gate (when parking distance is not a retract i.e. gs sensor expected to be triggered).
+        # Note: filament_detected is deliberately not required here - for a forward parking distance,
+        # get_all_sensors_for_gate() excludes this exact sensor from its position ordering (see
+        # mmu_sensor_manager.py _get_sensors), so filament_detected can never be true from gs alone
+        elif gs and u.p.gate_parking_distance >= 0:
             self.set_filament_pos_state(FILAMENT_POS_UNLOADED, silent=silent)
 
         # Somewhere in bowden

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -324,17 +324,26 @@ class Session:
         """
         from extras.mmu.mmu_constants import SENSOR_TENSION, SENSOR_COMPRESSION
         resting = {'tension': SENSOR_TENSION, 'compression': SENSOR_COMPRESSION}
+        # Keyed by the buffer's OWN namespace prefix (buffer.name, which is what
+        # MmuBuffer actually qualifies its sensor keys with - not necessarily the
+        # requesting unit's name, for a shared buffer). Bare sensor names collide
+        # across units (every buffer's switches are called filament_tension /
+        # filament_compression regardless of which unit owns them), so both `at_rest`
+        # and `derived` below must stay qualified or one unit's buffer state bleeds
+        # into another's - which is what silently left a switch-based buffer's
+        # sensors untouched whenever another unit's buffer was proportional.
         at_rest = set()
-        spring_states = []
+        spring_by_prefix = {}
         for unit in self.mmu.mmu_machine.units:
             buffer = getattr(unit, 'buffer', None)
             if buffer is None:
                 continue
             spring = getattr(buffer, 'buffer_spring_state', 'none')
-            spring_states.append(spring)
+            prefix = getattr(buffer, 'name', unit.name)
+            spring_by_prefix[prefix] = spring
             sensor_name = resting.get(spring)
             if sensor_name is not None:
-                at_rest.add(sensor_name)
+                at_rest.add('%s:%s' % (prefix, sensor_name))
 
         # A PROPORTIONAL (analog) buffer derives its compression/tension sensors from the
         # ADC reading, so the resting state must be expressed as a RAW VALUE and left to
@@ -347,19 +356,20 @@ class Session:
             handle = _SensorHandle(self, name, sensor)
             if handle.kind != 'proportional':
                 continue
-            spring = spring_states[0] if spring_states else 'none'
+            prefix = name.split(':')[0]
+            spring = spring_by_prefix.get(prefix, 'none')
             handle.feed(self._resting_raw(handle, spring), settle=False)
-            # Exclude the analog sensor ITSELF as well as the two it derives: the loop
-            # below would otherwise call set(False) on it, which for a proportional sensor
-            # means feeding neutral - overwriting the resting value just fed.
-            derived |= {SENSOR_TENSION, SENSOR_COMPRESSION, name.split(':')[-1]}
+            # Exclude the analog sensor ITSELF as well as the two it derives, scoped to
+            # THIS buffer's own namespace: the loop below would otherwise call set(False)
+            # on it, which for a proportional sensor means feeding neutral - overwriting
+            # the resting value just fed.
+            derived |= {'%s:%s' % (prefix, SENSOR_TENSION), '%s:%s' % (prefix, SENSOR_COMPRESSION), name}
 
         for name, sensor in self.sensors().items():
-            bare = name.split(':')[-1]
-            if bare in derived:
+            if name in derived:
                 continue        # derived from the analog reading above
             try:
-                _SensorHandle(self, name, sensor).set(bare in at_rest)
+                _SensorHandle(self, name, sensor).set(name in at_rest)
             except AssertionError:
                 logging.debug('cannot drive sensor %s directly', name)
         self.reactor.advance(0.)
@@ -394,7 +404,7 @@ class Session:
         from .filament import FilamentPath
         model = FilamentPath(self.mmu.num_gates, layout=layout)
         owned = [name for name in self.sensors()
-                 if name.split(':')[-1] not in getattr(self, '_spring_at_rest', set())
+                 if name not in getattr(self, '_spring_at_rest', set())
                  and model.position(name) is not None]
         # Which gates each unit owns, so a unit-qualified sensor is not answered from another
         # unit's filament - see FilamentPath.gates_visible_to.

--- a/test/test_mmu_selector.py
+++ b/test/test_mmu_selector.py
@@ -570,6 +570,35 @@ class TestMultiUnitSelectors(SelectorTestCase):
             self.assertIn(name, model.sensor_names(),
                           '%s is not bound, so it can never read triggered' % name)
 
+    def test_recover_reports_unloaded_for_a_forward_parked_exit_sensor(self):
+        """
+        unit1's gate_homing_endstop is mmu_exit with gate_parking_distance = +10 (a
+        forward park, not a retract), so a properly parked gate leaves the exit switch
+        covered rather than clear. recover_filament_pos's gate-parked branch used to
+        also require filament_detected, which is computed from
+        get_all_sensors_for_gate() - and that deliberately excludes this exact sensor's
+        position when parking is forward (mmu_sensor_manager.py's _get_sensors, "only
+        valid if is not usually triggered i.e. parking retract"), so the requirement
+        could never be satisfied and MMU_RECOVER concluded IN_BOWDEN for a perfectly
+        normal parked gate.
+        """
+        model = self.hh.filament()
+        self.hh.run_gcode('MMU_SELECT GATE=10')
+        self.hh.place_filament(10, position=model.layout['mmu_exit'] + 10.0)
+        self.assertTrue(model.triggered('mmu_exit_10'))
+
+        self.hh.run_gcode('MMU_RECOVER')
+
+        self.assertEqual(self.hh.errors, [])
+        self.assertEqual(self.hh.mmu.filament_pos, FILAMENT_POS_UNLOADED)
+
+        # The status line should show the gate as homed (3 blocks then the triggered
+        # marker), not as not-yet-reached, and the trailing state text should read
+        # UNLOADED rather than nothing at all.
+        visual = self.hh.mmu.get_filament_position_string()
+        self.assertIn('■■■◉', visual)  # UI_SOLID_SQUARE x3 then UI_SENSOR_TRIGGERED
+        self.assertIn('UNLOADED', visual)
+
 
 class TestPersistedPositionRestore(unittest.TestCase):
     """


### PR DESCRIPTION
## Summary

- **Test harness bug** (`test/hh/bootstrap.py`): `apply_initial_sensor_states` tracked which buffer sensors to skip/set using bare names (`filament_tension`/`filament_compression`), which collide across units. On `ercf_vvd` (the only profile mixing a proportional buffer on unit0 with a switch-based buffer on unit1), unit0's proportional-sensor bookkeeping spuriously suppressed unit1's real switches, leaving them at NEUTRAL instead of unit1's configured `tension` resting state after boot. Both `at_rest` and `derived` are now keyed by the buffer's own namespace prefix instead of the bare suffix.
- **Production bug** (`extras/mmu/mmu_filament_movement.py`, `extras/mmu/mmu_controller.py`): `recover_filament_pos`'s gate-parked branch also required `filament_detected`, but for a forward `gate_parking_distance` that flag can never be true from the gate sensor alone (`get_all_sensors_for_gate()` deliberately excludes that sensor's position in this case). `MMU_RECOVER` fell through to `IN_BOWDEN` on a perfectly normal parked gate instead of `UNLOADED`. The status line rendering gets a matching fix so a forward-parked, unloaded gate renders as homed rather than not-yet-reached.
- **Test** (`test/test_mmu_selector.py`): adds `test_recover_reports_unloaded_for_a_forward_parked_exit_sensor`, and removes the `sensor('unit1:filament_tension').set(True)` workaround it needed before the harness fix.

## Why

The harness bug was masking the production bug: a fresh `ercf_vvd` boot left unit1's buffer at NEUTRAL instead of its configured `tension` resting state, which made `check_filament_in_mmu` conclude filament was present on an empty gate - producing the same "not detected as either unloaded or fully loaded" symptom as the real `recover_filament_pos` bug, for an unrelated reason. Fixing the harness first isolated the actual bug so it could be fixed and tested directly.

## Test plan

- [x] `test_recover_reports_unloaded_for_a_forward_parked_exit_sensor` passes without the workaround
- [x] `make test` (full suite): 954 tests, OK (1 skip, 4 expected failures - both pre-existing)