### PR TITLE
nfc: give preload its own jog scan window

### DIFF
--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -542,7 +542,7 @@ heater_rotate_interval      : [[PARAM_HEATER_ROTATE_INTERVAL]]			# Interval in m
 # supported spool tags (Bambu, Creality, OpenSpool, OpenTag, etc). A "deep read" parses the full tag (material, color,
 # vendor, temperatures) instead of just the UID, and uses it to populate the local gate map when a tag is presented.
 # Optionally, if a scanned tag's UID isn't yet known to Spoolman, a new spool can be created automatically from the tag.
-# Related parameters: 'nfc_gate_jog_scan_window' and 'spoolman_nfc_auto_create' (mmu.cfg)
+# Related parameters: 'nfc_gate_jog_scan_window', 'nfc_preload_jog_scan_window' and 'spoolman_nfc_auto_create' (mmu.cfg)
 nfc_deep_read               : [[PARAM_NFC_DEEP_READ]]
 
 # When the filament is parked in the gate this represents the maximum filament move in the retract and extrude
@@ -550,6 +550,11 @@ nfc_deep_read               : [[PARAM_NFC_DEEP_READ]]
 # rotation this range should be at least 480mm if possible.
 # E.g. "-100, 400" means can retract -100mm and extruder 400mm.  "0, 0" will disable jog scan operation
 nfc_gate_jog_scan_window    : [[PARAM_NFC_GATE_JOG_SCAN_WINDOW]]
+
+# Used specifically when scanning for a tag during MMU_PRELOAD, which often homes to a different endstop
+# (typically the per-gate mmu_exit sensor) than the general gate homing endstop. Defaults to the same value
+# as nfc_gate_jog_scan_window when not set explicitly.
+nfc_preload_jog_scan_window : [[PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW]]
 
 # NFC reader LED feedback: which segment the shared-reader lookup effects render on.
 # '' = auto ('status' for a shared/bypass reader, 'exit' for a per-gate reader).

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -47,8 +47,9 @@ from .mmu_sensor_utils    import MmuVirtualEndstopSensor, MmuCompoundEndstop
 # Parameter set for a "home filament to the gate" operation and the park that follows it.
 # There are exactly two of these: the normal gate_* set (_gate_profile) and the preload
 # gate_preload_* set (_preload_profile). Every gate homing/parking primitive is driven by
-# one of them, so the endstop, homing budget and parking distance always travel together.
-GateHomeProfile = namedtuple('GateHomeProfile', ['endstop', 'homing_max', 'parking_distance', 'attempts'])
+# one of them, so the endstop, homing budget, parking distance and NFC jog scan window
+# always travel together.
+GateHomeProfile = namedtuple('GateHomeProfile', ['endstop', 'homing_max', 'parking_distance', 'attempts', 'jog_scan_window'])
 
 
 class MmuFilamentMovement:
@@ -69,6 +70,7 @@ class MmuFilamentMovement:
             homing_max=u.p.gate_homing_max,
             parking_distance=u.p.gate_parking_distance,
             attempts=(u.p.gate_load_attempts if allow_retry else 1),
+            jog_scan_window=u.p.nfc_gate_jog_scan_window,
         )
 
 
@@ -84,6 +86,7 @@ class MmuFilamentMovement:
             homing_max=u.p.gate_preload_homing_max,
             parking_distance=u.p.gate_preload_parking_distance,
             attempts=u.p.gate_preload_attempts,
+            jog_scan_window=u.p.nfc_preload_jog_scan_window,
         )
 
 
@@ -97,7 +100,7 @@ class MmuFilamentMovement:
               [gate_preload_endstop, NFC reader]. If the READER stops the move the tag is
               read and homing continues to the physical endstop, then parks. If the PHYSICAL
               endstop stops it first we hand over to the scan logic: sweep forward through
