### PR TITLE
rfid: allow multiple UIDs per spool with explicit append/replace semantics

### DIFF
--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -28,7 +28,9 @@
 #    which this module auto-creates on the Spoolman server if missing:
 #      - printer_name : which printer a spool is assigned to
 #      - mmu_gate_map : which gate on that printer the spool sits in
-#      - rfid         : the NFC/RFID tag UID registered against the spool
+#      - rfid         : the NFC/RFID tag UID(s) registered against the spool
+#                        (a comma-separated list - a spool can have more than
+#                        one physical tag, e.g. one on each side)
 #    A cache of spool -> (printer, gate, attributes) is maintained locally for
 #    efficiency, along with a reverse UID -> spool_id map for fast tag lookups.
 # 
@@ -385,20 +387,50 @@ class MmuServer:
                             .replace(' ', ''))
 
 
-    def _get_uid_from_extra(self, extra) -> str:
+    @staticmethod
+    def _parse_uid_list(raw) -> list[str]:
         '''
-        Read and normalise the tag UID stored in a spool's extra fields.
-        Values are JSON-encoded on the wire (like the other extra fields) but
-        tolerate a bare string in case it was set manually. Returns '' if unset.
+        Split a (possibly comma-separated) UID value into normalised UIDs.
+        Blank entries are dropped and duplicates removed, order preserved.
+        None/'' -> [].
+        '''
+        if not raw:
+            return []
+        seen: list[str] = []
+        for part in str(raw).split(','):
+            part = part.strip()
+            if not part:
+                continue
+            norm = MmuServer._normalise_uid(part)
+            if norm and norm not in seen:
+                seen.append(norm)
+        return seen
+
+
+    def _get_uid_list_from_extra(self, extra) -> list[str]:
+        '''
+        Read the list of tag UIDs stored in a spool's extra fields. Values are
+        JSON-encoded on the wire (like the other extra fields) but tolerate a
+        bare string in case it was set manually. A spool may have more than
+        one UID registered (e.g. a tag on each side), stored comma-separated.
+        Returns [] if unset.
         '''
         raw = (extra or {}).get(MMU_RFID_FIELD)
         if not raw:
-            return ''
+            return []
         try:
             raw = json.loads(raw)
         except (ValueError, TypeError):
             pass # Fall back to the raw value if it isn't valid JSON
-        return self._normalise_uid(raw) if raw else ''
+        return self._parse_uid_list(raw)
+
+
+    def _get_uid_from_extra(self, extra) -> str:
+        '''
+        Comma-joined display string of all tag UIDs registered on this spool
+        (see _get_uid_list_from_extra). Returns '' if unset.
+        '''
+        return ','.join(self._get_uid_list_from_extra(extra))
 
 
     def _get_filament_attr(self, spool_info) -> dict:
@@ -439,9 +471,14 @@ class MmuServer:
                 filament_attr = self._get_filament_attr(spool_info)
                 new_spool_location[spool_id] = (printer_name, mmu_gate, filament_attr)
 
-                # Maintain reverse UID -> spool_id map for fast tag resolution
-                uid = filament_attr.get('rfid')
-                if uid:
+                # Maintain reverse UID -> spool_id map for fast tag resolution. A spool
+                # may register more than one UID (e.g. a tag on each side). There's no
+                # automatic fix for a UID claimed by two spools, so just report it -
+                # the later spool_id wins the cache entry.
+                for uid in self._get_uid_list_from_extra(spool_info.get('extra')):
+                    other_spool_id = new_uid_to_spool_id.get(uid)
+                    if other_spool_id is not None and other_spool_id != spool_id:
+                        errors += f"\n  - Tag {uid} is registered against both spool {other_spool_id} and spool {spool_id}"
                     new_uid_to_spool_id[uid] = spool_id
 
                 if printer_name and mmu_gate >= 0:
@@ -1352,8 +1389,7 @@ class MmuServer:
         mmu_gate = int(extra.get(MMU_GATE_FIELD, -1))
         filament_attr = self._get_filament_attr(spool_info)
         self.spool_location[spool_id] = (printer_name, mmu_gate, filament_attr)
-        uid = filament_attr.get('rfid')
-        if uid:
+        for uid in self._get_uid_list_from_extra(extra):
             self.uid_to_spool_id[uid] = spool_id
         return spool_id
 
@@ -1468,19 +1504,71 @@ class MmuServer:
         return None
 
 
