### PR TITLE
nfc: retain a bare tag UID through to gate assignment

### DIFF
--- a/extras/mmu/commands/mmu_spoolman.py
+++ b/extras/mmu/commands/mmu_spoolman.py
@@ -29,29 +29,37 @@ class MmuSpoolmanCommand(BaseCommand):
     HELP_BRIEF = "Manage spoolman integration"
     HELP_PARAMS = (
         f"{CMD}: {HELP_BRIEF}\n"
-        + "QUIET     = [0|1]\n"
-        + "SYNC      = [0|1]\n"
-        + "CLEAR     = [0|1]\n"
-        + "REFRESH   = [0|1]\n"
-        + "FIX       = [0|1]\n"
-        + "SPOOLID   = #(int)\n"
-        + "GATE      = #(int)\n"
+        + "QUIET     = [0|1] Suppress non-critical console output\n"
+        + "SYNC      = [0|1] Sync the local and remote (spoolman) gate maps\n"
+        + "CLEAR     = [0|1] Clear all gate/spool assignments for this printer in the spoolman db\n"
+        + "REFRESH   = [0|1] Rebuild spoolman's cache of this printer's assignments, then sync (unless SYNC= is also given)\n"
+        + "FIX       = [0|1] With REFRESH=, also unassign any inconsistent spool/gate pairs found (partial or duplicate assignments)\n"
+        + "SPOOLID   = #(int) Spoolman spool id. With GATE=, assign it to that gate; alone, unset\n"
+        + "              its gate. Also the target spool for RFID=/REGISTER=/SPOOLINFO=\n"
+        + "GATE      = #(int) Gate number. With SPOOLID=, assign that spool to it; alone, unset\n"
+        + "              its spool. Also resolves RFID='s target spool, or REGISTER='s source gate\n"
         + "RFID      = # Write this NFC/RFID tag UID (or comma-separated UIDs) onto the spool record\n"
         + "              (needs SPOOLID or GATE). Replaces any existing UID(s); RFID='' clears them.\n"
-        + "APPEND    = [0|1] With RFID=, add to the existing UID(s) instead of replacing them\n"
-        + "PRINTER   = _name_\n"
-        + "SPOOLINFO = [0|-1|spool_id]\n"
+        + "APPEND    = [0|1] With RFID=, add to the existing UID(s) instead of replacing them; with\n"
+        + "              REGISTER=, add to the spool's existing UID(s) instead of replacing them\n"
+        + "REGISTER  = [0|1] With GATE= and SPOOLID=, write GATE's already-recorded NFC/RFID uid\n"
+        + "              onto SPOOLID in spoolman and assign it locally (no new scan - unlike\n"
+        + "              'MMU_NFC ... REGISTER=1', which reads a fresh tag). Needs spoolman_support != pull.\n"
+        + "PRINTER   = _name_ Show another printer's gate/spool assignments instead of this one\n"
+        + "SPOOLINFO = [0|-1|spool_id] Display spoolman details for a spool (0 or -1 = the active spool)\n"
+        + "(no parameters to shoe the current spoolman gate/spool assignments)\n"
     )
     HELP_SUPPLEMENT = (
         "Examples:\n"
-        + f"{CMD}                     ...Show the current spoolman gate/spool assignments\n"
-        + f"{CMD} REFRESH=1           ...Refresh the local gate map from the spoolman database\n"
-        + f"{CMD} GATE=0 SPOOLID=45   ...Assign spoolman spool id 45 to gate 0\n"
-        + f"{CMD} SPOOLINFO=45        ...Display spoolman details for spool id 45\n"
-        + f"{CMD} SPOOLID=45 RFID=E2003412         ...Register tag E2003412 against spool id 45 in the spoolman db (replaces any existing tags)\n"
+        + f"{CMD}                              ...Show the current spoolman gate/spool assignments\n"
+        + f"{CMD} REFRESH=1                    ...Refresh the local gate map from the spoolman database\n"
+        + f"{CMD} GATE=0 SPOOLID=45            ...Assign spoolman spool id 45 to gate 0\n"
+        + f"{CMD} SPOOLINFO=45                 ...Display spoolman details for spool id 45\n"
+        + f"{CMD} SPOOLID=45 RFID=E2003412     ...Register tag E2003412 against spool id 45 in the spoolman db (replaces any existing tags)\n"
         + f"{CMD} SPOOLID=45 RFID=E2003499 APPEND=1 ...Register a second tag on the same spool (e.g. one on each side), keeping E2003412\n"
-        + f"{CMD} SPOOLID=45 RFID=''             ...Clear all tags registered against spool id 45\n"
-        + f"{CMD} GATE=0 RFID=E2003412      ...Same, for whichever spool is assigned to gate 0\n"
+        + f"{CMD} SPOOLID=45 RFID=''           ...Clear all tags registered against spool id 45\n"
+        + f"{CMD} GATE=0 RFID=E2003412         ...Same, for whichever spool is assigned to gate 0\n"
+        + f"{CMD} GATE=3 SPOOLID=87 REGISTER=1 ...Bind gate 3's already-known tag uid onto newly-created spool 87\n"
     )
 
     def __init__(self, mmu):