-              the positive half of nfc_gate_jog_scan_window looking for the tag, then park
+              the positive half of nfc_preload_jog_scan_window looking for the tag, then park
               from wherever that left us (reverse-home back to the gate, then park).
 
         'pending' is the (spool_id, tag) the MMU_PRELOAD command grabbed up front (before its
@@ -303,7 +306,7 @@ class MmuFilamentMovement:
             for i in range(profile.attempts):
                 if nfc is not None:
                     homed, tag_read, overshoot = self._home_to_gate_with_nfc(
-                        gate, endstop_name, nfc, homing_max)
+                        gate, endstop_name, nfc, homing_max, profile.jog_scan_window)
                 else:
                     msg = (
                         f"Initial homing to {endstop_name} sensor"
@@ -485,7 +488,7 @@ class MmuFilamentMovement:
         return compound, nfc_es_name, nfc_mgr
 
 
-    def _home_to_gate_with_nfc(self, gate, gate_es_name, nfc, homing_max):
+    def _home_to_gate_with_nfc(self, gate, gate_es_name, nfc, homing_max, jog_scan_window):
         """
         One NFC-augmented gate-home attempt against the compound [gate switch, NFC reader].
         Forward-only, and the two outcomes are deliberately different operations:
@@ -494,20 +497,24 @@ class MmuFilamentMovement:
             then carry on homing to the gate switch. We finish ON the datum, so the caller
             parks in place (offset 0).
           GATE switch stops us first - the tag is somewhere ahead of the reader. Hand over to
-            the scan logic and sweep forward through the positive half of
-            nfc_gate_jog_scan_window looking for it. We finish AHEAD of the datum, so the
+            the scan logic and sweep forward through the positive half of the caller's
+            jog_scan_window (the profile's nfc_gate_jog_scan_window or
+            nfc_preload_jog_scan_window) looking for it. We finish AHEAD of the datum, so the
             caller has to reverse-home back to it before parking (offset > 0).
 
         Reads the tag (deep if enabled) when found and applies it to the gate map. Never
         parks - the caller owns that.
 
+        Args:
+            jog_scan_window: (neg, pos) from the caller's GateHomeProfile - only the
+                positive half is used, to bound the forward scan leg.
+
         Returns:
             (homed, tag_read, offset) - offset is how far forward of the gate datum the
             filament was left, for the caller to budget its park with.
         """
-        u = self.mmu_unit()
         compound, nfc_es_name, nfc_mgr = nfc
-        window = u.p.nfc_gate_jog_scan_window
+        window = jog_scan_window
         pos = max(0.0, window[1]) if len(window) == 2 else 0.0
 
         # Phase 1: home to whichever of {gate switch, tag} arrives first
@@ -623,7 +630,7 @@ class MmuFilamentMovement:
         profile = self._gate_profile()
         pre_scan_status = self.gate_status[gate] # Restored if a re-park fails (filament is still present)
 
-        window = u.p.nfc_gate_jog_scan_window
+        window = profile.jog_scan_window
         if len(window) != 2 or window[0] > 0 or window[1] < 0:
             raise MmuError("nfc_gate_jog_scan_window must be (neg, pos) with neg <= 0 <= pos, got %s" % (window,))
         neg, pos = window[0], window[1]

--- a/extras/mmu/unit/mmu_unit_parameters.py
+++ b/extras/mmu/unit/mmu_unit_parameters.py
@@ -109,6 +109,24 @@ class MmuUnitParameters(TunableParametersBase):
                 % (abs(neg), self.gate_homing_max)
             )
 
+    def _validate_nfc_preload_jog_scan_window(self, value):
+        # Empty (or absent) disables the NFC scan-on-miss during MMU_PRELOAD
+        if not value:
+            return
+        if len(value) != 2:
+            raise ValueError("nfc_preload_jog_scan_window must be two values (neg, pos), e.g. 0,480")
+        neg, pos = value[0], value[1]
+        if neg > 0 or pos < 0:
+            raise ValueError("nfc_preload_jog_scan_window must be (neg, pos) with neg <= 0 <= pos")
+        # Same TARGETS-from-the-gate-datum semantics as nfc_gate_jog_scan_window, but
+        # checked against the preload homing budget - preload can home to a different
+        # endstop (e.g. the per-gate mmu_exit sensor) with its own recovery budget.
+        if abs(neg) > self.gate_preload_homing_max:
+            raise ValueError(
+                "nfc_preload_jog_scan_window backward reach (%.1fmm) cannot exceed gate_preload_homing_max (%.1fmm)"
+                % (abs(neg), self.gate_preload_homing_max)
+            )
+
     # Parking distance sign convention: -ve = retraction (toward the gate/gears), +ve =
     # extrusion (forward, past the sensor). Parking forward past the sensor is only safe
     # on the per-gate mmu_exit sensor; the shared mmu_shared_exit, encoder and
@@ -151,6 +169,7 @@ class MmuUnitParameters(TunableParametersBase):
 
         # NFC / RFID reading
         ParamSpec('nfc_gate_jog_scan_window',         'floatlist', [0.0, 0.0], section="NFC", validator=_validate_nfc_gate_jog_scan_window),
+        ParamSpec('nfc_preload_jog_scan_window',      'floatlist', lambda self: self.nfc_gate_jog_scan_window, section="NFC", validator=_validate_nfc_preload_jog_scan_window),
         ParamSpec('nfc_deep_read',                    'int',    0,    section="NFC", limits=dict(minval=0, maxval=1)),
         ParamSpec('nfc_led_segment',                  'str',  'auto', section="NFC"),
 

--- a/installer/Kconfig.nfc_reader
+++ b/installer/Kconfig.nfc_reader
@@ -8,6 +8,7 @@
 #
 # PARAM_NFC_DEEP_READ
 # PARAM_NFC_GATE_JOG_SCAN_WINDOW
+# PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW
 # PARAM_NFC_LED_SEGMENT
 #
 # Shared:
@@ -610,6 +611,17 @@ if MMU_HAS_NFC_READER
         direction that is safely possible when searching for the RFID tag. To be sure to allow for complete spool
         rotation this range should be at least 480mm if possible.
         E.g. "-100, 400" means can retract -100mm and extruder 400mm. "0, 0" will disable jog scan operation