-    async def set_spool_uid(self, spool_id=None, uid=None, silent=False) -> bool:
+    async def set_spool_uid(self, spool_id=None, uid=None, append=False, silent=False) -> bool:
         '''
-        Register (write) an NFC/RFID tag UID onto a spool record in Spoolman,
-        so future scans of that tag resolve to this spool_id.
+        Write NFC/RFID tag UID(s) onto a spool record in Spoolman, so future
+        scans of those tags resolve to this spool_id. 'uid' may be blank, a
+        single UID or a comma-separated list.
+
+        append=False (default): replace whatever UID(s) are currently
+        registered with the ones supplied. A blank 'uid' clears the field
+        entirely - this is the supported way to unregister all tags from a
+        spool.
+
+        append=True: add the supplied UID(s) to whatever is already
+        registered (deduped), rather than replacing it - e.g. registering a
+        second physical tag stuck on the other side of the same spool. The
+        current value is re-fetched from Spoolman rather than trusted from
+        the local cache, to avoid acting on a stale read.
         '''
         if not await self._check_init_spoolman(): return False
         async with self.cache_lock:
-            if spool_id is None or not uid:
+            if spool_id is None:
                 await self._log_n_send(f"NFC: cannot register tag - spool_id={spool_id} uid={uid}", error=True, silent=silent)
                 return False
 