@@ -83,6 +91,7 @@ class MmuSpoolmanCommand(BaseCommand):
         spoolinfo = gcmd.get_int('SPOOLINFO', None, minval=-1)  # -1 or 0 is active spool
         rfid = gcmd.get('RFID', None)        # Tag UID(s) to write onto a spool record
         append = bool(gcmd.get_int('APPEND', 0, minval=0, maxval=1))
+        register = bool(gcmd.get_int('REGISTER', 0, minval=0, maxval=1))
         run = False
 
         if refresh:
@@ -106,7 +115,26 @@ class MmuSpoolmanCommand(BaseCommand):
             run = True
 
         # Rest of the options are mutually exclusive
-        if rfid is not None:
+        if register:
+            # Bind a gate's already-recorded NFC/RFID uid onto a spool_id created after the
+            # fact - unlike RFID= (below), no uid is supplied on the command line.
+            if spool_id is None or gate is None or gate < 0:
+                mmu.log_error("REGISTER=1 needs both GATE=<gate> (0..%d) and SPOOLID=<id>" % (mmu.num_gates - 1))
+                return
+            if mmu.p.spoolman_support == SPOOLMAN_PULL:
+                mmu.log_error("REGISTER=1 is not applicable with spoolman_support=pull - use RFID=<uid> "
+                              "to write a UID onto a spool directly, or re-scan the tag after creating it")
+                return
+            uid = mmu.gate_spool_rfid[gate]
+            if not uid:
+                mmu.log_error("Gate %d has no NFC/RFID tag UID recorded yet - scan one first, or "
+                              "use RFID=<uid> to supply it explicitly" % gate)
+                return
+            mmu._spoolman_set_spool_uid(spool_id, uid, append=append, quiet=quiet)
+            mod_gate_ids = mmu.gate_maps.assign_spool_id(gate, spool_id)
+            mmu.gate_maps.persist_gate_map(spoolman_sync=True, gate_ids=mod_gate_ids)
+
+        elif rfid is not None:
             # Write an NFC/RFID tag UID onto an EXISTING spool record in the spoolman db.
             #
             # Note the direction: this is the opposite of 'MMU_NFC ... REGISTER=1', which

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -175,7 +175,7 @@ class MmuController(MmuFilamentMovement):
         self.gate_maps.clear_slicer_tool_map()
 
         self.pending_spool_id = -1      # For automatic assignment of spool_id if set perhaps by rfid reader
-        self.pending_metadata = None    # (uid, metadata) staged from a shared NFC deep read, applied to the next gate
+        self.pending_tag = None         # (uid, metadata) staged from a shared NFC read, applied to the next gate
         self.nfc_lookup_pending = False # A shared NFC reader UID lookup is in flight (guards further shared reads)
         self._nfc_led_unit = None       # mmu_unit that initiated the current NFC read (for the fail flash)
         self.pending_phase = None       # Base spoolman pending spool_id LED phase: None | 'pending' | 'expiring'
@@ -1684,7 +1684,9 @@ class MmuController(MmuFilamentMovement):
         """
         if next_spool_id > 0:
             self.pending_spool_id = next_spool_id
-            self.pending_metadata = None # A resolved spool is authoritative; it supersedes any staged tag metadata
+            # A resolved spool is authoritative over any staged tag metadata, but keep the uid
+            # so it can still be recorded on the gate once applied
+            self.pending_tag = (self.pending_tag[0], None) if self.pending_tag is not None else None
             self.reactor.update_timer(self.pending_timer, self.reactor.monotonic() + self.p.spoolman_pending_id_timeout)
             self.log_info(f"Spool ID: Assignment of {next_spool_id} will timeout in {self.p.spoolman_pending_id_timeout} seconds")
             self._pending_led_start()  # Base spoolman pending overlay (also fires for a manual NEXT_SPOOLID)
@@ -1693,10 +1695,10 @@ class MmuController(MmuFilamentMovement):
                 self.log_info("Spool ID: Automatic assignment of id cancelled")
             self.pending_spool_id = -1
             self._pending_led_stop() # End the pending overlay (no-op if it was never active, e.g. NFC-fail)
-            # Keep any staged tag metadata pending (with a fresh timeout window) so a
-            # deep read still populates the gate on an unknown-tag result; otherwise
-            # disable the timer to prevent reuse.
-            if self.pending_metadata is not None:
+            # Keep any staged tag pending (with a fresh timeout window) so it still
+            # populates the gate on an unknown-tag result; otherwise disable the timer
+            # to prevent reuse.
+            if self.pending_tag is not None:
                 self.reactor.update_timer(self.pending_timer, self.reactor.monotonic() + self.p.spoolman_pending_id_timeout)
             else:
                 self.reactor.update_timer(self.pending_timer, self.reactor.NEVER)
@@ -1758,11 +1760,11 @@ class MmuController(MmuFilamentMovement):
 
     def _clear_pending(self):
         """
