### PR TITLE
kconfig: expose remaining hardcoded parameters via menuconfig

### DIFF
--- a/installer/macro_vars/Kconfig.blobifier
+++ b/installer/macro_vars/Kconfig.blobifier
@@ -1,4 +1,4 @@
-menu "Blobifier (_BLOBIFIER)"
+menu "Blobifier            (_BLOBIFIER)"
   help
     Blobifier purging system configuration variables.
 

--- a/installer/macro_vars/Kconfig.client
+++ b/installer/macro_vars/Kconfig.client
@@ -1,4 +1,4 @@
-menu "Client macros      (_MMU_CLIENT)"
+menu "Client macros        (_MMU_CLIENT)"
   help
     Happy Hare client macro configuration variables.
 

--- a/installer/macro_vars/Kconfig.cut_tip
+++ b/installer/macro_vars/Kconfig.cut_tip
@@ -1,4 +1,4 @@
-menu "Toolhead tip cutting (_MMU_CUT_TIP)"
+menu "Toolhead tip cutting   (_MMU_CUT_TIP)"
   help
     Happy Hare toolhead tip cutting macro configuration variables.
 

--- a/installer/macro_vars/Kconfig.form_tip
+++ b/installer/macro_vars/Kconfig.form_tip
@@ -1,4 +1,4 @@
-menu "Tip forming        (_MMU_FORM_TIP)"
+menu "Tip forming          (_MMU_FORM_TIP)"
   help
     Happy Hare tip forming macro configuration variables.
 

--- a/installer/macro_vars/Kconfig.purge
+++ b/installer/macro_vars/Kconfig.purge
@@ -1,4 +1,4 @@
-menu "Purge              (_MMU_PURGE)"
+menu "Purge                (_MMU_PURGE)"
   help
     Happy Hare reference purging macro configuration variables.
 

--- a/installer/macro_vars/Kconfig.sequence
+++ b/installer/macro_vars/Kconfig.sequence
@@ -1,4 +1,4 @@
-menu "Sequence macros    (_MMU_SEQUENCE)"
+menu "Sequence macros      (_MMU_SEQUENCE)"
   help
     Happy Hare sequence macro configuration variables.
 

--- a/installer/macro_vars/Kconfig.software
+++ b/installer/macro_vars/Kconfig.software
@@ -1,4 +1,4 @@
-menu "Print start/end    (_MMU_SOFTWARE)"
+menu "Print start/end      (_MMU_SOFTWARE)"
   help
     Happy Hare optional configuration for print start/end checks.
 

--- a/installer/macro_vars/Kconfig.state
+++ b/installer/macro_vars/Kconfig.state
@@ -1,4 +1,4 @@
-menu "State change hooks (_MMU_STATE)"
+menu "State change hooks   (_MMU_STATE)"
   help
     You can extend functionality to all Happy Hare state change or event
     macros by adding a command (or call to your gcode macro).


### PR DESCRIPTION
## Summary
- Adds Kconfig entries and `[[PARAM_X]]` template wiring for ~45 parameters that were still hardcoded literals in mmu.cfg/mmu_parameters.cfg/mmu_hardware.cfg (selector/gear stepper tuning, gate load/autoload, bowden correction, encoder move validation, toolhead tension, sync feedback tuning, espooler operation, logging, timeouts, and workflow options), following the existing config/param pairing pattern.
- Cleans up macro vars Kconfig layout for consistency.

## Test plan
- [x] Run `make menuconfig` and verify the new options appear under the correct sections
- [x] Confirm generated config templates substitute the new `[[PARAM_X]]` placeholders correctly