-            uid_norm = self._normalise_uid(uid)
-            data = {'extra': {MMU_RFID_FIELD: json.dumps(uid_norm)}}
+            new_uids = self._parse_uid_list(uid)
+            if append and not new_uids:
+                await self._log_n_send("NFC: APPEND=1 needs a tag UID to add", error=True, silent=silent)
+                return False
+
+            if append:
+                spool_info = await self._fetch_spool_info(spool_id)
+                if spool_info is None:
+                    await self._log_n_send(f"NFC: SpoolId {spool_id} not found", error=True, silent=silent)
+                    return False
+                existing_uids = self._get_uid_list_from_extra(spool_info.get('extra'))
+                final_uids = existing_uids + [u for u in new_uids if u not in existing_uids]
+            else:
+                final_uids = new_uids
+
+            # A UID that's already claimed by a different spool is silently moved
+            # over - make that visible, and strip it from the OTHER spool's own
+            # record too, so it doesn't reappear there on the next full cache
+            # rebuild (best-effort: a failure here doesn't abort this write).
+            for u in new_uids:
+                other_spool_id = self.uid_to_spool_id.get(u)
+                if other_spool_id is None or other_spool_id == spool_id:
+                    continue
+                await self._log_n_send(f"NFC: tag {u} was registered to spool {other_spool_id} - moving it to spool {spool_id}", silent=silent)
+                other_info = await self._fetch_spool_info(other_spool_id)
+                if other_info is None:
+                    continue
+                other_uids = [x for x in self._get_uid_list_from_extra(other_info.get('extra')) if x != u]
+                other_resp = await self.http_client.request(
+                    method="PATCH",
+                    url=f"{self.spoolman.spoolman_url}/v1/spool/{other_spool_id}",
+                    body={'extra': {MMU_RFID_FIELD: json.dumps(','.join(other_uids))}}
+                )
+                if other_resp.has_error():
+                    logging.warning(f"NFC: failed to strip moved tag {u} from its previous spool {other_spool_id}: {self.spoolman._get_response_error(other_resp)}")
+                    continue
+                if other_spool_id in self.spool_location:
+                    printer, gate, filament_attr = self.spool_location[other_spool_id]
+                    filament_attr['rfid'] = ','.join(other_uids)
+                    self.spool_location[other_spool_id] = (printer, gate, filament_attr)
+
+            data = {'extra': {MMU_RFID_FIELD: json.dumps(','.join(final_uids))}}
             response = await self.http_client.request(
                 method="PATCH",
                 url=f"{self.spoolman.spoolman_url}/v1/spool/{spool_id}",
@@ -1493,19 +1581,25 @@ class MmuServer:
             elif response.has_error():
                 err_msg = self.spoolman._get_response_error(response)
                 logging.error(f"Attempt to register tag failed: {err_msg}")
-                await self._log_n_send(f"NFC: Failed to register tag {uid_norm} on spool {spool_id}. See moonraker.log for details.", error=True, silent=silent)
+                await self._log_n_send(f"NFC: Failed to register tag(s) {','.join(new_uids)} on spool {spool_id}. See moonraker.log for details.", error=True, silent=silent)
                 return False
 
             # Update caches to reflect the new UID association
             self.uid_to_spool_id = {u: sid for u, sid in self.uid_to_spool_id.items() if sid != spool_id}
-            self.uid_to_spool_id[uid_norm] = spool_id
-            self.uid_miss_cache.pop(uid_norm, None) # This tag is now known
+            for u in final_uids:
+                self.uid_to_spool_id[u] = spool_id
+            for u in new_uids:
+                self.uid_miss_cache.pop(u, None) # This tag is now known
             if spool_id in self.spool_location:
                 printer, gate, filament_attr = self.spool_location[spool_id]
-                filament_attr['rfid'] = uid_norm
+                filament_attr['rfid'] = ','.join(final_uids)
                 self.spool_location[spool_id] = (printer, gate, filament_attr)
 
-            await self._log_n_send(f"NFC: tag {uid_norm} registered against spool {spool_id} in Spoolman db", silent=silent)
+            if not final_uids:
+                await self._log_n_send(f"NFC: cleared all registered tags for spool {spool_id} in Spoolman db", silent=silent)
+            else:
+                verb = "appended to" if append else "registered against"
+                await self._log_n_send(f"NFC: tag(s) {','.join(new_uids)} {verb} spool {spool_id} in Spoolman db", silent=silent)
             return True
 
 

--- a/extras/mmu/commands/mmu_nfc.py
+++ b/extras/mmu/commands/mmu_nfc.py
@@ -40,6 +40,7 @@ class MmuNfcCommand(BaseCommand):
         + "READ     = [0|1] Read the addressed reader once and report the UID\n"
         + "DEEP     = [0|1] With READ=1, also parse and report the tag metadata (ignores nfc_deep_read setting)\n"
         + "REGISTER = [0|1] Read tag (implies READ=1 DEEP=1) and resolve it in Spoolman (may auto-create). Shared reader: report-only, Per-gate: updates gate map\n"
+        + "APPEND   = [0|1] With REGISTER=1 on a gate that already has a spool assigned, bind the newly scanned tag onto that spool instead of resolving/auto-creating (e.g. a second tag on the same spool)\n"
         + "INIT     = [0|1] (Re)initialize the addressed reader\n"
         + "RELEASE  = [0|1] Release the current target on the addressed reader\n"
         + "INIT_ALL = [0|1] (Re)initialize every reader on every unit\n"
@@ -55,6 +56,7 @@ class MmuNfcCommand(BaseCommand):
         + f"{CMD} SHARED=1 READ=1 DEEP=1 ...Read the shared reader and report the parsed tag metadata\n"
         + f"{CMD} SHARED=1 REGISTER=1    ...Read tag and resolve/register it in Spoolman (report only, no assignment)\n"
         + f"{CMD} GATE=2 REGISTER=1      ...Read tag on gate 2 and apply to the gate map (as if auto-scanned)\n"
+        + f"{CMD} GATE=2 REGISTER=1 APPEND=1 ...Read a 2nd tag on gate 2 and bind it onto the spool already assigned there\n"
         + f"{CMD} GATE=2 INIT=1          ...(Re)initialize the reader on gate 2\n"
         + f"{CMD} GATES=0,1,2,3 ENABLE=0 ...Disable selected per-gate readers\n"
         + f"{CMD} INIT_ALL=1             ...Re-initialize every reader on all units\n"
@@ -85,6 +87,7 @@ class MmuNfcCommand(BaseCommand):
         read     = gcmd.get_int('READ', 0, minval=0, maxval=1)
         deep     = bool(gcmd.get_int('DEEP', 0, minval=0, maxval=1))
         register = bool(gcmd.get_int('REGISTER', 0, minval=0, maxval=1))
+        append   = bool(gcmd.get_int('APPEND', 0, minval=0, maxval=1))
         init     = gcmd.get_int('INIT', 0, minval=0, maxval=1)
         release  = gcmd.get_int('RELEASE', 0, minval=0, maxval=1)
         if register: # Registration needs the tag read and its metadata (for auto-create)
@@ -125,7 +128,7 @@ class MmuNfcCommand(BaseCommand):
                 if mgr is None or not mgr.has_reader(gate=g):
                     skipped.append(g)
                     continue
-                if not self._do_actions(mmu, mmu_unit, mgr, False, g, enable, init, release, read, deep, register):
+                if not self._do_actions(mmu, mmu_unit, mgr, False, g, enable, init, release, read, deep, register, append):
                     self._report_one(mmu_unit, mgr, shared=False, gate=g, details=details)
             if skipped:
                 mmu.log_always("NFC: no reader on gate(s) %s - skipped" % ",".join(map(str, skipped)))
@@ -140,10 +143,10 @@ class MmuNfcCommand(BaseCommand):
             raise gcmd.error("%s: no NFC %s configured" % (mmu_unit.name, label))
 
         # A bare selector (e.g. MMU_NFC GATE=3) just reports that reader's status
-        if not self._do_actions(mmu, mmu_unit, mgr, shared, gate, enable, init, release, read, deep, register):
+        if not self._do_actions(mmu, mmu_unit, mgr, shared, gate, enable, init, release, read, deep, register, append):
             self._report_one(mmu_unit, mgr, shared=shared, gate=gate, details=details)
 
-    def _do_actions(self, mmu, mmu_unit, mgr, shared, gate, enable, init, release, read, deep=False, register=False):
+    def _do_actions(self, mmu, mmu_unit, mgr, shared, gate, enable, init, release, read, deep=False, register=False, append=False):
         """
         Apply the requested action(s) to one addressed reader. Returns True if any
         action was performed (False -> caller falls back to a status report).
@@ -185,13 +188,29 @@ class MmuNfcCommand(BaseCommand):
                     mmu.log_always(msg)
                     if register:
                         if shared:
-                            # Report-only Spoolman resolve/auto-create: no pending, no gate map
-                            mmu._spoolman_register_tag(uid, metadata)
+                            if append:
+                                mmu.log_error("NFC: APPEND=1 needs a gate with an assigned spool - not "
+                                              "applicable to the shared reader. Use 'MMU_SPOOLMAN "
+                                              "SPOOLID=<id> RFID=%s APPEND=1' instead." % uid)
+                            else:
+                                # Report-only Spoolman resolve/auto-create: no pending, no gate map
+                                mmu._spoolman_register_tag(uid, metadata)
                         else:
-                            # Per-gate: full normal tag-read semantics - gate map updates
-                            # (spool_id on async resolution; metadata per nfc_deep_read)
-                            mmu.log_always("NFC: dispatching tag for gate %d - gate map will update on resolution" % gate)
-                            mmu._nfc_tag_read(uid, gate=gate, metadata=metadata, unit=mmu_unit)
+                            existing_spool_id = mmu.gate_spool_id[gate]
+                            if append and existing_spool_id and existing_spool_id > 0:
+                                # Bind this newly scanned tag onto the spool already assigned to
+                                # this gate (e.g. a 2nd physical tag on the same spool) instead of
+                                # resolving/auto-creating - which would otherwise ignore an unknown
+                                # tag or, worse, auto-create a duplicate spool for it.
+                                mmu.log_always("NFC: appending tag %s to spool %d already assigned to gate %d" % (uid, existing_spool_id, gate))
+                                mmu._spoolman_set_spool_uid(existing_spool_id, uid, append=True, quiet=False)
+                            else:
+                                if append:
+                                    mmu.log_always("NFC: gate %d has no spool assigned yet - APPEND=1 ignored, resolving/creating normally" % gate)
+                                # Per-gate: full normal tag-read semantics - gate map updates
+                                # (spool_id on async resolution; metadata per nfc_deep_read)
+                                mmu.log_always("NFC: dispatching tag for gate %d - gate map will update on resolution" % gate)
+                                mmu._nfc_tag_read(uid, gate=gate, metadata=metadata, unit=mmu_unit)
                 else:
                     mmu.log_always("NFC: %s %s - no tag detected" % (mmu_unit.name, label))
             did_action = True

--- a/extras/mmu/commands/mmu_spoolman.py
+++ b/extras/mmu/commands/mmu_spoolman.py
@@ -36,7 +36,9 @@ class MmuSpoolmanCommand(BaseCommand):
         + "FIX       = [0|1]\n"
         + "SPOOLID   = #(int)\n"
         + "GATE      = #(int)\n"
-        + "RFID      = # Write this NFC/RFID tag UID onto the spool record (needs SPOOLID or GATE)\n"
+        + "RFID      = # Write this NFC/RFID tag UID (or comma-separated UIDs) onto the spool record\n"
+        + "              (needs SPOOLID or GATE). Replaces any existing UID(s); RFID='' clears them.\n"
+        + "APPEND    = [0|1] With RFID=, add to the existing UID(s) instead of replacing them\n"
         + "PRINTER   = _name_\n"
         + "SPOOLINFO = [0|-1|spool_id]\n"
     )
@@ -46,7 +48,9 @@ class MmuSpoolmanCommand(BaseCommand):
         + f"{CMD} REFRESH=1           ...Refresh the local gate map from the spoolman database\n"
         + f"{CMD} GATE=0 SPOOLID=45   ...Assign spoolman spool id 45 to gate 0\n"
         + f"{CMD} SPOOLINFO=45        ...Display spoolman details for spool id 45\n"
-        + f"{CMD} SPOOLID=45 RFID=E2003412  ...Register tag E2003412 against spool id 45 in the spoolman db\n"
+        + f"{CMD} SPOOLID=45 RFID=E2003412         ...Register tag E2003412 against spool id 45 in the spoolman db (replaces any existing tags)\n"
+        + f"{CMD} SPOOLID=45 RFID=E2003499 APPEND=1 ...Register a second tag on the same spool (e.g. one on each side), keeping E2003412\n"
+        + f"{CMD} SPOOLID=45 RFID=''             ...Clear all tags registered against spool id 45\n"
         + f"{CMD} GATE=0 RFID=E2003412      ...Same, for whichever spool is assigned to gate 0\n"
     )
 
@@ -77,7 +81,8 @@ class MmuSpoolmanCommand(BaseCommand):
         gate = gcmd.get_int('GATE', None, minval=-1, maxval=mmu.num_gates - 1)
         printer = gcmd.get('PRINTER', None)  # Option to see other printers
         spoolinfo = gcmd.get_int('SPOOLINFO', None, minval=-1)  # -1 or 0 is active spool
-        rfid = gcmd.get('RFID', None)        # Tag UID to write onto a spool record
+        rfid = gcmd.get('RFID', None)        # Tag UID(s) to write onto a spool record
+        append = bool(gcmd.get_int('APPEND', 0, minval=0, maxval=1))
         run = False
 
         if refresh:
@@ -111,9 +116,9 @@ class MmuSpoolmanCommand(BaseCommand):
             #
             # Dispatched before the SPOOLID/GATE branch below, where a bare SPOOLID means
             # "unset that spool's gate" - which would otherwise swallow SPOOLID=n RFID=x.
-            if not rfid.strip():
-                mmu.log_error("RFID= needs a tag UID. To clear a gate's locally recorded "
-                              "tag use 'MMU_GATE_MAP GATE=%s RFID='" % (gate if gate is not None else 'n'))
+            if append and not rfid.strip():
+                mmu.log_error("APPEND=1 needs a tag UID to add. To clear all tags "
+                              "registered against a spool, use RFID='' without APPEND=1.")
                 return
             target = spool_id
             if target is None:
@@ -127,7 +132,7 @@ class MmuSpoolmanCommand(BaseCommand):
                                   "name the spool explicitly" % gate)
                     return
                 mmu.log_debug("Gate %d resolves to spool id %d for tag registration" % (gate, target))
-            mmu._spoolman_set_spool_uid(target, rfid.strip(), quiet=quiet)
+            mmu._spoolman_set_spool_uid(target, rfid.strip(), append=append, quiet=quiet)
 
         elif spoolinfo is not None:
             # Dump spool info for active spool or specified spool id

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -3483,27 +3483,30 @@ class MmuController(MmuFilamentMovement):
             self.log_error("Error while registering tag uid: %s\n%s" % (str(e), SPOOLMAN_CONFIG_ERROR))
 
 
-    def _spoolman_set_spool_uid(self, spool_id, uid, quiet=True):
+    def _spoolman_set_spool_uid(self, spool_id, uid, append=False, quiet=True):
         """
-        Register (write) an NFC/RFID tag UID onto a spool record in Spoolman
-        so future scans of that tag resolve to this spool_id. Called by
-        'MMU_SPOOLMAN SPOOLID=.. RFID=..'.
+        Write NFC/RFID tag UID(s) onto a spool record in Spoolman so future
+        scans of those tags resolve to this spool_id. Called by
+        'MMU_SPOOLMAN SPOOLID=.. RFID=..' and by a per-gate 'MMU_NFC REGISTER=1
+        APPEND=1' binding a newly scanned tag onto the gate's assigned spool.
 
-        This is the opposite direction to _spoolman_register_tag / MMU_NFC REGISTER=1,
-        which takes a UID and finds (or auto-creates) a spool for it. Here the spool
-        already exists and the tag is bound onto it - the case auto-create cannot serve.
+        This is the opposite direction to _spoolman_register_tag / MMU_NFC REGISTER=1
+        (without APPEND), which takes a UID and finds (or auto-creates) a spool for it.
+        Here the spool already exists and the tag is bound onto it - the case auto-create
+        cannot serve.
 
         Args:
             spool_id: Spool ID to associate the tag with.
-            uid: Tag UID to write onto the spool record.
+            uid: Tag UID (or comma-separated UIDs) to write onto the spool record.
+            append: If True, add to the spool's existing UID(s) instead of replacing them.
             quiet: If True, suppress non-critical output.
         """
         if self.p.spoolman_support == SPOOLMAN_OFF: return
-        self.log_debug("Registering tag uid %s against spool %s in spoolman db" % (uid, spool_id))
+        self.log_debug("Registering tag uid %s against spool %s in spoolman db (append=%s)" % (uid, spool_id, append))
         try:
             webhooks = self.printer.lookup_object('webhooks')
             webhooks.call_remote_method("spoolman_set_spool_uid",
-                                        spool_id=spool_id, uid=uid, silent=quiet)
+                                        spool_id=spool_id, uid=uid, append=append, silent=quiet)
         except Exception as e:
             self.log_error("Error while registering tag uid on spool: %s\n%s" % (str(e), SPOOLMAN_CONFIG_ERROR))
 

--- a/test/hh/spoolman.py
+++ b/test/hh/spoolman.py
@@ -8,8 +8,11 @@
 # Wire-format details that matter (getting these wrong makes HH silently see no data):
 #   - `extra` values are JSON-ENCODED STRINGS, not raw values. HH does
 #     json.loads(extra.get('printer_name', '""')) at mmu_server.py:437 and tolerates a
-#     bare string for the RFID field (_get_uid_from_extra, :388-401). `mmu_gate` is read
-#     with int() so it is stored as a plain numeric string.
+#     bare string for the RFID field (_get_uid_list_from_extra). The RFID field may hold
+#     more than one UID, comma-separated (a spool can have a tag on each side) -
+#     _parse_uid_list splits/normalises/dedupes it; a single UID is just a one-element
+#     case of the same format. `mmu_gate` is read with int() so it is stored as a plain
+#     numeric string.
 #   - a spool embeds its filament, which embeds its vendor:
 #     spool['filament']['vendor']['name'] (_get_filament_attr, :404-415).
 #   - UIDs are normalised uppercase with ':', '-' and ' ' stripped (_normalise_uid,
@@ -51,6 +54,23 @@ SPOOLMANDB_BAMBU = {
 def normalise_uid(uid):
     return (str(uid).strip('"\'').upper()
             .replace(':', '').replace('-', '').replace(' ', ''))
+
+
+def parse_uid_list(raw):
+    """Split a (possibly comma-separated) UID value into normalised UIDs. Mirrors
+    MmuServer._parse_uid_list (mmu_server.py) so the store's notion of 'the UIDs
+    on a spool' matches what HH itself would parse from the same extra value."""
+    if not raw:
+        return []
+    seen = []
+    for part in str(raw).split(','):
+        part = part.strip()
+        if not part:
+            continue
+        norm = normalise_uid(part)
+        if norm and norm not in seen:
+            seen.append(norm)
+    return seen
 
 
 class Response:
@@ -122,7 +142,11 @@ class InMemorySpoolman:
         sid = self._take_id('spool')
         extra = {}
         if uid is not None:
-            extra[FIELD_RFID] = json.dumps(normalise_uid(uid))
+            # 'uid' may be a single UID, a comma-separated string of several, or
+            # an actual list/tuple of UIDs (a spool can have more than one tag).
+            uids = uid if isinstance(uid, (list, tuple)) else [uid]
+            uids = parse_uid_list(','.join(str(u) for u in uids))
+            extra[FIELD_RFID] = json.dumps(','.join(uids))
         if printer is not None:
             extra[FIELD_PRINTER] = json.dumps(printer)
         if gate is not None:
@@ -136,16 +160,21 @@ class InMemorySpoolman:
         }
         return sid
 