-        Clear any pending spool_id and staged tag metadata together, and
+        Clear any pending spool_id and staged tag together, and
         disable the timeout timer. Keeps the two in lockstep from a single place.
         """
         self.pending_spool_id = -1
-        self.pending_metadata = None
+        self.pending_tag = None
         self.reactor.update_timer(self.pending_timer, self.reactor.NEVER)
         self._pending_led_stop() # End the base pending overlay (phase + warn timer + repaint)
 
@@ -1777,14 +1779,16 @@ class MmuController(MmuFilamentMovement):
         and the generic cancellation in _set_action.
 
         A resolved Spoolman spool_id takes precedence (Spoolman is the source of truth);
-        otherwise, if a deep read staged tag metadata, apply that to the gate map directly.
-        Either way the (live) pending state is cleared afterwards.
+        otherwise, if a staged tag exists (uid, with or without metadata), apply that to the
+        gate map directly. Either way the (live) pending state is cleared afterwards.
         """
-        spool_id, tag = (self.pending_spool_id, self.pending_metadata) if pending is None else pending
+        spool_id, tag = (self.pending_spool_id, self.pending_tag) if pending is None else pending
 
         if spool_id > 0 and self.p.spoolman_support != SPOOLMAN_PULL:
             self.log_info("Spool ID: %s automatically assigned to gate %d" % (spool_id, gate))
             mod_gate_ids = self.gate_maps.assign_spool_id(gate, spool_id)
+            if tag is not None:
+                self.gate_maps.set_gate_filament_from_tag(gate, rfid=tag[0])
 
             # Request sync and update of filament attributes from Spoolman
             if self.p.spoolman_support == SPOOLMAN_PUSH:
@@ -1794,7 +1798,7 @@ class MmuController(MmuFilamentMovement):
 
         elif tag is not None:
             uid, metadata = tag
-            self._apply_metadata_to_gate(gate, uid, metadata)
+            self._apply_tag_to_gate(gate, uid, metadata)
 
         self._clear_pending()
 
@@ -1845,12 +1849,12 @@ class MmuController(MmuFilamentMovement):
 
     def _grab_pending(self):
         """
-        Atomically capture and clear the pending spool_id/metadata so a long operation
+        Atomically capture and clear the pending spool_id/tag so a long operation
         (preload) owns the result locally - immune to the timeout, the LED countdown, and the
         generic cancellation done in _set_action for non-preload movement. Apply the returned
         value later with _check_pending_filament(gate, pending=...). Returns (spool_id, tag).
         """
-        grabbed = (self.pending_spool_id, self.pending_metadata)
+        grabbed = (self.pending_spool_id, self.pending_tag)
         self._clear_pending()
         return grabbed
 
@@ -1862,8 +1866,8 @@ class MmuController(MmuFilamentMovement):
         spool_id is activated in Spoolman directly and 'active_filament' seeded; the
         filament attributes arrive asynchronously via 'MMU_GATE_MAP BYPASS=1 ...'
         (requested here through the same Moonraker fetch used for real gates).
