### PR TITLE
kconfig: expose remaining hardcoded parameters via menuconfig

### DIFF
--- a/config/base/mmu.cfg
+++ b/config/base/mmu.cfg
@@ -76,10 +76,10 @@ units                     : [[MMU_UNITS]]		# Comma separated list of mmu unit co
 #
 log_level                 : [[PARAM_LOG_LEVEL]]
 log_file_level            : [[PARAM_LOG_FILE_LEVEL]]		# Can also be set to -1 to disable log file completely
-log_statistics            : 1		# 1 to log statistics on every toolchange (default), 0 to disable (but still recorded)
-log_visual                : 1		# 1 log visual representation of filament, 0 = disable
-log_startup_status        : 1		# Whether to log tool to gate status on startup, 1 = summary (default), 0 = disable
-log_m117_messages         : 1		# Whether send toolchange message via M117 to screen
+log_statistics            : [[PARAM_LOG_STATISTICS]]		# 1 to log statistics on every toolchange (default), 0 to disable (but still recorded)
+log_visual                : [[PARAM_LOG_VISUAL]]		# 1 log visual representation of filament, 0 = disable
+log_startup_status        : [[PARAM_LOG_STARTUP_STATUS]]		# Whether to log tool to gate status on startup, 1 = summary (default), 0 = disable
+log_m117_messages         : [[PARAM_LOG_M117_MESSAGES]]		# Whether send toolchange message via M117 to screen
 suppress_klipper_warnings : 0		# Whether to push startup klipper warnings to mmu.log rather than display on console
 
 
@@ -103,8 +103,8 @@ extruder_accel             : [[PARAM_EXTRUDER_ACCEL]]	# Extruder stepper acceler
 # When Happy Hare calls out to a macro for user customization and for parking moves these settings are applied and the previous
 # values automatically restored afterwards. This allows for deterministic movement speed regardless of the starting state.
 #
-macro_toolhead_max_accel        : 0	# Default printer toolhead acceleration applied when macros are run. 0 = use printer max
-macro_toolhead_min_cruise_ratio : 0.5	# Default printer cruise ratio applied when macros are run
+macro_toolhead_max_accel        : [[PARAM_MACRO_TOOLHEAD_MAX_ACCEL]]	# Default printer toolhead acceleration applied when macros are run. 0 = use printer max
+macro_toolhead_min_cruise_ratio : [[PARAM_MACRO_TOOLHEAD_MIN_CRUISE_RATIO]]	# Default printer cruise ratio applied when macros are run
 
 
 # Tip forming --------------------------------------------------------------------------------------------------------
@@ -283,28 +283,28 @@ console_show_filament_color : 1		# 1 = Use colored "swatch" for filament, 0 = Sa
 #
 # Temperature and timeouts
 #
-timeout_pause              : 72000	# Idle time out (printer shuts down) in seconds used when in MMU pause state
-disable_heater             : 600	# Delay in seconds after which the hotend heater is disabled in the MMU_PAUSE state
-default_extruder_temp      : 200	# Default temperature for performing swaps and forming tips when not in print (overridden by gate map)
-extruder_temp_variance     : 2		# When waiting for extruder temperature this is the +/- permissible variance in degrees (>= 1)
+timeout_pause              : [[PARAM_TIMEOUT_PAUSE]]	# Idle time out (printer shuts down) in seconds used when in MMU pause state
+disable_heater             : [[PARAM_DISABLE_HEATER]]	# Delay in seconds after which the hotend heater is disabled in the MMU_PAUSE state
+default_extruder_temp      : [[PARAM_DEFAULT_EXTRUDER_TEMP]]	# Default temperature for performing swaps and forming tips when not in print (overridden by gate map)
+extruder_temp_variance     : [[PARAM_EXTRUDER_TEMP_VARIANCE]]		# When waiting for extruder temperature this is the +/- permissible variance in degrees (>= 1)
 
 #
 # Other workflow options
 #
-startup_reset_ttg_map      : 0		# 1 = reset TTG map on startup, 0 = do nothing
-show_error_dialog          : 1		# 1 = show pop-up dialog in addition to console message, 0 = show error in console
+startup_reset_ttg_map      : [[PARAM_STARTUP_RESET_TTG_MAP]]		# 1 = reset TTG map on startup, 0 = do nothing
+show_error_dialog          : [[PARAM_SHOW_ERROR_DIALOG]]		# 1 = show pop-up dialog in addition to console message, 0 = show error in console
 
 # If enabled with MMU with toolhead sensor, this will cause filament position recovery to perform extra moves to
 # look for filament trapped in the space after extruder but before sensor
-strict_filament_recovery   : 0
+strict_filament_recovery   : [[PARAM_STRICT_FILAMENT_RECOVERY]]
 
-filament_recovery_on_pause : 1		# 1 = Run a quick check to determine current filament position on pause/error, 0 = disable
+filament_recovery_on_pause : [[PARAM_FILAMENT_RECOVERY_ON_PAUSE]]		# 1 = Run a quick check to determine current filament position on pause/error, 0 = disable
 
 # Whether to automatically retry a failed tool change. If enabled Happy Hare will perform the equivalent of 'MMU_RECOVER' + 'Tx'
 # commands which usually is all that is necessary to recover. Note that enabling this can mask problems with your MMU
-retry_tool_change_on_error : 0
- 
-bypass_autoload            : 1		# If extruder sensor fitted this controls the automatic loading of extruder for bypass operation
+retry_tool_change_on_error : [[PARAM_RETRY_TOOL_CHANGE_ON_ERROR]]
+
+bypass_autoload            : [[PARAM_BYPASS_AUTOLOAD]]		# If extruder sensor fitted this controls the automatic loading of extruder for bypass operation
 
 #
 # ADVANCED OPTIONS. Don't mess unless you fully understand. Read documentation.

--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -290,7 +290,7 @@ enable_pin               : [[PIN_GEAR_ENABLE]]
 rotation_distance        : [[PARAM_GEAR_ROTATION_DISTANCE]]	# Typically 22.73 for Bondtech. OVERRIDDEN by calibrated 'mmu_*_gear_rotation_distances' in mmu_vars.cfg
 gear_ratio               : [[PARAM_GEAR_GEAR_RATIO]]		# E.g. ERCFv2 80:20, Tradrack 50:17
 microsteps               : [[PARAM_GEAR_MICROSTEPS]]		# Recommend 16. Increase only if you "step compress" issues when syncing
-full_steps_per_rotation  : 200		# 200 for 1.8 degree, 400 for 0.9 degree
+full_steps_per_rotation  : [[PARAM_GEAR_FULL_STEPS_PER_ROTATION]]		# 200 for 1.8 degree, 400 for 0.9 degree
 
 # Uncomment the two lines below to enable filament "touch" movement option with gear motor
 [% if PIN_GEAR_DIAG != "" %]