+
+    config PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW
+      string "NFC reader preload jog scan window"
+      default PARAM_NFC_GATE_JOG_SCAN_WINDOW
+      array_editor "," 2
+      help
+        Same as the jog scan window above, but used specifically when scanning for a tag during MMU_PRELOAD.
+        Preload often homes to a different endstop (typically the per-gate mmu_exit sensor rather than the
+        general gate homing endstop), so the safe scan range can differ. Defaults to the same value as the
+        gate jog scan window.
+        E.g. "-100, 400" means can retract -100mm and extrude 400mm. "0, 0" disables jog scanning during preload
 
     choice CHOICE_NFC_LED_SEGMENT
       prompt "NFC reader led feedback segment"

--- a/test/test_mmu_nfc_scan.py
+++ b/test/test_mmu_nfc_scan.py
@@ -148,6 +148,23 @@ class TestJogScanFindsTag(NfcScanTestCase):
         self.hh.run_gcode('MMU_NFC_SCAN GATE=0')
         self.assertNotIn('tag read', ' '.join(self.hh.console).lower())
 
+    def test_scan_uses_the_gate_window_even_when_preload_window_differs(self):
+        """
+        Regression test: MMU_NFC_SCAN always drives _gate_profile(), so it must keep
+        sweeping nfc_gate_jog_scan_window even when nfc_preload_jog_scan_window is set
+        to something else entirely.
+        """
+        u = self.hh.mmu.mmu_unit(0)
+        u.p.nfc_gate_jog_scan_window = [-50.0, 30.0]
+        u.p.nfc_preload_jog_scan_window = [-20.0, 12.0]
+        self.preload(0)  # no tag attached: sweep runs its full length, finds nothing
+        self.hh.mmu.select_gate(0)
+        self.hh.run_gcode('MMU_NFC_SCAN GATE=0')
+
+        trips = [d for _g, d, r in self.fil.history if 'mmu_nfc_0' in r and abs(d) in (30.0, 12.0)]
+        self.assertIn(30.0, [abs(d) for d in trips], 'MMU_NFC_SCAN never swept the 30mm gate window')
+        self.assertNotIn(12.0, [abs(d) for d in trips], 'MMU_NFC_SCAN swept the preload window instead')
+
     def test_tag_already_on_the_reader_short_circuits_the_jog(self):
         """
         _jog_scan pre-reads before moving, so a tag already sitting on the reader is
@@ -313,6 +330,26 @@ class TestPreloadNfcCompound(NfcScanTestCase):
         self.assertEqual(self.hh.mmu.filament_pos, FILAMENT_POS_UNLOADED)
         self.assertFalse(self.hh.sensor('mmu_exit_0').present,
                          'the park must end behind the gate switch')
+        self.assertEqual(self.hh.errors, [])
+
+    def test_gate_first_scan_uses_the_preload_window_not_the_gate_window(self):
+        """
+        Regression test: _home_to_gate_with_nfc must sweep whatever window its caller's
+        profile carries. MMU_PRELOAD drives _preload_profile(), so its forward sweep leg
+        must be bounded by nfc_preload_jog_scan_window, not nfc_gate_jog_scan_window -
+        the two are given distinct positive halves here so a fix that reads the wrong one
+        is caught immediately.
+        """
+        u = self.hh.mmu.mmu_unit(0)
+        u.p.nfc_gate_jog_scan_window = [-50.0, 30.0]
+        u.p.nfc_preload_jog_scan_window = [-20.0, 12.0]
+        self.hh.place_filament(0, position=-100.0)  # no tag: gate switch always wins first
+        self.hh.run_gcode('MMU_PRELOAD GATE=0')
+
+        trips = [d for _g, d, r in self.fil.history if 'mmu_nfc_0' in r and d > 0]
+        self.assertEqual(trips, [12.0],
+                         'preload swept %r - expected a single 12mm leg from '
+                         'nfc_preload_jog_scan_window' % (trips,))
         self.assertEqual(self.hh.errors, [])
 
 


### PR DESCRIPTION
## Summary
- `_home_to_gate_with_nfc()` always read `nfc_gate_jog_scan_window`, even though it's only ever reached via preload's compound NFC/gate home - and preload frequently homes to a different endstop (the per-gate `mmu_exit` sensor) than the normal gate load, making the borrowed window unsafe.
- Adds `nfc_preload_jog_scan_window`, defaulting to `nfc_gate_jog_scan_window` (same lambda-default idiom already used by `gate_preload_homing_max`) but independently tunable.
- `GateHomeProfile` now carries the window alongside the endstop/homing budget/parking distance it already threads through `_gate_profile()` and `_preload_profile()`, so each caller gets its own window automatically.

## Test plan
- [x] `./venv/bin/python -m unittest test.test_mmu_nfc_scan` - 45 tests pass, including two new regression tests proving preload and `MMU_NFC_SCAN` sweep independent windows
- [x] `./venv/bin/python -m unittest` (full suite) - 956 tests, OK, 4 expected failures (matches known baseline)
- [x] Rendered a test config for the default NFC profile (`-50, 50` for both) and an EMU+NFC profile (`-100, 400` for both), confirming the per-mmu-type Kconfig override propagates through the new symbol correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)