-        Without a spool_id, staged deep-read tag metadata populates active_filament
-        locally (works with spoolman off). Consumes/clears the pending state.
+        Without a spool_id, staged tag metadata populates active_filament locally
+        (works with spoolman off). Consumes/clears the pending state.
         """
         spool_id, tag = self._grab_pending()
         if spool_id > 0 and self.p.spoolman_support != SPOOLMAN_PULL:
@@ -1873,16 +1877,19 @@ class MmuController(MmuFilamentMovement):
             self._spoolman_update_filaments([(TOOL_GATE_BYPASS, spool_id)])
         elif tag is not None:
             uid, metadata = tag
-            name, material, vendor, color, temperature = self._filament_from_metadata(metadata)
-            self.log_info("NFC: bypass filament attributes set from tag metadata (uid %s)" % uid)
-            self.active_filament = {
-                'filament_name': name,
-                'material': material,
-                'vendor': vendor,
-                'color': color,
-                'spool_id': -1,
-                'temperature': temperature,
-            }
+            if isinstance(metadata, dict) and metadata.get('material'):
+                name, material, vendor, color, temperature = self._filament_from_metadata(metadata)
+                self.log_info("NFC: bypass filament attributes set from tag metadata (uid %s)" % uid)
+                self.active_filament = {
+                    'filament_name': name,
+                    'material': material,
+                    'vendor': vendor,
+                    'color': color,
+                    'spool_id': -1,
+                    'temperature': temperature,
+                }
+            else:
+                self.log_info("NFC: tag %s has no usable filament data for bypass" % uid)
 
 
 # -----------------------------------------------------------------------------------------------------------
@@ -3291,8 +3298,8 @@ class MmuController(MmuFilamentMovement):
         """
         Entry point for a tag read from a unit's NFC manager. Two independent
         concerns:
-          1. If a deep read produced metadata, populate the local gate map from
-             it - immediately for a known (per-gate) reader, or staged as pending
+          1. Record the uid (and, if a deep read produced it, metadata) into the local
+             gate map - immediately for a known (per-gate) reader, or staged as pending
              for a shared reader (applied to whichever gate the next load/preload
              targets). This happens even when Spoolman is disabled.
           2. If Spoolman is active, resolve the UID to a spool (optionally
@@ -3312,56 +3319,70 @@ class MmuController(MmuFilamentMovement):
         # takes over (pending overlay / gate map render); a failure queues the fail flash.
         if unit is not None and self._nfc_led_enabled(unit):
             self._nfc_led_on_read(unit, deep=bool(metadata), gate=gate)
-        if self.nfc_deep_read_enabled(unit) and metadata:
-            if gate is None:
-                self._stage_pending_metadata(uid, metadata)
-            else:
-                self._apply_metadata_to_gate(gate, uid, metadata)
+        if gate is None:
+            self._stage_pending_tag(uid, metadata)
+        else:
+            self._apply_tag_to_gate(gate, uid, metadata)
         if self.p.spoolman_support != SPOOLMAN_OFF:
             self._spoolman_get_spool_by_uid(uid, gate=gate, metadata=metadata, unit=unit)
 
 
-    def _stage_pending_metadata(self, uid, metadata):
+    def _stage_pending_tag(self, uid, metadata):
         """
-        Stage deep-read tag metadata from a shared reader to be applied to the
-        gate that the next load/preload targets (mirrors pending_spool_id). A
-        resolved Spoolman spool takes precedence in _check_pending_filament.
+        Stage a tag (uid, with or without deep-read metadata) from a shared reader
+        to be applied to the gate that the next load/preload targets (mirrors
+        pending_spool_id). A resolved Spoolman spool takes precedence in
+        _check_pending_filament.
         """
-        self.pending_metadata = (uid, metadata)
+        self.pending_tag = (uid, metadata)
         self.reactor.update_timer(self.pending_timer,
                                   self.reactor.monotonic() + self.p.spoolman_pending_id_timeout)
         # log_info, not log_debug: this is the ONLY acknowledgment a shared reader produces.
-        # A per-gate read says "gate N filament set from tag ..." (_apply_metadata_to_gate),
-        # so at debug level a shared read looked like nothing had happened at all.
-        #
-        # Guarded exactly as _apply_metadata_to_gate is, and for two reasons: describing the
-        # tag means reaching into the payload, and metadata this thin will be REJECTED by that
-        # same guard when the pending gate is assigned - so claiming it was staged would be a
-        # lie. Fall back to naming the UID.
+        # A per-gate read says "gate N filament set from tag ..." (_apply_tag_to_gate), so at
+        # debug level a shared read looked like nothing had happened at all.
         if isinstance(metadata, dict) and metadata.get('material'):
             name, material, vendor, _color, temperature = self._filament_from_metadata(metadata)
             self.log_info("NFC: tag %s read: %s %s %s @ %dC - staged for the next gate loaded"
                           % (uid, vendor, material, name, temperature))
         else:
-            self.log_info("NFC: tag %s read, but it carries no usable filament data" % uid)
+            self.log_info("NFC: tag %s read, but it carries no usable filament data - staged for the next gate loaded"
+                          % uid)
 
 
-    def _apply_metadata_to_gate(self, gate, uid, metadata):
+    def _apply_tag_to_gate(self, gate, uid, metadata):
         """
-        Populate the local gate map for 'gate' from parsed NFC tag metadata. Does
-        not assign a spool_id; if a Spoolman spool later resolves for this tag it
-        takes precedence and overwrites these attributes.
+        Populate the local gate map for 'gate' from a scanned tag: always records the
+        uid, and additionally applies filament attributes if the tag carried usable
+        metadata. Does not assign a spool_id from metadata alone; if a Spoolman spool
+        later resolves for this tag it takes precedence and overwrites these attributes.
+
+        A uid different from the one already recorded on this gate means the physical
+        tag changed, so any spool_id assigned here belongs to the old tag and is
+        cleared - Spoolman resolution, if any, will reassign the correct one.
         """
         if self.p.spoolman_support == SPOOLMAN_PULL:
-            return # Remote gate map owns filament attributes
-        if not (isinstance(metadata, dict) and metadata.get('material')):
-            return
-        name, material, vendor, color, temperature = self._filament_from_metadata(metadata)
-        self.gate_maps.set_gate_filament_from_tag(
-            gate, name=name, material=material, vendor=vendor,
-            color=color, temperature=temperature, rfid=uid)
-        self.log_info("NFC: gate %d filament set from tag: %s %s %s @ %dC" % (
-            gate, vendor, material, name, temperature))
+            return # Remote gate map owns filament attributes, including rfid/spool_id
+
+        mod_gate_ids = []
+        if uid != self.gate_maps.gate_spool_rfid[gate] and self.gate_maps.gate_spool_id[gate] > 0:
+            mod_gate_ids = self.gate_maps.assign_spool_id(gate, -1)
+
+        if isinstance(metadata, dict) and metadata.get('material'):
+            name, material, vendor, color, temperature = self._filament_from_metadata(metadata)
+            self.gate_maps.set_gate_filament_from_tag(
+                gate, name=name, material=material, vendor=vendor,
+                color=color, temperature=temperature, rfid=uid)
+            self.log_info("NFC: gate %d filament set from tag: %s %s %s @ %dC" % (
+                gate, vendor, material, name, temperature))
+        else:
+            self.gate_maps.set_gate_filament_from_tag(gate, rfid=uid)
+            self.log_info("NFC: tag %s recorded for gate %d (no usable filament data)" % (uid, gate))
+
+        if mod_gate_ids:
+            if self.p.spoolman_support == SPOOLMAN_PUSH:
+                self._spoolman_push_gate_map(mod_gate_ids)
+            elif self.p.spoolman_support == SPOOLMAN_READONLY:
+                self._spoolman_update_filaments(mod_gate_ids)
 
 
     def _filament_from_metadata(self, metadata):

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -144,17 +144,21 @@ class MmuFilamentMovement:
                                "triggered (filament from another gate still loaded?)"
                                % (gate, shared_name))
 
