### PR TITLE
Handle rewind when using a shared_lane_endstop (BTT)

### DIFF
--- a/extras/mmu/commands/mmu_nfc_scan.py
+++ b/extras/mmu/commands/mmu_nfc_scan.py
@@ -83,11 +83,15 @@ class MmuNfcScanCommand(BaseCommand):
         filament_pos = mmu.filament_pos
         is_unloaded = filament_pos == FILAMENT_POS_UNLOADED
 
-        # Selecting a different gate with filament loaded requires a crossload-capable MMU
+        # Selecting a different gate with filament loaded requires a crossload-capable MMU -
+        # and, if the gate endstop is a per-unit SHARED resource (mmu_shared_exit, extruder
+        # entry, or the encoder), can_crossload alone isn't enough: it says the selector won't
+        # jam, not that the shared path is clear. Check both.
         can_continue = (
             is_unloaded
             or scan_unit is not active_unit
-            or active_unit.can_crossload
+            or (active_unit.can_crossload
+                and not mmu._shared_gate_path_occupied(scan_unit.p.gate_homing_endstop, gate))
         )
         if not can_continue:
             if self.check_if_loaded(): return

--- a/extras/mmu/commands/mmu_preload.py
+++ b/extras/mmu/commands/mmu_preload.py
@@ -73,10 +73,16 @@ class MmuPreloadCommand(BaseCommand):
         filament_pos = mmu.filament_pos
         is_unloaded = filament_pos == FILAMENT_POS_UNLOADED
 
+        # Selecting a different gate with filament loaded requires a crossload-capable MMU -
+        # and, if the preload endstop is a per-unit SHARED resource (mmu_shared_exit, extruder
+        # entry, or the encoder), can_crossload alone isn't enough: it says the selector won't
+        # jam, not that the shared path is clear. Check both.
+        preload_endstop = preload_unit.p.gate_preload_endstop or preload_unit.p.gate_homing_endstop
         can_continue = (
             is_unloaded
             or preload_unit is not active_unit
-            or active_unit.can_crossload
+            or (active_unit.can_crossload
+                and not mmu._shared_gate_path_occupied(preload_endstop, gate))
         )
 
         if not can_continue:

--- a/extras/mmu/mmu_constants.py
+++ b/extras/mmu/mmu_constants.py
@@ -166,6 +166,10 @@ SENSOR_NFC_PREFIX        = "mmu_nfc"        # Per-gate NFC/RFID reader used as a
 EXTRUDER_ENDSTOPS = [SENSOR_EXTRUDER_ENCODER, SENSOR_GEAR_TOUCH, SENSOR_EXTRUDER_ENTRY, SENSOR_EXTRUDER_NONE, SENSOR_COMPRESSION]
 GATE_ENDSTOPS     = [SENSOR_SHARED_EXIT, SENSOR_ENCODER, SENSOR_EXIT_PREFIX, SENSOR_EXTRUDER_ENTRY]
 