@@ -376,7 +376,7 @@ enable_pin               : [[PIN_SELECTOR_ENABLE]]
 rotation_distance        : [[PARAM_SELECTOR_ROTATION_DISTANCE]]
 gear_ratio               : [[PARAM_SELECTOR_GEAR_RATIO]]
 microsteps               : 16		# Don't need high fidelity
-full_steps_per_rotation  : 200		# 200 for 1.8 degree, 400 for 0.9 degree
+full_steps_per_rotation  : [[PARAM_SELECTOR_FULL_STEPS_PER_ROTATION]]		# 200 for 1.8 degree, 400 for 0.9 degree
 [% if PIN_SELECTOR_ENDSTOP %]
 endstop_pin              : [[PIN_SELECTOR_ENDSTOP]]		# Selector default endstop (likely microswitch)
 [% endif %]

--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -49,7 +49,7 @@ selector_homing_speed    : [[PARAM_SELECTOR_HOMING_SPEED]]			# mm/s speed of ini
 [% if PARAM_SELECTOR_TYPE not in ["RotarySelector", "IndexedSelector"] %]
 selector_touch_speed     : [[PARAM_SELECTOR_TOUCH_SPEED]]			# mm/s speed of all "touch" selector moves (if stallguard configured)
 [% endif %]
-selector_accel           : 1200			# Selector stepper acceleration
+selector_accel           : [[PARAM_SELECTOR_ACCEL]]			# Selector stepper acceleration
 [% if PIN_SELECTOR_DIAG != "" and PARAM_SELECTOR_TYPE not in ["RotarySelector", "IndexedSelector"] %]
 
 # Selector touch (stallguard) operation. If stallguard is configured, then this can be used to switch on touch movement which
@@ -202,10 +202,10 @@ gate_preload_attempts         : [[PARAM_GATE_PRELOAD_ATTEMPTS]]		# How many atte
 gate_endstop_to_encoder       : [[PARAM_GATE_ENDSTOP_TO_ENCODER]]		# Distance between gate endstop and encoder (IF both fitted. +ve if encoder after endstop)
 [% endif %]
 [% if PARAM_SELECTOR_TYPE in ["LinearServoSelector", "Testing"] %]
-gate_load_attempts            : 2		# Number of times MMU will attempt to grab the filament on initial load (type-A designs with servo)
+gate_load_attempts            : [[PARAM_GATE_LOAD_ATTEMPTS]]		# Number of times MMU will attempt to grab the filament on initial load (type-A designs with servo)
 [% endif %]
 [% if MMU_HAS_SENSOR_ENTRY %]
-gate_autoload                 : 1		# If mmu entry sensor fitted this controls the automatic loading of the gate
+gate_autoload                 : [[PARAM_GATE_AUTOLOAD]]		# If mmu entry sensor fitted this controls the automatic loading of the gate
 [% endif %]
 gate_final_eject_distance     : [[PARAM_GATE_FINAL_EJECT_DISTANCE]]		# Additional distance to eject filament on MMU_EJECT to clear MMU's grip
 
@@ -238,14 +238,14 @@ bowden_unload_homing_buffer      : [[PARAM_BOWDEN_UNLOAD_HOMING_BUFFER]]		# Dist
 # reading and make correction moves to bring the filament to within the 'bowden_allowable_encoder_delta' of the end of
 # bowden position (this does require a reliable encoder and is not recommended for very high speed loading >350mm/s)
 #
-bowden_apply_correction          : 0		# 1 to enable, 0 disabled
-bowden_allowable_encoder_delta   : 20.0		# How close in mm the correction moves will attempt to get to target
+bowden_apply_correction          : [[PARAM_BOWDEN_APPLY_CORRECTION]]		# 1 to enable, 0 disabled
+bowden_allowable_encoder_delta   : [[PARAM_BOWDEN_ALLOWABLE_ENCODER_DELTA]]		# How close in mm the correction moves will attempt to get to target
 
 # This saftey check uses the encoder to verify the filament is free of extruder before the fast bowden movement to
 # reduce possibility of grinding filament. If enabled the trigger can be tuned by setting the "bowden_pre_unload_error_tolerance"
 # which represents the percentage of allowable mismatch between actual movement and that seen by encoder. Setting to 50% tolerance
 # usually works well. Increasing will make test more tolerant and a value of 100% essentially disables error detection
-bowden_pre_unload_test            : 1		# 1 to check for bowden movement before full pull (slower), 0 don't check (faster)
+bowden_pre_unload_test            : [[PARAM_BOWDEN_PRE_UNLOAD_TEST]]		# 1 to check for bowden movement before full pull (slower), 0 don't check (faster)
 bowden_pre_unload_error_tolerance : 50		# ADVANCED: % tune pre_unload_test sensitivity
 
 # ADVANCED: Controls the detection of successful bowden load/unload movement and represents the percentage of allowable
@@ -335,12 +335,12 @@ toolhead_post_load_tighten        : 60		# % of clog detection length, 0 to disab
 
 # If synchronizing gear and extruder and you have a sync-feedback "buffer" (switch based or proportional) this setting
 # determines whether to use it to create neutral tension after loading
-toolhead_post_load_tension_adjust : 1	# 1 to enable (recommended), 0 to disable
+toolhead_post_load_tension_adjust : [[PARAM_TOOLHEAD_POST_LOAD_TENSION_ADJUST]]	# 1 to enable (recommended), 0 to disable
 
 # If sync-feedback compression sensor is available this test will ensure the filament passes the extruder entry by checking
 # for neutral tension when moving filament with just the extruder. Recommended with sprung loaded sync-feedback buffers.
 # This is ignored if toolhead sensor is available.
-toolhead_entry_tension_test       : 1		# 1 to enable (recommended), 0 to disable
+toolhead_entry_tension_test       : [[PARAM_TOOLHEAD_ENTRY_TENSION_TEST]]		# 1 to enable (recommended), 0 to disable
 [% if MMU_HAS_ENCODER %]
 
 # ADVANCED: Controls the detection of successful extruder load/unload movement and represents the percentage of allowable
@@ -385,16 +385,16 @@ sync_purge                      : [[PARAM_SYNC_PURGE]]	# Synchronize during stan
 # so that values are saved)
 #
 sync_feedback_enabled           : [[PARAM_SYNC_FEEDBACK_ENABLED]]	# Turn off even if sensor is installed and active