-        # A pending shared-NFC spool_id takes precedence over this gate's own reader: consume
-        # the pending and do a normal preload (skip the per-gate NFC read) rather than have
-        # both try to assign the gate. Without a pending, use the per-gate reader if present.
-        have_pending = pending is not None and (pending[0] > 0 or pending[1] is not None)
+        # A strong pending (resolved spool_id, or a tag with usable metadata) takes precedence
+        # over this gate's own reader: consume it and do a normal preload (skip the per-gate
+        # NFC read) rather than have both try to assign the gate. A weak pending (bare uid only)
+        # is not trusted enough to skip the gate's own reader - it's applied below only as a
+        # fallback if that reader finds nothing.
+        spool_id, tag = pending if pending is not None else (-1, None)
+        has_material = tag is not None and isinstance(tag[1], dict) and tag[1].get('material')
+        have_strong_pending = spool_id > 0 or has_material
 
         # Decide the NFC path HERE, above the banner, so the banner cannot promise a scan
         # that won't happen. _build_gate_nfc_compound() declines (returns None) when there is
         # no reader, the reader is disabled, or the gate endstop isn't a real MCU switch.
         # Encoder homing can't be compounded at all, so it never even asks.
         nfc = None
-        if not have_pending and profile.endstop != SENSOR_ENCODER:
+        if not have_strong_pending and profile.endstop != SENSOR_ENCODER:
             gate_es_name = self.sensor_manager.get_qualified_endstop_name(profile.endstop)
             compound, nfc_es_name, nfc_mgr = self._build_gate_nfc_compound(
                 gate, gate_es_name, name="preload_compound")
@@ -207,7 +211,10 @@ class MmuFilamentMovement:
                 self.log_info("NFC: tag read for gate %d" % gate)
             else:
                 self.log_info("NFC: no tag found for gate %d while preloading" % gate)