-    def spool_uid(self, spool_id):
-        """The normalised UID registered against a spool, or '' if none."""
+    def spool_uids(self, spool_id):
+        """The list of normalised UIDs registered against a spool ([] if none)."""
         raw = self.spools[spool_id]['extra'].get(FIELD_RFID)
         if not raw:
-            return ''
+            return []
         try:
             raw = json.loads(raw)
         except (ValueError, TypeError):
             pass
-        return normalise_uid(raw) if raw else ''
+        return parse_uid_list(raw)
+
+    def spool_uid(self, spool_id):
+        """Comma-joined display string of the UID(s) registered against a spool,
+        or '' if none. Use spool_uids() to test against the individual UIDs."""
+        return ','.join(self.spool_uids(spool_id))
 
     def spool_gate(self, spool_id):
         return int(self.spools[spool_id]['extra'].get(FIELD_GATE, -1))
@@ -160,7 +189,7 @@ class InMemorySpoolman:
     def find_spool_by_uid(self, uid):
         target = normalise_uid(uid)
         for sid in self.spools:
-            if self.spool_uid(sid) == target:
+            if target in self.spool_uids(sid):
                 return sid
         return None
 

--- a/test/test_mmu_moonraker.py
+++ b/test/test_mmu_moonraker.py
@@ -154,6 +154,29 @@ class TestUidCache(MoonrakerTestCase):
                                  'MMU_GATE_MAP NEXT_SPOOLID=1 QUIET=1')
 
 