+# Gate endstops that are a per-UNIT resource shared by every gate on that unit, rather than
+# owned by a single gate (contrast SENSOR_EXIT_PREFIX, which is per-gate)
+SHARED_GATE_ENDSTOPS = [SENSOR_SHARED_EXIT, SENSOR_EXTRUDER_ENTRY, SENSOR_ENCODER]
+
 # Gear/Extruder synchronization modes
 DRIVE_UNSYNCED                = 0
 DRIVE_EXTRUDER_SYNCED_TO_GEAR = 1 # Aka 'gear+extruder'

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -882,25 +882,61 @@ class MmuFilamentMovement:
 
     def _park_after_scan(self, off, profile, gate_es_name):
         """
-        Return the filament to its parked position after a scan, from a real gate datum.
+        Return the filament to park after a scan. Park is 'gate datum + parking_distance'
+        and 'off' is the offset from that datum, so both routes below produce the same
+        displacement - they differ only in whether the datum is re-observed on the way.
 
-        Always finishes through _park_from_gate() so the park is measured from the switch
-        RELEASE point every time. Approaching the datum from the other direction would
-        land the park a switch-hysteresis off (the test model has no hysteresis, so this
-        is only visible on hardware), and _park_from_gate also carries the encoder-overshoot
-        handling.
+        PRIVATE datum (per-gate mmu_exit, or the encoder): home to it, so the park is
+        measured from the switch RELEASE point every time. Approaching from the other
+        direction would land the park a switch-hysteresis off (no hysteresis in the test
+        model, so hardware-only), and _park_from_gate carries the encoder-overshoot
+        handling. extra_homing=abs(off) budgets homing_max + however far we strayed.
 
-        extra_homing=abs(off) budgets profile.homing_max + the distance we actually strayed,
-        so a sweep that ended far from the gate can still reach it.
+        SHARED datum (mmu_shared_exit, or the extruder entry sensor on a no-bowden design
+        where it is registered as the shared exit): do NOT home. The scan never reached that
+        sensor - it is downstream of the merge and park sits parking_distance behind it
+        (-100mm on Box Turtle) - and a reverse home against an already-clear sensor
+        completes instantly at zero distance (MmuVirtualEndstopSensor.home_start), giving
+        a fake datum plus an unearned parking move that walks the filament backward on
+        every scan. Move the known displacement instead: 'off' is accumulated from halt
+        positions (mmu_drive.move takes halt_pos, not trig_pos) so the deceleration ramps
+        are already in it, and this is the same open-loop trust the parking move itself
+        relies on.
+
+        The rewind is the same net displacement _park_from_gate would produce (-off back
+        to the datum, then +parking_distance), without the trip to a sensor we cannot
+        reach. It comes out positive only when the sweep ended further back than park, in
+        which case we creep forward to it - still behind the datum, so never into shared
+        territory.
+
+        Finishes with a free slip check: a per-gate exit sensor may be fitted even when it
+        is not the gate homing endstop (Box Turtle implies both), and reading it costs no
+        motion.
         """
-        covered = self.sensor_manager.check_sensor(gate_es_name)
-        if covered is None:
-            covered = off > 0   # Encoder gate homing: no switch to consult
-        if covered:
-            self._park_from_gate(profile, extra_homing=abs(off))
-        else:
-            self._home_to_gate(profile._replace(attempts=1), extra_homing=abs(off))
-            self._park_from_gate(profile)
+        if profile.endstop not in (SENSOR_SHARED_EXIT, SENSOR_EXTRUDER_ENTRY):
+            covered = self.sensor_manager.check_sensor(gate_es_name)
+            if covered is None:
+                covered = off > 0   # Encoder gate homing: no switch to consult
+            if covered:
+                self._park_from_gate(profile, extra_homing=abs(off))
+            else:
+                self._home_to_gate(profile._replace(attempts=1), extra_homing=abs(off))
+                self._park_from_gate(profile)
+            return
+
+        rewind = profile.parking_distance - off
+        self.log_debug("NFC: gate %d: rewinding %.1fmm to park (off=%.1f from datum, "
+                       "parking_distance=%.1f, shared datum '%s' not re-homed)"
+                       % (self.gate_selected, rewind, off, profile.parking_distance,
+                          profile.endstop))
+        self.set_filament_direction(DIRECTION_UNLOAD)
+        self.move_filament("NFC: rewind to park", rewind)
+        self.set_filament_pos_state(FILAMENT_POS_UNLOADED)
+
+        exit_name = self.sensor_manager.get_gate_sensor_name(SENSOR_EXIT_PREFIX, self.gate_selected)
+        if self.sensor_manager.has_sensor(exit_name) and self.sensor_manager.check_sensor(exit_name):
+            self.log_warning("NFC: gate %d: filament still detected at '%s' after re-park "
+                             "- possible slip during the scan" % (self.gate_selected, exit_name))
 
 
 # -----------------------------------------------------------------------------------------------------------

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -90,6 +90,37 @@ class MmuFilamentMovement:
         )
 
 