-        self._check_pending_filament(gate, pending=pending) # Apply the grabbed spool_id if any
+        if not tag_read:
+            # A fresh per-gate read already applied directly above - don't let a weaker/stale
+            # pending from a different physical location overwrite it.
+            self._check_pending_filament(gate, pending=pending)
         run_post_preload_macro()
 
 

--- a/test/test_mmu_dev_test.py
+++ b/test/test_mmu_dev_test.py
@@ -294,8 +294,9 @@ class TestNfcReadFeedback(DevTestCase):
 
     def test_a_tag_with_no_usable_data_is_reported_as_such(self):
         """
-        Describing the tag means reaching into the payload, and metadata this thin gets
-        REJECTED when the pending gate is assigned - so claiming it was staged would be a lie.
+        Describing the tag means reaching into the payload, and metadata this thin carries
+        no filament attributes - but the bare uid itself IS still staged and will land on
+        whichever gate loads next, so "staged" is now accurate, not a lie.
         """
         unit = next(u for u in self.hh.mmu.mmu_machine.units
                     if self.hh.mmu.nfc_deep_read_enabled(u))
@@ -306,7 +307,7 @@ class TestNfcReadFeedback(DevTestCase):
         self.hh.run_gcode('_MMU_TEST NFC_READ=1 DEEP=1 UNIT=%d MATERIAL=' % unit.unit_index)
         said = ' '.join(self.hh.console[before:])
         self.assertIn('no usable filament data', said)
-        self.assertNotIn('staged', said)
+        self.assertIn('staged', said)
         self.assertEqual(self.hh.errors, [])
 
 

--- a/test/test_mmu_nfc_scan.py
+++ b/test/test_mmu_nfc_scan.py
@@ -297,6 +297,30 @@ class TestPreloadNfcCompound(NfcScanTestCase):
                          'per-gate NFC scan ran despite a pending shared-reader UID')
         self.assertEqual(self.hh.mmu.gate_maps.gate_spool_id[0], 7)
 
+    def test_weak_pending_does_not_bypass_the_per_gate_reader(self):
+        """
+        A bare-uid ('weak') pending is not trusted enough to skip the gate's own NFC
+        reader - only a resolved spool_id or a tag with usable metadata ('strong') does.
+        A fresh per-gate read must win over the stale weak pending, not be clobbered by it.
+        """
+        self.hh.mmu.pending_tag = ('DEADBEEF', None)
+        self.fil.attach_tag(0, TAG, offset=40.0)
+        at = len(self.hh.console)
+        self.hh.place_filament(0, position=-100.0)
+        self.hh.run_gcode('MMU_PRELOAD GATE=0')
+        banners = [l for l in self.hh.console[at:] if l.startswith('Preloading')]
+        self.assertEqual(banners, ['Preloading gate 0 with NFC scan...'],
+                         'a weak (bare-uid) pending must not skip the per-gate NFC scan')
+        self.assertEqual(self.hh.mmu.gate_maps.gate_spool_rfid[0], TAG,
+                         "the gate's own fresher read must win over the stale weak pending")
+
+    def test_weak_pending_is_applied_when_the_gates_reader_finds_nothing(self):
+        """The weak pending is not wasted - it is the fallback when the per-gate scan finds no tag."""
+        self.hh.mmu.pending_tag = ('DEADBEEF', None)
+        self.hh.place_filament(0, position=-100.0)   # no tag attached
+        self.hh.run_gcode('MMU_PRELOAD GATE=0')
+        self.assertEqual(self.hh.mmu.gate_maps.gate_spool_rfid[0], 'DEADBEEF')
+
     def test_nfc_first_finishes_on_the_gate_and_parks_without_reverse_homing(self):
         """
         Reader stops the move, tag is read, homing CONTINUES to the gate switch - so the

--- a/test/test_mmu_roundtrip.py
+++ b/test/test_mmu_roundtrip.py
@@ -134,12 +134,21 @@ class TestSharedReaderAutoCreate(RoundTripTestCase):
         self.assertEqual(self.rt.mmu.pending_spool_id, -1)
 
     def test_no_autocreate_without_metadata(self):
-        """A UID-only read of an unregistered tag is a definitive miss."""
+        """A UID-only read of an unregistered tag is a definitive miss on spool_id."""
         self.rt.present_tag(UNKNOWN_TAG, gate=None, deep=False)
         self.assertEqual(self.rt.db.created_spools, [])
         self.assertEqual(self.last_callback(),
                          'MMU_GATE_MAP NEXT_SPOOLID=-2 QUIET=1')
         self.assertEqual(self.rt.mmu.pending_spool_id, -1)
+
+    def test_bare_uid_is_retained_as_a_weak_pending_after_the_miss(self):
+        """
+        The uid itself is not a dead end even though Spoolman doesn't know it - it stays
+        staged (no spool_id LED overlay, since there is no spool_id) so it can still land
+        on whichever gate loads next.
+        """
+        self.rt.present_tag(UNKNOWN_TAG, gate=None, deep=False)
+        self.assertEqual(self.rt.mmu.pending_tag, (UNKNOWN_TAG, None))
 
 
 class TestKnownTagResolution(RoundTripTestCase):
@@ -189,12 +198,27 @@ class TestKnownTagResolution(RoundTripTestCase):
         self.rt.present_tag(TAG_A, gate=2, deep=False)
         self.assertEqual(list(self.rt.mmu.gate_spool_id), [-1, -1, 1, -1])
 
+    def test_shared_resolution_uid_is_applied_with_the_spool_id(self):
+        """
+        A shared read that resolves to a spool_id must not lose the uid itself - once
+        applied to a gate, gate_spool_rfid records which physical tag resolved there.
+        """
+        self.rt.present_tag(TAG_A, gate=None, deep=False)
+        self.assertEqual(self.rt.mmu.pending_tag, (TAG_A, None),
+                         'the uid must survive spool_id resolution, only metadata is superseded')
+        self.rt.mmu._check_pending_filament(3)
+        self.assertEqual(self.rt.mmu.gate_spool_id[3], 1)
+        self.assertEqual(self.rt.mmu.gate_spool_rfid[3], TAG_A)
+
 
 class TestPerGateFailure(RoundTripTestCase):
     """
     Session 5: a per-gate lookup failure used to send NOTHING back. Now all three
     failure sites report GATE=x LOOKUP=-1|-2 so the console and the gate's LEDs