-sync_feedback_speed_multiplier  : 5	# % "twolevel" gear speed delta to keep filament neutral in buffer (recommend 5%)
-sync_feedback_boost_multiplier  : 3	# % "twolevel" extra gear speed boost for finding initial neutral position (recommend 3%)
-sync_feedback_extrude_threshold : 5	# Extruder movement (mm) for updates (keep small but set > retract distance)
+sync_feedback_speed_multiplier  : [[PARAM_SYNC_FEEDBACK_SPEED_MULTIPLIER]]	# % "twolevel" gear speed delta to keep filament neutral in buffer (recommend 5%)
+sync_feedback_boost_multiplier  : [[PARAM_SYNC_FEEDBACK_BOOST_MULTIPLIER]]	# % "twolevel" extra gear speed boost for finding initial neutral position (recommend 3%)
+sync_feedback_extrude_threshold : [[PARAM_SYNC_FEEDBACK_EXTRUDE_THRESHOLD]]	# Extruder movement (mm) for updates (keep small but set > retract distance)
 
 # If defined this forces debugging to a telemetry log file "sync_<gate>.jsonl". This is great if trying to tune clog/tangle
 # detection or for getting help on the Happy Hare forum. To plot graph of sync-feedback operation, run:
 #  ~/Happy-Hare/utils/plot_sync_feedback.sh
 #   0 = disable (normal operation), 1 = enable telemetry log (for debugging)
 #
-sync_feedback_debug_log         : 0
+sync_feedback_debug_log         : [[PARAM_SYNC_FEEDBACK_DEBUG_LOG]]
 
 
 [% endif %]
@@ -481,30 +481,30 @@ flowguard_encoder_max_motion : [[PARAM_FLOWGUARD_ENCODER_MAX_MOTION]]
 # If using a digitally controlled espooler motor (not PWM) then you should turn off the "print" mode and set
 # 'espooler_min_stepper_speed' to prevent "over movement"
 #
-espooler_min_distance    : 30			# Individual stepper movements less than this distance will not active espooler
-espooler_max_stepper_speed : 300		# Gear stepper speed at which espooler will be at maximum power
-espooler_min_stepper_speed : 0			# Gear stepper speed at which espooler will become inactive (useful for non PWM control)
-espooler_speed_exponent  : 0.5			# Controls non-linear espooler power relative to stepper speed (see notes)
-espooler_assist_reduced_speed : 50		# Control the % of the rewind speed that is applied to assisting load (want rewind to be faster)
-espooler_printing_power  : 0			# If >0, fixes the % of PWM power while printing. 0=allows burst movement
-espooler_operations      : rewind, assist, print	# List of operational modes (allows disabling even if h/w is configured)
+espooler_min_distance    : [[PARAM_ESPOOLER_MIN_DISTANCE]]			# Individual stepper movements less than this distance will not active espooler
+espooler_max_stepper_speed : [[PARAM_ESPOOLER_MAX_STEPPER_SPEED]]		# Gear stepper speed at which espooler will be at maximum power
+espooler_min_stepper_speed : [[PARAM_ESPOOLER_MIN_STEPPER_SPEED]]			# Gear stepper speed at which espooler will become inactive (useful for non PWM control)
+espooler_speed_exponent  : [[PARAM_ESPOOLER_SPEED_EXPONENT]]			# Controls non-linear espooler power relative to stepper speed (see notes)
+espooler_assist_reduced_speed : [[PARAM_ESPOOLER_ASSIST_REDUCED_SPEED]]		# Control the % of the rewind speed that is applied to assisting load (want rewind to be faster)
+espooler_printing_power  : [[PARAM_ESPOOLER_PRINTING_POWER]]			# If >0, fixes the % of PWM power while printing. 0=allows burst movement
+espooler_operations      : [[PARAM_ESPOOLER_OPERATIONS]]	# List of operational modes (allows disabling even if h/w is configured)
 #
 # The following burst configuration is used to control the small rotation in the ASSIST direction optionally used
 # when in 'print' operation is enabled, 'espooler_printing_power: 0' and is triggered (tension switch or extruder movement).
 # It can also be used to loosen filament with 'MMU_ESPOOLER COMMAND=assist BURST=1'
 #
-espooler_assist_extruder_move_length : 100	# Distance (mm) extruder needs to move between each assist burst
-espooler_assist_burst_power : 100		# The % power of the burst move
-espooler_assist_burst_duration : 0.4		# The duration of the burst move is seconds
-espooler_assist_burst_trigger : 0		# If trigger assist switch is fitted 0=disable, 1=enable
-espooler_assist_burst_trigger_max : 3		# If trigger assist switch is fitted this limits the max number of back-to-back advances
+espooler_assist_extruder_move_length : [[PARAM_ESPOOLER_ASSIST_EXTRUDER_MOVE_LENGTH]]	# Distance (mm) extruder needs to move between each assist burst
+espooler_assist_burst_power : [[PARAM_ESPOOLER_ASSIST_BURST_POWER]]		# The % power of the burst move
+espooler_assist_burst_duration : [[PARAM_ESPOOLER_ASSIST_BURST_DURATION]]		# The duration of the burst move is seconds
+espooler_assist_burst_trigger : [[PARAM_ESPOOLER_ASSIST_BURST_TRIGGER]]		# If trigger assist switch is fitted 0=disable, 1=enable
+espooler_assist_burst_trigger_max : [[PARAM_ESPOOLER_ASSIST_BURST_TRIGGER_MAX]]		# If trigger assist switch is fitted this limits the max number of back-to-back advances
 #
 # The following burst configuration is used to control the small rotation in the REWIND direction optionally used
 # when running running the filament drying cycle. The goal is to rotate the spool 60-90 degrees. It can also be
 # used to tighten the filament with 'MMU_ESPOOLER COMMAND=rewind BURST=1'
 #
-espooler_rewind_burst_power : 100		# The % power of the rewind burst move
-espooler_rewind_burst_duration : 0.4		# The duration of the rewind burst move is seconds
+espooler_rewind_burst_power : [[PARAM_ESPOOLER_REWIND_BURST_POWER]]		# The % power of the rewind burst move
+espooler_rewind_burst_duration : [[PARAM_ESPOOLER_REWIND_BURST_DURATION]]		# The duration of the rewind burst move is seconds
 
 
 [% endif %]
@@ -615,12 +615,12 @@ skip_cal_encoder           : [[PARAM_SKIP_CAL_ENCODER]]		# Skip encoder calibrat
 #  1 = force mmu homing on startup if unloaded, then reselect the last gate used
 #  0 = trust the position saved at shutdown, so no homing is needed (an explicit
 #      MMU_MOTORS_OFF discards that saved position and does require a re-home)
-startup_home_selector    : 0
+startup_home_selector    : [[PARAM_STARTUP_HOME_SELECTOR]]
 [% endif %]
 [% if MMU_HAS_ENCODER %]
 # ADVANCED: Determines if encoder measurement should be used to validate movement distance
 #  0 = Validation is disabled (eliminates slight pause between moves but less safe)