+class TestMultiUidSpool(MoonrakerTestCase):
+    """
+    A spool can carry more than one physical tag (e.g. one stuck on each side).
+    Both UIDs must independently resolve to the same spool_id.
+    """
+    SECOND_UID = '99998888'
+    SPOOLS = (dict(uid=[KNOWN_UID, SECOND_UID], material='PLA'),)
+
+    def test_extra_field_stores_both_uids_comma_separated(self):
+        self.assertEqual(set(self.hh.db.spool_uids(1)), {KNOWN_UID, self.SECOND_UID})
+
+    def test_cache_maps_both_uids_to_the_same_spool(self):
+        self.assertEqual(self.hh.mmu_server.uid_to_spool_id,
+                         {KNOWN_UID: 1, self.SECOND_UID: 1})
+
+    def test_either_uid_resolves_to_the_spool(self):
+        for uid in (KNOWN_UID, self.SECOND_UID):
+            with self.subTest(uid=uid):
+                self.hh.call_remote('spoolman_get_spool_by_uid', uid=uid,
+                                    gate=None, silent=True)
+                self.assertEqual(self.last_gcode(), 'MMU_GATE_MAP NEXT_SPOOLID=1 QUIET=1')
+
+
 class TestSharedReaderLookup(MoonrakerTestCase):
     SPOOLS = (dict(uid=KNOWN_UID, material='PLA', vendor='Prusament'),)
 