+    def _shared_gate_path_occupied(self, endstop, gate):
+        """
+        True if 'endstop' is a per-UNIT resource shared by every gate on that unit (not
+        owned by any single gate - see SHARED_GATE_ENDSTOPS) and another gate on the same
+        unit currently occupies it.
+
+        mmu_shared_exit / extruder_entry are real switches downstream of every gate on the
+        unit: read the live sensor directly, since it reflects any gate's filament, not just
+        the one selected - this is correct no matter when it's called.
+
+        The encoder has no presence sensor at all. The only equivalent signal is whether the
+        unit's actively-loaded (fed-forward) filament belongs to a different gate - the same
+        physical fact the switch reads, measured the only way available. That signal only
+        exists BEFORE this operation's own gate selection moves 'gate_selected' onto 'gate' -
+        callers must check this ahead of their own select_gate(gate) (see the command-level
+        can_continue checks in mmu_nfc_scan.py / mmu_preload.py). Called again afterwards, as
+        _preload_gate/_jog_scan do below for the switch-based endstops, gate_selected already
+        equals 'gate' and this branch is inert by construction - there is nothing left to
+        observe at that point, which is fine since the command layer already gated entry.
+        """
+        if endstop not in SHARED_GATE_ENDSTOPS:
+            return False
+        if endstop == SENSOR_ENCODER:
+            unit = self.mmu_unit(gate)
+            return (self.filament_pos != FILAMENT_POS_UNLOADED
+                    and self.gate_selected != gate
+                    and unit.owns_gate(self.gate_selected))
+        shared_name = self.sensor_manager.get_qualified_endstop_name(endstop)
+        return bool(self.sensor_manager.check_sensor(shared_name))
+
+
     def _preload_gate(self, pending=None):
         """
         Preload filament at the selected gate, working entirely from the preload parameter
@@ -133,16 +164,14 @@ class MmuFilamentMovement:
         profile = self._preload_profile()
 
         # MMU_PRELOAD only runs on a gate that is free to preload (unloaded, or a different
-        # unit, or crossload-capable). A *shared* gate endstop that already reads triggered
-        # therefore means another gate's filament occupies the shared exit path - preloading
-        # would home backward into it. Refuse rather than proceed. (A pre-triggered per-gate
-        # exit sensor is the benign "already preloaded" case handled above.)
-        if profile.endstop == SENSOR_SHARED_EXIT:
-            shared_name = self.sensor_manager.get_qualified_endstop_name(SENSOR_SHARED_EXIT)
-            if self.sensor_manager.check_sensor(shared_name):
-                raise MmuError("Cannot preload gate %d: shared exit sensor '%s' is already "
-                               "triggered (filament from another gate still loaded?)"
-                               % (gate, shared_name))
+        # unit, or crossload-capable). A *shared* gate endstop already occupied by another
+        # gate's filament means preloading would home backward (or, for the encoder, forward)
+        # into it. Refuse rather than proceed. (A pre-triggered per-gate exit sensor is the
+        # benign "already preloaded" case handled above - not a shared endstop.)
+        if self._shared_gate_path_occupied(profile.endstop, gate):
+            raise MmuError("Cannot preload gate %d: shared '%s' path is already occupied "
+                           "(filament from another gate still loaded?)"
+                           % (gate, profile.endstop))
 
         # A strong pending (resolved spool_id, or a tag with usable metadata) takes precedence
         # over this gate's own reader: consume it and do a normal preload (skip the per-gate
@@ -650,6 +679,15 @@ class MmuFilamentMovement:
             raise MmuError("Gate %d has no NFC reader to scan" % gate)
         if not nfc_manager.is_enabled(gate=gate):
             raise MmuError("Gate %d NFC reader is disabled (re-enable with MMU_NFC ... ENABLE=1)" % gate)
+
+        # The forward sweep can reach past a SHARED gate datum into territory another gate's
+        # filament may occupy (see _shared_gate_path_occupied). MMU_NFC_SCAN already selected
+        # this gate before calling in here, so this only still catches mmu_shared_exit/
+        # extruder_entry (a live switch, order-independent) - the command-level can_continue
+        # check is what guards the encoder case, before selection moved.
+        if self._shared_gate_path_occupied(profile.endstop, gate):
+            raise MmuError("Cannot scan gate %d: shared '%s' path is already occupied "
+                           "(filament from another gate still loaded?)" % (gate, profile.endstop))
 
         endstop_name = self.sensor_manager.get_gate_sensor_name(SENSOR_NFC_PREFIX, gate)
 

--- a/extras/mmu/unit/mmu_unit_parameters.py
+++ b/extras/mmu/unit/mmu_unit_parameters.py
@@ -70,6 +70,20 @@ class MmuUnitParameters(TunableParametersBase):
     def _on_gate_homing_endstop(self, old, new):
         if new != old:
             self._mmu_unit.calibrator.adjust_bowden_lengths_on_homing_change()
+            # gate_parking_distance's legal sign depends on this endstop (see
+            # _validate_gate_parking_distance) - a value that was fine for the old endstop
+            # can be unsafe for the new one (e.g. a positive park, fine on mmu_exit, driving
+            # forward into a now-shared merge zone on encoder/mmu_shared_exit/extruder_entry).
+            # Re-check it now rather than leaving a stale, now-unsafe value in place until
+            # something else happens to touch it. Same for gate_preload_parking_distance
+            # when gate_preload_endstop is '' and so inherits this one.
+            self._validate_gate_parking_distance(self.gate_parking_distance)
+            if not self.gate_preload_endstop:
+                self._validate_gate_preload_parking_distance(self.gate_preload_parking_distance)
+
+    def _on_gate_preload_endstop(self, old, new):
+        if new != old:
+            self._validate_gate_preload_parking_distance(self.gate_preload_parking_distance)
 
     def _on_flowguard_tuning_change(self, old, new):
         # Push live FlowGuard tuning (relief) to a running controller
@@ -162,7 +176,7 @@ class MmuUnitParameters(TunableParametersBase):
         ParamSpec('gate_load_attempts',               'int',       1, section="GATE HOMING", limits=dict(minval=1, maxval=20)),
 
         # Gate preloading
-        ParamSpec('gate_preload_endstop',             'choice',   '', section="GATE HOMING", choices={o: o for o in (GATE_ENDSTOPS + [''])}),
+        ParamSpec('gate_preload_endstop',             'choice',   '', section="GATE HOMING", choices={o: o for o in (GATE_ENDSTOPS + [''])}, on_change=_on_gate_preload_endstop),
         ParamSpec('gate_preload_homing_max',          'float', lambda self: self.gate_homing_max, section="GATE HOMING"),
         ParamSpec('gate_preload_parking_distance',    'float', -10.0, section="GATE HOMING", validator=_validate_gate_preload_parking_distance),
         ParamSpec('gate_preload_attempts',            'int',       2, section="GATE HOMING", limits=dict(minval=1, maxval=20)),

--- a/extras/mmu/unit/mmu_unit_parameters.py
+++ b/extras/mmu/unit/mmu_unit_parameters.py
@@ -108,6 +108,10 @@ class MmuUnitParameters(TunableParametersBase):
                 "nfc_gate_jog_scan_window backward reach (%.1fmm) cannot exceed gate_homing_max (%.1fmm)"
                 % (abs(neg), self.gate_homing_max)
             )
+        # Note: a forward reach past a SHARED gate datum is deliberately not rejected here.
+        # Whether that is safe depends on the shared path being unoccupied, which is a
+        # runtime property this validator cannot see. Nothing checks it at scan time
+        # either - a sweep forward of a shared datum can meet another gate's filament.
 
     def _validate_nfc_preload_jog_scan_window(self, value):
         # Empty (or absent) disables the NFC scan-on-miss during MMU_PRELOAD

--- a/test/test_mmu_nfc_scan.py
+++ b/test/test_mmu_nfc_scan.py
@@ -28,11 +28,22 @@ from test.hh.bootstrap import install
 install()   # Put the fake klippy root on sys.path before importing MMU modules
 
 from extras.mmu.unit import mmu_nfc_manager
+from test.hh import profiles as hh_profiles
+
+# nfc_per_gate has no encoder object at all (mmu_unit().encoder is None) - fine for every
+# other test here, but the encoder-occupancy guard needs a profile where 'encoder' is a real,
+# usable gate_homing_endstop rather than one that would blow up on first use regardless of
+# the guard. Derived rather than added to profiles.py: nothing else needs this combination.
+NFC_PER_GATE_ENCODER = hh_profiles.NFC_PER_GATE.derive(
+    'nfc_per_gate_encoder',
+    syms={'MMU_HAS_ENCODER': True, 'PIN_ENCODER': 'unit0:PA6', 'CHOICE_GATE_HOMING_ENDSTOP_ENCODER': True},
+    description='BoxTurtle + per-gate NFC + encoder, for shared-endstop occupancy tests')
 
 logging.getLogger().setLevel(logging.CRITICAL)
 
 GATE_AVAILABLE = 1
 FILAMENT_POS_UNLOADED = 0
+FILAMENT_POS_LOADED = 10
 TAG = '04A1B2C3'
 
 
@@ -700,6 +711,107 @@ class TestReparkDrift(NfcScanTestCase):
         # sought=False is "home until the switch releases"; already released -> 0 travel
         trip = self.fil.trip_distance(0, -300., ['mmu_exit_0'], sought=False)
         self.assertEqual(trip, ('mmu_exit_0', 0.0))
+
+
+class TestSharedGateOccupancy(NfcScanTestCase):
+    """
+    PR #1028/#1032 fixed _park_after_scan's re-park for a SHARED gate endstop (mmu_shared_exit
+    / extruder_entry) but, by its own added comment in _validate_nfc_gate_jog_scan_window,
+    left the actual cross-gate hazard unguarded: nothing stopped a scan from sweeping into a
+    shared path another gate on the same unit was already occupying. can_crossload cannot
+    cover this on its own - it says the SELECTOR mechanism won't jam moving between gates, not
+    that a downstream SHARED sensor/encoder is clear. These pin the guard added on top:
+    _shared_gate_path_occupied(), called from the command-level can_continue check and again
+    (for the switch-based endstops) from _jog_scan/_preload_gate itself.
+    """
+
+    def use_shared_endstop(self, endstop, gate=0):
+        self.hh.mmu.mmu_unit(gate).p.gate_homing_endstop = endstop
+
+    def test_shared_exit_rewind_settles_and_does_not_drift_on_repeated_scans(self):
+        """
+        The open-loop rewind _park_after_scan now uses for mmu_shared_exit/extruder_entry
+        must settle at ONE park position and stay there - the same invariant TestReparkDrift
+        pins for the per-gate mmu_exit case, just off a different datum (mmu_shared_exit sits
+        +10mm from the gate, not 0, so the settled park differs from mmu_exit's -100).
+        """
+        self.use_shared_endstop('mmu_shared_exit')
+        self.preload(0)
+        self.hh.mmu.select_gate(0)
+        self.hh.run_gcode('MMU_NFC_SCAN GATE=0')
+        self.assertEqual(self.hh.errors, [])
+        settled = self.fil.tip[0]
+        for _ in range(3):
+            self.hh.run_gcode('MMU_NFC_SCAN GATE=0')
+        self.assertEqual(self.hh.errors, [])
+        self.assertAlmostEqual(self.fil.tip[0], settled, places=1,
+                               msg='repeated scans drifted away from the settled shared-exit park')
+
+    def test_shared_exit_scan_is_refused_when_a_sibling_gate_occupies_it(self):
+        """
+        mmu_shared_exit is ONE physical switch shared by every gate on the unit. If gate 1's
+        filament is currently sitting on it, scanning gate 0 must not sweep into that
+        occupied territory - refuse before any motion, the same way _preload_gate already did
+        for this endstop (now widened and reused here).
+        """
+        self.use_shared_endstop('mmu_shared_exit')
+        self.preload(0)
+        self.hh.place_filament(1, position=self.fil.layout['mmu_shared_exit'] + 5.0)
+        self.hh.mmu.gate_maps.set_gate_status(1, GATE_AVAILABLE)
+        self.hh.mmu.select_gate(0)
+        self.fil.history.clear()
+        self.hh.run_gcode('MMU_NFC_SCAN GATE=0')
+        self.assertEqual(self.fil.history, [], 'an occupied shared path must not move the filament')
+        self.assertTrue(any('occupied' in e for e in self.hh.errors), self.hh.errors)
+
+    def test_encoder_scan_is_refused_when_the_active_filament_is_on_a_sibling_gate(self):
+        """
+        The encoder has no presence sensor, so the only signal equivalent to "is the shared
+        path occupied" is whether the unit's actively fed-forward filament belongs to a
+        different gate - measured before this command's own gate selection moves it. The
+        command-level can_continue check is the only place this is checkable (see
+        _shared_gate_path_occupied's docstring), so it must refuse here even though the unit
+        is crossload-capable.
+
+        Needs a profile with a real encoder object (nfc_per_gate has none), so this boots its
+        own session rather than using self.hh.
+        """
+        hh = session(NFC_PER_GATE_ENCODER, virtual_nfc=True)
+        try:
+            hh.boot()
+            self.assertEqual(hh.errors, [], 'bootup was not clean')
+            fil = hh.filament()
+            self.assertEqual(hh.mmu.mmu_unit(0).p.gate_homing_endstop, 'encoder')
+            self.assertTrue(hh.mmu.mmu_unit(0).can_crossload, 'precondition: boxturtle is crossload-capable')
+            hh.place_filament(0)
+            hh.mmu.gate_maps.set_gate_status(0, GATE_AVAILABLE)
+            hh.place_filament(1)
+            hh.mmu.gate_maps.set_gate_status(1, GATE_AVAILABLE)
+            hh.mmu.select_gate(1)
+            hh.mmu.filament_pos = FILAMENT_POS_LOADED
+            fil.history.clear()
+            hh.run_gcode('MMU_NFC_SCAN GATE=0')
+            self.assertEqual(fil.history, [], 'encoder-shared occupancy must not move the filament')
+            self.assertTrue(hh.errors, 'expected the scan to be refused')
+        finally:
+            hh.close()
+
+    def test_switching_to_a_shared_endstop_rechecks_a_stale_parking_distance(self):
+        """
+        gate_parking_distance's legal sign depends on gate_homing_endstop (see
+        _validate_gate_parking_distance). MMU_TEST_CONFIG already re-validates correctly
+        within ONE combined command (alphabetical field order applies gate_homing_endstop
+        first), but two SEPARATE commands used to leave a hole: set a positive parking
+        distance while on mmu_exit (legal), then switch to a shared endstop in a later
+        command, and the stale now-unsafe value was never rechecked.
+        """
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_parking_distance=10')
+        self.assertEqual(self.hh.errors, [])
+        with self.assertRaises(Exception) as cm:
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=encoder')
+        self.assertIn('gate_parking_distance', str(cm.exception))
+        # The switch must not have landed half-applied with a stale positive parking distance
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.gate_homing_endstop, 'encoder')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Re-opens #1028, which was merged and then reverted on `v4` (GitHub doesn't allow un-merging a PR back to pending) so the change can go through review again from a clean pending state.

Same effective change as #1028 - a revert-of-the-revert on top of current `v4`, rather than the original (now stale relative to `v4`) `ww-V4-Development` branch, so it doesn't regress unrelated work that landed on `v4` since #1028 was opened.