-encoder_move_validation  : 1
+encoder_move_validation  : [[PARAM_ENCODER_MOVE_VALIDATION]]
 [% endif %]
 
 

--- a/installer/Kconfig.encoder
+++ b/installer/Kconfig.encoder
@@ -7,6 +7,10 @@
 #   PARAM_ENCODER_RESOLUTION
 #   PARAM_GATE_ENDSTOP_TO_ENCODER
 #   PIN_ENCODER (duplicate with pins)
+#   PARAM_BOWDEN_APPLY_CORRECTION
+#   PARAM_BOWDEN_ALLOWABLE_ENCODER_DELTA
+#   PARAM_BOWDEN_PRE_UNLOAD_TEST
+#   PARAM_ENCODER_MOVE_VALIDATION
 #
 # Can be disabled and forced off with:
 #   select UNSELECT_MMU_HAS_ENCODER
@@ -138,7 +142,59 @@ if MMU_HAS_ENCODER
         default 1 if BOOL_REGISTER_AS_SENSOR
         default 0
 
-  endif
+    endif
+
+    comment "_"
+    comment "_Bowden movement"
+
+    config BOOL_BOWDEN_APPLY_CORRECTION
+      bool "Apply bowden correction moves?"
+      default n
+      help
+        In addition to different bowden loading speeds for buffer and non-buffered filament it is possible to
+        detect missed steps caused by "jerking" on a heavy spool. If bowden correction is enabled Happy Hare
+        will "believe" the encoder reading and make correction moves to bring the filament to within the
+        'bowden_allowable_encoder_delta' of the end of bowden position (this does require a reliable encoder
+        and is not recommended for very high speed loading >350mm/s)
+
+    config PARAM_BOWDEN_APPLY_CORRECTION
+      int
+      default 1 if BOOL_BOWDEN_APPLY_CORRECTION
+      default 0
+
+    config PARAM_BOWDEN_ALLOWABLE_ENCODER_DELTA
+      float "Bowden allowable encoder delta"
+      default 20.0
+      help
+        How close in mm the correction moves will attempt to get to target
+
+    config BOOL_BOWDEN_PRE_UNLOAD_TEST
+      bool "Check for bowden movement before full unload pull?"
+      default y
+      help
+        This saftey check uses the encoder to verify the filament is free of extruder before the fast bowden
+        movement to reduce possibility of grinding filament. If enabled the trigger can be tuned by setting
+        the "bowden_pre_unload_error_tolerance" which represents the percentage of allowable mismatch between
+        actual movement and that seen by encoder. Setting to 50% tolerance usually works well. Increasing
+        will make test more tolerant and a value of 100% essentially disables error detection.
+        1 to check for bowden movement before full pull (slower), 0 don't check (faster)
+
+    config PARAM_BOWDEN_PRE_UNLOAD_TEST
+      int
+      default 1 if BOOL_BOWDEN_PRE_UNLOAD_TEST
+      default 0
+
+    config BOOL_ENCODER_MOVE_VALIDATION
+      bool "Use encoder to validate movement distance?"
+      default y
+      help
+        ADVANCED: Determines if encoder measurement should be used to validate movement distance.
+        Disabling eliminates slight pause between moves but is less safe
+
+    config PARAM_ENCODER_MOVE_VALIDATION
+      int
+      default 1 if BOOL_ENCODER_MOVE_VALIDATION
+      default 0
 
   endmenu
 endif

--- a/installer/Kconfig.espooler
+++ b/installer/Kconfig.espooler
@@ -7,6 +7,21 @@
 # PIN_ESPOOLER_FWD_<gate>
 # PIN_ESPOOLER_TRIG_<gate>
 #
+# PARAM_ESPOOLER_MIN_DISTANCE
+# PARAM_ESPOOLER_MAX_STEPPER_SPEED
+# PARAM_ESPOOLER_MIN_STEPPER_SPEED
+# PARAM_ESPOOLER_SPEED_EXPONENT
+# PARAM_ESPOOLER_ASSIST_REDUCED_SPEED
+# PARAM_ESPOOLER_PRINTING_POWER
+# PARAM_ESPOOLER_OPERATIONS
+# PARAM_ESPOOLER_ASSIST_EXTRUDER_MOVE_LENGTH
+# PARAM_ESPOOLER_ASSIST_BURST_POWER
+# PARAM_ESPOOLER_ASSIST_BURST_DURATION
+# PARAM_ESPOOLER_ASSIST_BURST_TRIGGER
+# PARAM_ESPOOLER_ASSIST_BURST_TRIGGER_MAX
+# PARAM_ESPOOLER_REWIND_BURST_POWER
+# PARAM_ESPOOLER_REWIND_BURST_DURATION
+#
 # Can be disabled and forced off with:
 #   select UNSELECT_MMU_HAS_ESPOOLER
 
@@ -40,7 +55,148 @@ if MMU_HAS_ESPOOLER
   config UNSELECT_MMU_HAS_FILAMENT_BUFFER
     default y
 