-    learn about it - while leaving the gate map untouched.
+    learn about it. The gate map's *filament attributes* stay untouched by a
+    failure, but a genuinely different physical tag (new uid) always lands its
+    uid on the gate and clears whatever spool_id belonged to the old one - see
+    TestStaleSpoolIdIsCleared below.
     """
     SPOOLS = (dict(uid=TAG_A, material='PLA'),)
 
@@ -202,11 +226,27 @@ class TestPerGateFailure(RoundTripTestCase):
         self.rt.present_tag(UNKNOWN_TAG, gate=2, deep=False)
         self.assertEqual(self.last_callback(), 'MMU_GATE_MAP GATE=2 LOOKUP=-2 QUIET=1')
 
-    def test_gate_map_is_untouched_by_a_failure(self):
+    def test_a_new_tags_failure_clears_the_old_spool_id(self):
+        """
+        Gate 2 was carrying spool 1's tag. A different, unregistered tag is scanned on
+        the same gate - the old spool_id must not linger next to the new uid.
+        """
         self.rt.present_tag(TAG_A, gate=2, deep=False)
         self.rt.present_tag(UNKNOWN_TAG, gate=2, deep=False)
+        self.assertEqual(self.rt.mmu.gate_spool_id[2], -1,
+                         'a new physical tag must clear the old spool_id, not carry it over')
+        self.assertEqual(self.rt.mmu.gate_spool_rfid[2], UNKNOWN_TAG)
+
+    def test_rescanning_the_same_tag_does_not_clear_its_own_assignment(self):
+        """
+        The clear is keyed on the uid changing, not on the lookup failing - re-presenting
+        the SAME tag (e.g. a recoverable Spoolman outage) must leave the assignment alone.
+        """
+        self.rt.present_tag(TAG_A, gate=2, deep=False)
+        self.rt.db.offline = True
+        self.rt.present_tag(TAG_A, gate=2, deep=False)
         self.assertEqual(self.rt.mmu.gate_spool_id[2], 1,
-                         'a failed lookup must not clear an existing assignment')
+                         'a recoverable failure on the SAME tag must not clear the assignment')
 
     def test_failure_is_surfaced_to_the_console(self):
         self.rt.present_tag(UNKNOWN_TAG, gate=2, deep=False)
@@ -308,6 +348,14 @@ class TestSpoolmanOff(RoundTripTestCase):
         self.assertEqual(self.rt.mmu.gate_vendor[1], 'Overture')
         self.assertEqual(self.rt.mmu.gate_spool_id[1], -1,
                          'no Spoolman means no spool id')
+        self.assertEqual(self.rt.errors, [])
+
+    def test_bare_uid_still_reaches_the_gate_map(self):
+        """Even with no metadata and no spool_id, the uid itself is recorded locally."""
+        self.rt.present_tag(UNKNOWN_TAG, gate=1, deep=False)
+        self.assertEqual(self.rt.mmu.gate_spool_rfid[1], UNKNOWN_TAG)
+        self.assertEqual(self.rt.mmu.gate_spool_id[1], -1)
+        self.assertEqual(self.rt.mmu.gate_material[1], '')
         self.assertEqual(self.rt.errors, [])
 
 
@@ -432,6 +480,54 @@ class TestSpoolmanRfidCommand(RoundTripTestCase):
                          'the freshly bound tag must resolve to spool 2')
         self.assertEqual(len(self.rt.db.created_spools), 0,
                          'it must resolve, not auto-create a duplicate')
+
+
+class TestSpoolmanRegisterCommand(RoundTripTestCase):
+    """
+    'MMU_SPOOLMAN GATE= SPOOLID= REGISTER=1': a spool with no Spoolman entry at scan
+    time leaves its uid sitting in the gate map with no spool_id. Once the matching
+    spool exists, REGISTER=1 binds the gate's already-known uid onto it, assigns it
+    locally, and fetches its attributes - without any new tag read.
+    """
+    SPOOLS = (dict(uid=TAG_A, material='PLA'),
+              dict(material='ABS', vendor='Polymaker'))
+
+    def _scan_bare_uid(self, gate=3, uid=UNKNOWN_TAG):
+        self.rt.present_tag(uid, gate=gate, deep=False)
+        self.assertEqual(self.rt.mmu.gate_spool_rfid[gate], uid, 'precondition: uid recorded, no spool')
+        self.assertEqual(self.rt.mmu.gate_spool_id[gate], -1, 'precondition: no spool_id yet')
+
+    def test_registers_the_gates_known_uid_and_assigns_locally(self):
+        self._scan_bare_uid()
+        self.rt.run_gcode('MMU_SPOOLMAN GATE=3 SPOOLID=2 REGISTER=1')
+        self.assertEqual(self.rt.db.spool_uid(2), UNKNOWN_TAG)
+        self.assertEqual(self.rt.mmu.gate_spool_id[3], 2)
+
+    def test_no_recorded_uid_errors(self):
+        errors_before = len(self.rt.errors)
+        self.rt.run_gcode('MMU_SPOOLMAN GATE=3 SPOOLID=2 REGISTER=1')
+        self.assertGreater(len(self.rt.errors), errors_before)
+        self.assertIn('no nfc/rfid tag uid recorded', self.rt.errors[-1].lower())
+
+    def test_missing_gate_or_spoolid_errors(self):
+        errors_before = len(self.rt.errors)
+        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 REGISTER=1')
+        self.assertGreater(len(self.rt.errors), errors_before)
+        self.rt.run_gcode('MMU_SPOOLMAN GATE=3 REGISTER=1')
+        self.assertGreater(len(self.rt.errors), errors_before + 1)
+
+    def test_bypass_gate_is_rejected(self):
+        errors_before = len(self.rt.errors)
+        self.rt.run_gcode('MMU_SPOOLMAN GATE=-1 SPOOLID=2 REGISTER=1')
+        self.assertGreater(len(self.rt.errors), errors_before)
+
+    def test_pull_mode_errors_instead_of_silently_finding_nothing(self):
+        self._scan_bare_uid()
+        self.rt.mmu.p.spoolman_support = 'pull'
+        errors_before = len(self.rt.errors)
+        self.rt.run_gcode('MMU_SPOOLMAN GATE=3 SPOOLID=2 REGISTER=1')
+        self.assertGreater(len(self.rt.errors), errors_before)
+        self.assertIn('pull', self.rt.errors[-1].lower())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- A tag UID with no resolved spool_id and no usable deep-read metadata used to be dropped entirely (both per-gate and shared-reader paths), so it could never be associated with a gate. It's now retained and applied on preload/insert, with a per-gate read still taking priority over a stale shared pending, and a gate's spool_id is cleared when a different physical tag is recorded there.
- Adds `MMU_SPOOLMAN GATE=<g> SPOOLID=<id> REGISTER=1` to bind a gate's already-recorded uid onto a spool created after the scan (no new tag read needed), and fills in the remaining undocumented `MMU_SPOOLMAN` parameters in its help text.

## Test plan
- [x] `make test` run before changes: 965 tests, 4 expected failures (baseline)
- [x] `make test` run after changes: 976 tests (11 new), same 4 expected failures, no regressions
- [x] Updated two pre-existing tests whose assumptions the new behavior deliberately supersedes
- [x] Added coverage for: bare-UID capture on both reader topologies, stale-spool_id clearing (+ same-tag negative case), successful shared-resolution also capturing the uid, weak-vs-strong pending preload sequencing, and the new `REGISTER=1` command (success + error paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)