@@ -494,15 +517,54 @@ class TestSetSpoolUid(MoonrakerTestCase):
                                      uid='11223344', silent=True)
         self.assertFalse(result)
 
-    def test_missing_uid_is_refused(self):
-        result = self.hh.call_remote('spoolman_set_spool_uid', spool_id=2, uid=None,
+    def test_blank_uid_clears_the_tag(self):
+        """A blank RFID (replace mode, the default) is the documented way to
+        unregister all tags from a spool - it must succeed, not be refused."""
+        self.assertEqual(self.hh.db.spool_uid(1), KNOWN_UID, 'precondition')
+        result = self.hh.call_remote('spoolman_set_spool_uid', spool_id=1, uid='',
                                      silent=True)
+        self.assertTrue(result)
+        self.assertEqual(self.hh.db.spool_uid(1), '')
+        self.assertIsNone(self.hh.mmu_server.uid_to_spool_id.get(KNOWN_UID))
+
+    def test_replace_drops_the_previous_tag(self):
+        """Default (append=False) replaces, it does not add to, the existing tag(s)."""
+        self.hh.call_remote('spoolman_set_spool_uid', spool_id=1, uid='99998888',
+                            silent=True)
+        self.assertEqual(self.hh.db.spool_uid(1), '99998888')
+        self.assertIsNone(self.hh.db.find_spool_by_uid(KNOWN_UID))
+
+    def test_append_keeps_the_existing_tag_and_adds_the_new_one(self):
+        """The 'second tag on the same spool' case: APPEND=1 must not lose KNOWN_UID."""
+        result = self.hh.call_remote('spoolman_set_spool_uid', spool_id=1,
+                                     uid='99998888', append=True, silent=True)
+        self.assertTrue(result)
+        self.assertEqual(set(self.hh.db.spool_uids(1)), {KNOWN_UID, '99998888'})
+        self.assertEqual(self.hh.db.find_spool_by_uid(KNOWN_UID), 1)
+        self.assertEqual(self.hh.db.find_spool_by_uid('99998888'), 1)
+
+    def test_append_with_blank_uid_is_refused(self):
+        result = self.hh.call_remote('spoolman_set_spool_uid', spool_id=1, uid='',
+                                     append=True, silent=True)
         self.assertFalse(result)
-        self.assertEqual(self.hh.db.spool_uid(2), '')
+        self.assertEqual(self.hh.db.spool_uid(1), KNOWN_UID, 'must be left untouched')
+
+    def test_append_moves_a_tag_registered_to_a_different_spool(self):
+        """No hard block on stealing a UID from another spool - just a warning
+        (mmu_server.py set_spool_uid) - but the move itself must still happen."""
+        self.hh.call_remote('spoolman_set_spool_uid', spool_id=2, uid=KNOWN_UID,
+                            append=True, silent=True)
+        self.assertEqual(self.hh.db.find_spool_by_uid(KNOWN_UID), 2)
+        self.assertNotIn(KNOWN_UID, self.hh.db.spool_uids(1))
 
     def test_unknown_spool_is_refused(self):
         result = self.hh.call_remote('spoolman_set_spool_uid', spool_id=999,
                                      uid='11223344', silent=True)
+        self.assertFalse(result)
+
+    def test_unknown_spool_is_refused_when_appending(self):
+        result = self.hh.call_remote('spoolman_set_spool_uid', spool_id=999,
+                                     uid='11223344', append=True, silent=True)
         self.assertFalse(result)
 
 

--- a/test/test_mmu_roundtrip.py
+++ b/test/test_mmu_roundtrip.py
@@ -29,6 +29,7 @@ logging.getLogger().setLevel(logging.CRITICAL)
 
 TAG_A = 'AAAA1111'
 TAG_B = 'BBBB2222'
+TAG_C = 'CCCC3333'
 UNKNOWN_TAG = 'DEADBEEF'
 TAG_METADATA = dict(material='PETG', brand='Overture', color='00FF00',
                     detail='PETG_Basic', min_temp=230, max_temp=250)
@@ -405,13 +406,23 @@ class TestSpoolmanRfidCommand(RoundTripTestCase):
         self.assertGreater(len(self.rt.errors), errors_before)
         self.assertIn('spoolid', self.rt.errors[-1].lower())
 
-    def test_blank_rfid_errors_rather_than_clearing(self):
-        """Blank means 'clear' in MMU_GATE_MAP; here it must not silently PATCH ''."""
+    def test_blank_rfid_clears_the_registered_tag(self):
+        """
+        Blank RFID= (no APPEND=1) is the documented way to unregister all tags
+        from a spool - it must succeed silently, not error (that used to be
+        rejected outright; now RFID='' is how a spool's tag(s) get cleared).
+        """
         self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 RFID=%s' % TAG_B)
         errors_before = len(self.rt.errors)
-        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 RFID=')
-        self.assertGreater(len(self.rt.errors), errors_before)
-        self.assertEqual(self.rt.db.spool_uid(2), TAG_B, 'existing tag must be untouched')
+        self.rt.run_gcode("MMU_SPOOLMAN SPOOLID=2 RFID=''")
+        self.assertEqual(len(self.rt.errors), errors_before)
+        self.assertEqual(self.rt.db.spool_uid(2), '')
+
+    def test_append_adds_a_second_tag_without_losing_the_first(self):
+        """A spool can carry more than one physical tag (e.g. one on each side)."""
+        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 RFID=%s' % TAG_B)
+        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 RFID=%s APPEND=1' % TAG_C)
+        self.assertEqual(set(self.rt.db.spool_uids(2)), {TAG_B, TAG_C})
 
     def test_the_registered_tag_then_resolves_on_a_scan(self):
         """The round trip: bind a tag, then scanning it must resolve to that spool."""


### PR DESCRIPTION
## Summary
- A Spoolman spool's `rfid_tag` extra field can now hold more than one UID (comma-separated), so users who tag both sides of a spool with their own RFID tags get both tags resolving to the same spool instead of the "other side" scanning as unknown.
- `MMU_SPOOLMAN ... RFID=` gains explicit append/replace semantics: replace is the default (and `RFID=''` now explicitly clears all tags, which used to be rejected outright), with `APPEND=1` to add a tag without losing the existing one(s).
- `MMU_NFC GATE=<g> REGISTER=1 APPEND=1` binds a freshly-scanned unknown tag directly onto the spool already assigned to that gate - the "second physical tag on the same spool" workflow via a scan, instead of manually retyping the UID into `MMU_SPOOLMAN`.
- A UID moving from one spool to another (typo, reused tag, deliberate append) is now visibly logged and the old spool's record is kept in sync rather than silently drifting.

## Behaviour change to note
`MMU_SPOOLMAN SPOOLID=x RFID=''` used to be rejected as invalid input; it now succeeds and clears the spool's registered tag(s).

## Test plan
- [x] `make test` - 965 tests, 1 skipped, 4 expected failures, 0 unexpected failures (matches the known-clean baseline)
- [x] Extended `test/hh/spoolman.py` mock Spoolman for multi-UID storage/lookup
- [x] New/updated cases in `test/test_mmu_moonraker.py` (`TestSetSpoolUid` append/replace/clear/collision, `TestMultiUidSpool`)
- [x] New/updated cases in `test/test_mmu_roundtrip.py` (`TestSpoolmanRfidCommand`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)