-  menu "eSpooler pins"
+  menu "eSpooler config"
+
+# -------------------------------------
+# eSpooler operation
+# -------------------------------------
+
+    config PARAM_ESPOOLER_MIN_DISTANCE
+      float "Espooler minimum move distance   "
+      default 30
+      help
+        Individual stepper movements less than this distance will not active espooler
+
+    config PARAM_ESPOOLER_MAX_STEPPER_SPEED
+      float "Espooler max stepper speed       "
+      default 300
+      help
+        Gear stepper speed at which espooler will be at maximum power
+
+    config PARAM_ESPOOLER_MIN_STEPPER_SPEED
+      float "Espooler min stepper speed       "
+      default 0
+      help
+        Gear stepper speed at which espooler will become inactive (useful for non PWM control)
+
+    config PARAM_ESPOOLER_SPEED_EXPONENT
+      float "Espooler speed exponent          "
+      default 0.5
+      help
+        Controls non-linear espooler power relative to stepper speed. Typically the espooler will be
+        controlled with PWM signal. This will be at the maximum at speeds equal or above
+        'espooler_max_stepper_speed'. The PWM signal will scale downwards towards 0 for slower speeds.
+        The falloff being controlled by this setting according to this formula (0.5 is a good starting
+        value):
+
+          espooler_pwm = (stepper_speed / espooler_max_stepper_speed) ^ espooler_speed_exponent
+
+    config PARAM_ESPOOLER_ASSIST_REDUCED_SPEED
+      int "Espooler assist reduced speed    "
+      range 0 100
+      default 50
+      help
+        Control the % of the rewind speed that is applied to assisting load (want rewind to be faster)
+
+    config PARAM_ESPOOLER_PRINTING_POWER
+      int "Espooler printing power          "
+      range 0 100
+      default 0
+      help
+        If >0, fixes the % of PWM power while printing. 0=allows burst movement
+
+    config PARAM_ESPOOLER_OPERATIONS
+      string "Espooler enabled operations      "
+      default "rewind, assist, print"
+      help
+        Regardless of h/w configuration you can enable/disable actions with this list. E.g. remove
+        'print' to turn off operation while printing. Options are:
+
+          rewind - when filament is being unloaded under MMU control (aka respool)
+          assist - when filament is being loaded under MMU control (% of "rewind" speed but with
+                   minimum of "print" power)
+          print  - while printing. Generally set 'espooler_printing_power' to a low percentage just to
+                   allow motor to be turned freely or set to 0 to enable/allow "burst" assist movements
+
+        If using a digitally controlled espooler motor (not PWM) then you should remove "print" and set
+        'espooler_min_stepper_speed' to prevent "over movement"
+
+    comment "_"
+    comment "Assist burst (ASSIST direction, e.g. print/loosen)"
+
+    config PARAM_ESPOOLER_ASSIST_EXTRUDER_MOVE_LENGTH
+      float "Espooler assist extruder move    "
+      default 100
+      help
+        This burst configuration is used to control the small rotation in the ASSIST direction
+        optionally used when 'print' operation is enabled, 'espooler_printing_power: 0' and is
+        triggered (tension switch or extruder movement). It can also be used to loosen filament with
+        'MMU_ESPOOLER COMMAND=assist BURST=1'.
+
+        Distance (mm) extruder needs to move between each assist burst
+
+    config PARAM_ESPOOLER_ASSIST_BURST_POWER
+      int "Espooler assist burst power      "
+      range 0 100
+      default 100
+      help
+        The % power of the burst move
+
+    config PARAM_ESPOOLER_ASSIST_BURST_DURATION
+      float "Espooler assist burst duration   "
+      default 0.4
+      help
+        The duration of the burst move in seconds
+
+    config BOOL_ESPOOLER_ASSIST_BURST_TRIGGER
+      bool "Trigger assist switch fitted?"
+      default n
+      help
+        If trigger assist switch is fitted 0=disable, 1=enable
+
+    config PARAM_ESPOOLER_ASSIST_BURST_TRIGGER
+      int
+      default 1 if BOOL_ESPOOLER_ASSIST_BURST_TRIGGER
+      default 0
+
+    config PARAM_ESPOOLER_ASSIST_BURST_TRIGGER_MAX
+      int
+      default 3
+
+    config PARAM_ESPOOLER_ASSIST_BURST_TRIGGER_MAX
+      prompt "Espooler assist burst trigger max"
+      depends on BOOL_ESPOOLER_ASSIST_BURST_TRIGGER
+      help
+        If trigger assist switch is fitted this limits the max number of back-to-back advances
+
+    comment "_"
+    comment "Rewind burst (REWIND direction, e.g. drying/tighten)"
+
+    config PARAM_ESPOOLER_REWIND_BURST_POWER
+      int "Espooler rewind burst power      "
+      range 0 100
+      default 100
+      help
+        This burst configuration is used to control the small rotation in the REWIND direction
+        optionally used when running the filament drying cycle. The goal is to rotate the spool
+        60-90 degrees. It can also be used to tighten the filament with
+        'MMU_ESPOOLER COMMAND=rewind BURST=1'.
+
+        The % power of the rewind burst move
+
+    config PARAM_ESPOOLER_REWIND_BURST_DURATION
+      float "Espooler rewind burst duration   "
+      default 0.4
+      help
+        The duration of the rewind burst move in seconds
+
+# -------------------------------------
+# eSpooler pins
+# -------------------------------------
+
+    comment "_"
+    comment "_eSpooler pins"
+
     @repeat var=i min=0 max=11@
       if PARAM_NUM_GATES > $(i)
         comment "_" if $(i) > 0

--- a/installer/Kconfig.filament_buffer
+++ b/installer/Kconfig.filament_buffer
@@ -8,7 +8,7 @@
 
 
 config UNSELECT_MMU_HAS_FILAMENT_BUFFER
-  bool
+  def_bool n
 
 if !UNSELECT_MMU_HAS_FILAMENT_BUFFER
   comment "_"

--- a/installer/Kconfig.gates
+++ b/installer/Kconfig.gates
@@ -8,18 +8,20 @@
 #   PARAM_GATE_PRELOAD_HOMING_MAX
 #   PARAM_GATE_PRELOAD_ATTEMPTS
 #   PARAM_GATE_FINAL_EJECT_DISTANCE
+#   PARAM_GATE_LOAD_ATTEMPTS
+#   PARAM_GATE_AUTOLOAD
 
 menu "Gate loading & parking"
 
   config PARAM_GATE_HOMING_MAX
-    float "Maximum homing distance   "
+    float "Maximum homing distance     "
     default 100
     help
       Maximum extra move distance (mm) to home (or actual move distance if
       using "encoder" endstop)
 
   config PARAM_GATE_PARKING_DISTANCE
-    float "Gate parking distance     "
+    float "Gate parking distance       "
     default -23
     help
       Parking position relative to homing endstop. Must be -ve (retraction)
@@ -30,7 +32,7 @@ menu "Gate loading & parking"
       Positive values for movement in the extrude direction (past sensor)
 
   config PARAM_GATE_PRELOAD_HOMING_MAX
-    float "Preload homing distance   "
+    float "Preload homing distance     "
     default PARAM_GATE_HOMING_MAX
     help
       Maximum homing distance (mm) to the mmu_exit endstop
@@ -38,7 +40,7 @@ menu "Gate loading & parking"
       Usually this is the same as gate homing distance
 
   config PARAM_GATE_PRELOAD_PARKING_DISTANCE
-    float "Preload parking distance  "
+    float "Preload parking distance    "
     default PARAM_GATE_PARKING_DISTANCE
     help
       Filament parking distance (mm) after homing to configured gate homing sensor
@@ -50,15 +52,35 @@ menu "Gate loading & parking"
       Usually this is the same as gate parking distance
 
   config PARAM_GATE_PRELOAD_ATTEMPTS
-    int "Number of preload attempts"
+    int "Number of preload attempts  "
     default 2
     help
       Number of attempts to make at loading the filament after preload is issued.
 
   config PARAM_GATE_FINAL_EJECT_DISTANCE
-    float "Final eject distance      "
+    float "Final eject distance        "
     default 20
     help
       Additional distance to eject filament on MMU_EJECT to clear MMU's grip
+
+  config PARAM_GATE_LOAD_ATTEMPTS
+    int "Number of gate load attempts"
+    range 1 20
+    default 2
+    depends on LINEAR_SERVO_SELECTOR || TESTING_SELECTOR
+    help
+      Number of times MMU will attempt to grab the filament on initial load (type-A designs with servo)
+
+  config BOOL_GATE_AUTOLOAD
+    bool "Automatically load gate when entry sensor triggers?"
+    default y
+    depends on MMU_HAS_SENSOR_ENTRY
+    help
+      If mmu entry sensor fitted this controls the automatic loading of the gate
+
+  config PARAM_GATE_AUTOLOAD
+    int
+    default 1 if BOOL_GATE_AUTOLOAD
+    default 0
 
 endmenu

--- a/installer/Kconfig.gear_stepper
+++ b/installer/Kconfig.gear_stepper
@@ -5,27 +5,34 @@
 #   PARAM_GEAR_ROTATION_DISTANCE
 #   PARAM_GEAR_RUN_CURRENT
 #   PARAM_GEAR_HOLD_CURRENT
+#   PARAM_GEAR_FULL_STEPS_PER_ROTATION
 
 menu "Gear stepper"
 
   config PARAM_GEAR_GEAR_RATIO
-    string "Gear ratio            "
+    string "Gear ratio             "
     default "1:1"
 
   config PARAM_GEAR_ROTATION_DISTANCE
-    float "Gear rotation distance"
+    float "Gear rotation distance "
     default 22.7316868
 
   config PARAM_GEAR_RUN_CURRENT
-    float "Gear run current      "
+    float "Gear run current       "
     default 0.7
 
   config PARAM_GEAR_HOLD_CURRENT
-    float "Gear hold current     "
+    float "Gear hold current      "
     default 0.1
 
   config PARAM_GEAR_MICROSTEPS
-    int "Microsteps            "
+    int "Microsteps             "
     default 16
+
+  config PARAM_GEAR_FULL_STEPS_PER_ROTATION
+    int "Full steps per rotation"
+    default 200
+    help
+      200 for 1.8 degree, 400 for 0.9 degree
 
 endmenu

--- a/installer/Kconfig.motor_sync
+++ b/installer/Kconfig.motor_sync
@@ -7,6 +7,8 @@
 #   PARAM_SYNC_FORM_TIP
 #   PARAM_SYNC_PURGE
 #   PARAM_SYNC_GEAR_CURRENT
+#   PARAM_TOOLHEAD_POST_LOAD_TENSION_ADJUST
+#   PARAM_TOOLHEAD_ENTRY_TENSION_TEST
 
 menu "MMU/Extruder sync"
   help
@@ -73,6 +75,33 @@ menu "MMU/Extruder sync"
   config PARAM_SYNC_PURGE
     int
     default 1 if BOOL_ENABLE_SYNC_PURGE
+    default 0
+
+  comment "_"
+
+  config BOOL_TOOLHEAD_POST_LOAD_TENSION_ADJUST
+    bool "Adjust neutral tension after toolhead load?"
+    default y
+    help
+      If synchronizing gear and extruder and you have a sync-feedback "buffer" (switch based or
+      proportional) this setting determines whether to use it to create neutral tension after loading
+
+  config PARAM_TOOLHEAD_POST_LOAD_TENSION_ADJUST
+    int
+    default 1 if BOOL_TOOLHEAD_POST_LOAD_TENSION_ADJUST
+    default 0
+
+  config BOOL_TOOLHEAD_ENTRY_TENSION_TEST
+    bool "Test filament entry via tension after extruder move?"
+    default y
+    help
+      If sync-feedback compression sensor is available this test will ensure the filament passes the
+      extruder entry by checking for neutral tension when moving filament with just the extruder.
+      Recommended with sprung loaded sync-feedback buffers. This is ignored if toolhead sensor is available.
+
+  config PARAM_TOOLHEAD_ENTRY_TENSION_TEST
+    int
+    default 1 if BOOL_TOOLHEAD_ENTRY_TENSION_TEST
     default 0
 
 endmenu

--- a/installer/Kconfig.options
+++ b/installer/Kconfig.options
@@ -14,6 +14,23 @@
 #
 #   INSTALL_12864_MENU
 #   INSTALL_CLIENT_MACROS
+#
+#   PARAM_LOG_STATISTICS
+#   PARAM_LOG_VISUAL
+#   PARAM_LOG_STARTUP_STATUS
+#   PARAM_LOG_M117_MESSAGES
+#
+#   PARAM_TIMEOUT_PAUSE
+#   PARAM_DISABLE_HEATER
+#   PARAM_DEFAULT_EXTRUDER_TEMP
+#   PARAM_EXTRUDER_TEMP_VARIANCE
+#
+#   PARAM_STARTUP_RESET_TTG_MAP
+#   PARAM_SHOW_ERROR_DIALOG
+#   PARAM_STRICT_FILAMENT_RECOVERY
+#   PARAM_FILAMENT_RECOVERY_ON_PAUSE
+#   PARAM_RETRY_TOOL_CHANGE_ON_ERROR
+#   PARAM_BYPASS_AUTOLOAD
 
 menu "Software Options"
   help
@@ -23,13 +40,10 @@ menu "Software Options"
     config files.
 
 
-
-
 # -------------------------------------
 # Endless Spool
 # -------------------------------------
 
-  comment "_"
   comment "_EndlessSpool"
 
   config BOOL_ENDLESS_SPOOL_ENABLED
@@ -210,12 +224,50 @@ menu "Software Options"
     default 4 if CHOICE_LOG_FILE_LEVEL_STEPPER
     default 2
 
+  config BOOL_LOG_STATISTICS
+    bool "Log statistics on every toolchange?"
+    default y
+    help
+      1 to log statistics on every toolchange (default), 0 to disable (but still recorded)
+
+  config PARAM_LOG_STATISTICS
+    int
+    default 1 if BOOL_LOG_STATISTICS
+    default 0
+
+  config BOOL_LOG_VISUAL
+    bool "Log visual representation of filament?"
+    default y
+    help
+      1 log visual representation of filament, 0 = disable
+
+  config PARAM_LOG_VISUAL
+    int
+    default 1 if BOOL_LOG_VISUAL
+    default 0
+
+  config PARAM_LOG_STARTUP_STATUS
+    int "Log tool to gate status on startup"
+    range 0 2
+    default 1
+    help
+      Whether to log tool to gate status on startup, 1 = summary (default), 0 = disable
+
+  config BOOL_LOG_M117_MESSAGES
+    bool "Send toolchange message via M117 to screen?"
+    default y
+    help
+      Whether send toolchange message via M117 to screen
+
+  config PARAM_LOG_M117_MESSAGES
+    int
+    default 1 if BOOL_LOG_M117_MESSAGES
+    default 0
+
 
 # -------------------------------------
 # Tool (Tx) Macros
 # -------------------------------------
-
-  comment "_"
 
   choice CHOICE_T_MACRO_COLOR
     prompt "Filament color shown on Tx tool macros (Mainsail/Fluidd)"
@@ -251,10 +303,121 @@ menu "Software Options"
 
 
 # -------------------------------------
+# Temperature & Timeouts
+# -------------------------------------
+
+  comment "_"
+  comment "_Temperature & Timeouts"
+
+  config PARAM_TIMEOUT_PAUSE
+    int "Pause idle timeout                 "
+    default 72000
+    help
+      Idle time out (printer shuts down) in seconds used when in MMU pause state
+
+  config PARAM_DISABLE_HEATER
+    int "Disable heater delay               "
+    default 600
+    help
+      Delay in seconds after which the hotend heater is disabled in the MMU_PAUSE state
+
+  config PARAM_DEFAULT_EXTRUDER_TEMP
+    float "Default extruder temperature       "
+    default 200
+    help
+      Default temperature for performing swaps and forming tips when not in print (overridden by gate map)
+
+  config PARAM_EXTRUDER_TEMP_VARIANCE
+    float "Extruder temperature variance      "
+    default 2
+    help
+      When waiting for extruder temperature this is the +/- permissible variance in degrees (>= 1)
+
+
+# -------------------------------------
+# Workflow
+# -------------------------------------
+
+  comment "_"
+  comment "_Workflow"
+
+  config BOOL_STARTUP_RESET_TTG_MAP
+    bool "Reset tool-to-gate map on startup?"
+    default n
+    help
+      1 = reset TTG map on startup, 0 = do nothing
+
+  config PARAM_STARTUP_RESET_TTG_MAP
+    int
+    default 1 if BOOL_STARTUP_RESET_TTG_MAP
+    default 0
+
+  config BOOL_SHOW_ERROR_DIALOG
+    bool "Show pop-up dialog on error?"
+    default y
+    help
+      1 = show pop-up dialog in addition to console message, 0 = show error in console
+
+  config PARAM_SHOW_ERROR_DIALOG
+    int
+    default 1 if BOOL_SHOW_ERROR_DIALOG
+    default 0
+
+  config BOOL_STRICT_FILAMENT_RECOVERY
+    bool "Use strict filament recovery?"
+    default n
+    help
+      If enabled with MMU with toolhead sensor, this will cause filament position recovery to perform
+      extra moves to look for filament trapped in the space after extruder but before sensor
+
+  config PARAM_STRICT_FILAMENT_RECOVERY
+    int
+    default 1 if BOOL_STRICT_FILAMENT_RECOVERY
+    default 0
+
+  config BOOL_FILAMENT_RECOVERY_ON_PAUSE
+    bool "Check filament position on pause/error?"
+    default y
+    help
+      1 = Run a quick check to determine current filament position on pause/error, 0 = disable
+
+  config PARAM_FILAMENT_RECOVERY_ON_PAUSE
+    int
+    default 1 if BOOL_FILAMENT_RECOVERY_ON_PAUSE
+    default 0
+
+  config BOOL_RETRY_TOOL_CHANGE_ON_ERROR
+    bool "Automatically retry a failed tool change?"
+    default n
+    help
+      Whether to automatically retry a failed tool change. If enabled Happy Hare will perform the
+      equivalent of 'MMU_RECOVER' + 'Tx' commands which usually is all that is necessary to recover.
+      Note that enabling this can mask problems with your MMU
+
+  config PARAM_RETRY_TOOL_CHANGE_ON_ERROR
+    int
+    default 1 if BOOL_RETRY_TOOL_CHANGE_ON_ERROR
+    default 0
+
+  config BOOL_BYPASS_AUTOLOAD
+    bool "Automatically load extruder for bypass operation?"
+    default y
+    depends on MMU_HAS_SENSOR_EXTRUDER
+    help
+      If extruder sensor fitted this controls the automatic loading of extruder for bypass operation
+
+  config PARAM_BYPASS_AUTOLOAD
+    int
+    default 1 if BOOL_BYPASS_AUTOLOAD
+    default 0
+
+
+# -------------------------------------
 # Optional Macros
 # -------------------------------------
 
   comment "_"
+  comment "_Optional Macros"
 
   config INSTALL_12864_MENU
     bool "Install Mini 12864 display menu?"

--- a/installer/Kconfig.selector_stepper
+++ b/installer/Kconfig.selector_stepper
@@ -7,6 +7,9 @@
 #   PARAM_SELECTOR_RUN_CURRENT
 #   PARAM_SELECTOR_HOLD_CURRENT
 #   PARAM_SELECTOR_ENDSTOP_NAME
+#   PARAM_SELECTOR_ACCEL
+#   PARAM_SELECTOR_FULL_STEPS_PER_ROTATION
+#   PARAM_STARTUP_HOME_SELECTOR
 #
 #   PARAM_SELECTOR_TOUCH_ENABLED
 #
@@ -22,24 +25,47 @@ if MMU_HAS_SELECTOR_STEPPER
 # -------------------------------------
 
     config PARAM_SELECTOR_GEAR_RATIO
-      string "Selector gear ratio       "
+      string "Selector gear ratio             "
       default "1:1"
 
     config PARAM_SELECTOR_ROTATION_DISTANCE
-      float "Selector rotation distance"
+      float "Selector rotation distance      "
       default 40
 
     config PARAM_SELECTOR_RUN_CURRENT
-      float "Selector run current      "
+      float "Selector run current            "
       default 0.5
 
     config PARAM_SELECTOR_HOLD_CURRENT
-      float "Selector hold current     "
+      float "Selector hold current           "
       default 0.2
 
     config PARAM_SELECTOR_ENDSTOP_NAME
       string
       default "mmu_sel_home"
+
+    config PARAM_SELECTOR_ACCEL
+      float "Selector stepper acceleration   "
+      default 1200
+
+    config PARAM_SELECTOR_FULL_STEPS_PER_ROTATION
+      int "Selector full steps per rotation"
+      default 200
+      help
+        200 for 1.8 degree, 400 for 0.9 degree
+
+    config BOOL_STARTUP_HOME_SELECTOR
+      bool "Home selector at startup?"
+      default n
+      help
+        1 = force mmu homing on startup if unloaded, then reselect the last gate used
+        0 = trust the position saved at shutdown, so no homing is needed (an explicit
+            MMU_MOTORS_OFF discards that saved position and does require a re-home)
+
+    config PARAM_STARTUP_HOME_SELECTOR
+      int
+      default 1 if BOOL_STARTUP_HOME_SELECTOR
+      default 0
 
 
 # -------------------------------------

--- a/installer/Kconfig.sync_feedback_buffer
+++ b/installer/Kconfig.sync_feedback_buffer
@@ -7,6 +7,10 @@
 #   PARAM_BUFFER_RANGE
 #   PARAM_BUFFER_MAXRANGE
 #   PARAM_BUFFER_SPRING_STATE
+#   PARAM_SYNC_FEEDBACK_SPEED_MULTIPLIER
+#   PARAM_SYNC_FEEDBACK_BOOST_MULTIPLIER
+#   PARAM_SYNC_FEEDBACK_EXTRUDE_THRESHOLD
+#   PARAM_SYNC_FEEDBACK_DEBUG_LOG
 #   MMU_HAS_SENSOR_BUFFER_COMPRESSION
 #   MMU_HAS_SENSOR_BUFFER_TENSION
 #   MMU_HAS_SENSOR_BUFFER_PROPORTIONAL
@@ -265,6 +269,43 @@ if MMU_HAS_SYNC_FEEDBACK_BUFFER
         default 0
 
     endif
+
+    comment "_"
+    comment "_Feedback tuning"
+
+    config PARAM_SYNC_FEEDBACK_SPEED_MULTIPLIER
+      float "Sync feedback speed multiplier   "
+      range 1 50
+      default 5
+      help
+        % "twolevel" gear speed delta to keep filament neutral in buffer (recommend 5%)
+
+    config PARAM_SYNC_FEEDBACK_BOOST_MULTIPLIER
+      float "Sync feedback boost multiplier   "
+      range 1 50
+      default 3
+      help
+        % "twolevel" extra gear speed boost for finding initial neutral position (recommend 3%)
+
+    config PARAM_SYNC_FEEDBACK_EXTRUDE_THRESHOLD
+      float "Sync feedback extrude threshold  "
+      default 5
+      help
+        Extruder movement (mm) for updates (keep small but set > retract distance)
+
+    config BOOL_SYNC_FEEDBACK_DEBUG_LOG
+      bool "Enable sync-feedback telemetry log?"
+      default n
+      help
+        If enabled this forces debugging to a telemetry log file "sync_<gate>.jsonl". This is great if
+        trying to tune clog/tangle detection or for getting help on the Happy Hare forum. To plot graph
+        of sync-feedback operation, run:
+          ~/Happy-Hare/utils/plot_sync_feedback.sh
+
+    config PARAM_SYNC_FEEDBACK_DEBUG_LOG
+      int
+      default 1 if BOOL_SYNC_FEEDBACK_DEBUG_LOG
+      default 0
 
   endmenu
 endif

--- a/installer/macro_vars/Kconfig
+++ b/installer/macro_vars/Kconfig
@@ -1,3 +1,9 @@
+# Assemble all marco configuration
+#
+# Also responsible for setting:
+#   PARAM_MACRO_TOOLHEAD_MAX_ACCEL
+#   PARAM_MACRO_TOOLHEAD_MIN_CRUISE_RATIO
+
 menu "Macro Variables"
 
   rsource "Kconfig.software"
@@ -23,5 +29,26 @@ menu "Macro Variables"
   endif
 
   rsource "Kconfig.purge"
+
+
+# -------------------------------------
+# Toolhead Control
+# -------------------------------------
+
+  comment "_"
+  comment "_Toolhead Control"
+
+  config PARAM_MACRO_TOOLHEAD_MAX_ACCEL
+    float "Macro toolhead max acceleration"
+    default 0
+    help
+      Default printer toolhead acceleration applied when macros are run for user customization and
+      parking moves (the previous value is automatically restored afterwards). 0 = use printer max
+
+  config PARAM_MACRO_TOOLHEAD_MIN_CRUISE_RATIO
+    float "Macro toolhead min cruise ratio"
+    default 0.5
+    help
+      Default printer cruise ratio applied when macros are run
 
 endmenu

--- a/installer/macro_vars/Kconfig.client
+++ b/installer/macro_vars/Kconfig.client
@@ -1,4 +1,4 @@
-menu "Client macros (_MMU_CLIENT)"
+menu "Client macros      (_MMU_CLIENT)"
   help
     Happy Hare client macro configuration variables.
 

--- a/installer/macro_vars/Kconfig.form_tip
+++ b/installer/macro_vars/Kconfig.form_tip
@@ -1,4 +1,4 @@
-menu "Tip forming (_MMU_FORM_TIP)"
+menu "Tip forming        (_MMU_FORM_TIP)"
   help
     Happy Hare tip forming macro configuration variables.
 

--- a/installer/macro_vars/Kconfig.purge
+++ b/installer/macro_vars/Kconfig.purge
@@ -1,4 +1,4 @@
-menu "Purge (_MMU_PURGE)"
+menu "Purge              (_MMU_PURGE)"
   help
     Happy Hare reference purging macro configuration variables.
 

--- a/installer/macro_vars/Kconfig.sequence
+++ b/installer/macro_vars/Kconfig.sequence
@@ -1,4 +1,4 @@
-menu "Sequence macros (_MMU_SEQUENCE)"
+menu "Sequence macros    (_MMU_SEQUENCE)"
   help
     Happy Hare sequence macro configuration variables.
 

--- a/installer/macro_vars/Kconfig.software
+++ b/installer/macro_vars/Kconfig.software
@@ -1,4 +1,4 @@
-menu "Print start/end (_MMU_SOFTWARE)"
+menu "Print start/end    (_MMU_SOFTWARE)"
   help
     Happy Hare optional configuration for print start/end checks.
 


### PR DESCRIPTION
## Summary
- Adds Kconfig entries for ~45 parameters that were still hardcoded literals in `mmu.cfg`/`mmu_parameters.cfg`/`mmu_hardware.cfg`, following the existing config/param pairing pattern (selector/gear stepper tuning, gate load/autoload, bowden correction, encoder move validation, toolhead tension, sync feedback tuning, espooler operation, logging, timeouts, and workflow options).
- Wires each new Kconfig param into its `.cfg` template via the matching `[[PARAM_X]]` placeholder so menuconfig actually drives the generated output.
- `startup_home_selector` moved into `Kconfig.selector_stepper` (per-unit) since `Kconfig.options` is sourced only once and can't hold a per-unit value.
- `macro_toolhead_max_accel`/`macro_toolhead_min_cruise_ratio` landed in `installer/macro_vars/Kconfig` (Toolhead Control section).
- Minor unrelated fix: `Kconfig.filament_buffer`'s `UNSELECT_MMU_HAS_FILAMENT_BUFFER` changed from plain `bool` to `def_bool n` to match the pattern used for equivalent unselect flags elsewhere.

## Test plan
- [x] `kconfiglib` parses `installer/Kconfig` with no errors
- [x] `make test ALL=1` — 965 tests, 1 skipped, 4 expected failures (matches the project's known-clean baseline, no new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)