### PR TITLE
Split MMU_SPOOLMAN tag registration into MMU_SPOOLMAN_TAG

### DIFF
--- a/extras/mmu/commands/mmu_nfc.py
+++ b/extras/mmu/commands/mmu_nfc.py
@@ -190,7 +190,7 @@ class MmuNfcCommand(BaseCommand):
                         if shared:
                             if append:
                                 mmu.log_error("NFC: APPEND=1 needs a gate with an assigned spool - not "
-                                              "applicable to the shared reader. Use 'MMU_SPOOLMAN "
+                                              "applicable to the shared reader. Use 'MMU_SPOOLMAN_TAG "
                                               "SPOOLID=<id> RFID=%s APPEND=1' instead." % uid)
                             else:
                                 # Report-only Spoolman resolve/auto-create: no pending, no gate map

--- a/extras/mmu/commands/mmu_spoolman.py
+++ b/extras/mmu/commands/mmu_spoolman.py
@@ -43,13 +43,13 @@ class MmuSpoolmanCommand(BaseCommand):
     )
     HELP_SUPPLEMENT = (
         "Examples:\n"
-        + f"{CMD}                              ...Show the current spoolman gate/spool assignments\n"
-        + f"{CMD} REFRESH=1                    ...Refresh the local gate map from the spoolman database\n"
-        + f"{CMD} GATE=0 SPOOLID=45            ...Assign spoolman spool id 45 to gate 0\n"
-        + f"{CMD} GATE=0                       ...Unassign whichever spool is on gate 0\n"
-        + f"{CMD} SPOOLID=45                   ...Unassign spool id 45 from whichever gate it's on\n"
-        + f"{CMD} SPOOLINFO=45                 ...Display spoolman details for spool id 45\n"
-        + f"{CMD} SPOOLINFO=-1                 ...Display spoolman details for active spool\n"
+        + f"{CMD}                   ...Show the current spoolman gate/spool assignments\n"
+        + f"{CMD} REFRESH=1         ...Refresh the local gate map from the spoolman database\n"
+        + f"{CMD} GATE=0 SPOOLID=45 ...Assign spoolman spool id 45 to gate 0\n"
+        + f"{CMD} GATE=0            ...Unassign whichever spool is on gate 0\n"
+        + f"{CMD} SPOOLID=45        ...Unassign spool id 45 from whichever gate it's on\n"
+        + f"{CMD} SPOOLINFO=45      ...Display spoolman details for spool id 45\n"
+        + f"{CMD} SPOOLINFO=-1      ...Display spoolman details for active spool\n"
         + "\nSee MMU_SPOOLMAN_TAG to register a tag/UID onto a spool record.\n"
     )
 

--- a/extras/mmu/commands/mmu_spoolman.py
+++ b/extras/mmu/commands/mmu_spoolman.py
@@ -21,47 +21,36 @@ from .mmu_base_command import *
 
 class MmuSpoolmanCommand(BaseCommand):
     """
-    Manage spoolman interactions displaying status or simple mutations of extra fields like printer, gate and rfid/uid".
+    Manage spoolman gate/spool assignment and status. Tag/UID registration onto a
+    spool record lives in MMU_SPOOLMAN_TAG instead.
     """
 
     CMD = "MMU_SPOOLMAN"
 
-    HELP_BRIEF = "Manage spoolman integration"
+    HELP_BRIEF = "Manage spoolman status / gate-spool assignment"
     HELP_PARAMS = (
         f"{CMD}: {HELP_BRIEF}\n"
         + "QUIET     = [0|1] Suppress non-critical console output\n"
-        + "SYNC      = [0|1] Sync the local and remote (spoolman) gate maps\n"
-        + "CLEAR     = [0|1] Clear all gate/spool assignments for this printer in the spoolman db\n"
-        + "REFRESH   = [0|1] Rebuild spoolman's cache of this printer's assignments, then sync (unless SYNC= is also given)\n"
-        + "FIX       = [0|1] With REFRESH=, also unassign any inconsistent spool/gate pairs found (partial or duplicate assignments)\n"
-        + "SPOOLID   = #(int) Spoolman spool id. With GATE=, assign it to that gate; Without GATE=, unset its gate. Also the target spool for RFID=/REGISTER=/SPOOLINFO=\n"
-        + "GATE      = #(int)|LAST Gate number, or LAST for whichever gate MMU_PRELOAD most\n"
-        + "              recently completed. With SPOOLID=, assign that spool to it; alone,\n"
-        + "              unset its spool. Also resolves RFID='s target spool. With REGISTER=,\n"
-        + "              defaults to the currently selected gate if omitted\n"
-        + "RFID      = # Write this NFC/RFID tag UID (or comma-separated UIDs) onto the spool record (needs SPOOLID or GATE). Replaces any existing UID(s); RFID='' clears them.\n"
-        + "APPEND    = [0|1] With RFID=, add to the existing UID(s) instead of replacing them; with REGISTER=, add to the spool's existing UID(s) instead of replacing them\n"
-        + "REGISTER  = [0|1] With SPOOLID= and a gate (GATE=, GATE=LAST, or the currently\n"
-        + "              selected gate), write that gate's already-recorded NFC/RFID uid onto\n"
-        + "              SPOOLID in spoolman; the gate map updates once spoolman confirms the\n"
-        + "              write (needs spoolman_support != pull)\n"
+        + "SYNC      = 1 Sync the local and remote (spoolman) gate maps\n"
+        + "CLEAR     = 1 Clear all gate/spool assignments for this printer in the spoolman db\n"
+        + "REFRESH   = 1 Rebuild spoolman's cache of this printer's assignments, then sync (unless SYNC= is also given)\n"
+        + "FIX       = 1 With REFRESH=, also unassign any inconsistent spool/gate pairs found (partial or duplicate assignments)\n"
+        + "SPOOLID   = #(int) Spoolman spool id\n"
+        + "GATE      = #(int) Gate number\n"
         + "PRINTER   = _name_ Show another printer's gate/spool assignments instead of this one\n"
-        + "SPOOLINFO = [0|-1|spool_id] Display spoolman details for a spool (0 or -1 = the active spool)\n"
-        + "(no parameters to shoe the current spoolman gate/spool assignments)\n"
+        + "SPOOLINFO = [-1|spool_id] Display spoolman details for a spool (0 = the active spool)\n"
+        + "(no parameters to show the current spoolman gate/spool assignments)\n"
     )
     HELP_SUPPLEMENT = (
         "Examples:\n"
         + f"{CMD}                              ...Show the current spoolman gate/spool assignments\n"
         + f"{CMD} REFRESH=1                    ...Refresh the local gate map from the spoolman database\n"
         + f"{CMD} GATE=0 SPOOLID=45            ...Assign spoolman spool id 45 to gate 0\n"
+        + f"{CMD} GATE=0                       ...Unassign whichever spool is on gate 0\n"
+        + f"{CMD} SPOOLID=45                   ...Unassign spool id 45 from whichever gate it's on\n"
         + f"{CMD} SPOOLINFO=45                 ...Display spoolman details for spool id 45\n"
-        + f"{CMD} SPOOLID=45 RFID=E2003412     ...Register tag E2003412 against spool id 45 in the spoolman db (replaces any existing tags)\n"
-        + f"{CMD} SPOOLID=45 RFID=E2003499 APPEND=1 ...Register a second tag on the same spool (e.g. one on each side), keeping E2003412\n"
-        + f"{CMD} SPOOLID=45 RFID=''           ...Clear all tags registered against spool id 45\n"
-        + f"{CMD} GATE=0 RFID=E2003412         ...Same, for whichever spool is assigned to gate 0\n"
-        + f"{CMD} GATE=3 SPOOLID=87 REGISTER=1 ...Bind gate 3's already-known tag uid onto newly-created spool 87\n"
-        + f"{CMD} GATE=LAST SPOOLID=87 REGISTER=1 ...Same, for whichever gate was most recently preloaded\n"
-        + f"{CMD} SPOOLID=87 REGISTER=1        ...Same, for the currently selected gate\n"
+        + f"{CMD} SPOOLINFO=-1                 ...Display spoolman details for active spool\n"
+        + "\nSee MMU_SPOOLMAN_TAG to register a tag/UID onto a spool record.\n"
     )
 
     def __init__(self, mmu):
@@ -88,30 +77,9 @@ class MmuSpoolmanCommand(BaseCommand):
         refresh = bool(gcmd.get_int('REFRESH', 0, minval=0, maxval=1))
         fix = bool(gcmd.get_int('FIX', 0, minval=0, maxval=1))
         spool_id = gcmd.get_int('SPOOLID', None, minval=1)
-
-        # GATE= is usually a plain int, but LAST resolves to the gate MMU_PRELOAD most
-        # recently completed - checked before the generic int parse since 'LAST' isn't one.
-        gate_str = gcmd.get('GATE', None)
-        if gate_str is not None and gate_str.strip().upper() == 'LAST':
-            gate = mmu.last_preloaded_gate
-            if gate < 0:
-                mmu.log_error("GATE=LAST needs a gate to have been preloaded first")
-                return
-        elif gate_str is not None:
-            try:
-                gate = int(gate_str)
-            except ValueError:
-                raise gcmd.error("Invalid GATE parameter: %s" % gate_str)
-            if not (-1 <= gate < mmu.num_gates):
-                raise gcmd.error("GATE must be between -1 and %d" % (mmu.num_gates - 1))
-        else:
-            gate = None
-
+        gate = gcmd.get_int('GATE', None, minval=-1, maxval=mmu.num_gates - 1)
         printer = gcmd.get('PRINTER', None)  # Option to see other printers
         spoolinfo = gcmd.get_int('SPOOLINFO', None, minval=-1)  # -1 or 0 is active spool
-        rfid = gcmd.get('RFID', None)        # Tag UID(s) to write onto a spool record
-        append = bool(gcmd.get_int('APPEND', 0, minval=0, maxval=1))
-        register = bool(gcmd.get_int('REGISTER', 0, minval=0, maxval=1))
         run = False
 
         if refresh:
@@ -135,60 +103,7 @@ class MmuSpoolmanCommand(BaseCommand):
             run = True
 
         # Rest of the options are mutually exclusive
-        if register:
-            # Bind a gate's already-recorded NFC/RFID uid onto a spool_id created after the
-            # fact - unlike RFID= (below), no uid is supplied on the command line. GATE=
-            # defaults to the currently selected gate (register's own default only - other
-            # branches below keep treating an omitted GATE= as "not given").
-            if gate is None:
-                gate = mmu.gate_selected
-            if spool_id is None or gate is None or gate < 0:
-                mmu.log_error("REGISTER=1 needs SPOOLID=<id> and a gate - specify GATE=<gate>, "
-                              "GATE=LAST, or select a gate first")
-                return
-            if mmu.p.spoolman_support == SPOOLMAN_PULL:
-                mmu.log_error("REGISTER=1 is not applicable with spoolman_support=pull - use RFID=<uid> "
-                              "to write a UID onto a spool directly, or re-scan the tag after creating it")
-                return
-            uid = mmu.gate_spool_rfid[gate]
-            if not uid:
-                mmu.log_error("Gate %d has no NFC/RFID tag UID recorded yet - scan one first, or "
-                              "use RFID=<uid> to supply it explicitly" % gate)
-                return
-            # No local assignment here - Moonraker confirms the write by calling back
-            # 'MMU_GATE_MAP GATE=<gate> SPOOLID=<spool_id>', so the gate map only updates
-            # once the uid has actually been registered, not optimistically.
-            mmu._spoolman_set_spool_uid(spool_id, uid, append=append, quiet=quiet, gate=gate)
-
-        elif rfid is not None:
-            # Write an NFC/RFID tag UID onto an EXISTING spool record in the spoolman db.
-            #
-            # Note the direction: this is the opposite of 'MMU_NFC ... REGISTER=1', which
-            # takes a UID and finds (or auto-creates) a spool for it. Here the spool
-            # already exists and the tag is bound onto it - the case auto-create cannot
-            # serve, e.g. sticking a blank tag on a spool spoolman already knows about.
-            #
-            # Dispatched before the SPOOLID/GATE branch below, where a bare SPOOLID means
-            # "unset that spool's gate" - which would otherwise swallow SPOOLID=n RFID=x.
-            if append and not rfid.strip():
-                mmu.log_error("APPEND=1 needs a tag UID to add. To clear all tags "
-                              "registered against a spool, use RFID='' without APPEND=1.")
-                return
-            target = spool_id
-            if target is None:
-                if gate is None or gate < 0:
-                    mmu.log_error("RFID= needs SPOOLID=<id>, or GATE=<gate> to use the spool "
-                                  "already assigned to that gate")
-                    return
-                target = mmu.gate_spool_id[gate]
-                if target is None or target <= 0:
-                    mmu.log_error("Gate %d has no spoolman spool assigned - use SPOOLID= to "
-                                  "name the spool explicitly" % gate)
-                    return
-                mmu.log_debug("Gate %d resolves to spool id %d for tag registration" % (gate, target))
-            mmu._spoolman_set_spool_uid(target, rfid.strip(), append=append, quiet=quiet)
-
-        elif spoolinfo is not None:
+        if spoolinfo is not None:
             # Dump spool info for active spool or specified spool id
             mmu._spoolman_display_spool_info(
                 spoolinfo if spoolinfo > 0 else None

--- a/extras/mmu/commands/mmu_spoolman_tag.py
+++ b/extras/mmu/commands/mmu_spoolman_tag.py
@@ -1,0 +1,147 @@
+# Happy Hare MMU Software
+#
+# Copyright (C) 2022-2026  moggieuk#6538 (discord)
+#                          moggieuk@hotmail.com
+#
+# Implements MMU_SPOOLMAN_TAG command
+#
+#
+# (\_/)
+# ( *,*)
+# (")_(") Happy Hare Ready
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+#
+
+# Happy Hare imports
+from ..mmu_constants   import *
+from .mmu_base_command import *
+
+
+class MmuSpoolmanTagCommand(BaseCommand):
+    """
+    Register an NFC/RFID tag UID onto an existing spoolman spool record, either by
+    supplying the UID directly (RFID=) or by binding a gate's already-recorded UID
+    (REGISTER=1). Split out of MMU_SPOOLMAN so that command's SPOOLID/GATE keep a
+    single meaning (gate-spool assignment).
+    """
+
+    CMD = "MMU_SPOOLMAN_TAG"
+
+    HELP_BRIEF = "Register an NFC/RFID tag UID onto a spoolman spool record"
+    HELP_PARAMS = (
+        f"{CMD}: {HELP_BRIEF}\n"
+        + "QUIET    = [0|1] Suppress non-critical console output\n"
+        + "SPOOLID  = #(int) Spoolman spool id to register the tag against\n"
+        + "GATE     = #(int)|LAST Gate whose assigned spool (RFID=) or recorded tag (REGISTER=) to use. If omitted implies current gate\n"
+        + "RFID     = _uid_ (or comma-separated UIDs) to write onto the spool. RFID='' to clear\n"
+        + "APPEND   = 1 Add to the existing UID(s) instead of replacing them\n"
+        + "REGISTER = 1 Bind the gate's already-recorded UID onto SPOOLID (needs spoolman_support != pull)\n"
+    )
+    HELP_SUPPLEMENT = (
+        "Examples:\n"
+        + f"{CMD} SPOOLID=45 RFID=E2003412     ...Register tag E2003412 against spool id 45 in the spoolman db (replaces any existing tags)\n"
+        + f"{CMD} SPOOLID=45 RFID=E2003499 APPEND=1 ...Register a second tag on the same spool (e.g. one on each side), keeping E2003412\n"
+        + f"{CMD} SPOOLID=45 RFID=''           ...Clear all tags registered against spool id 45\n"
+        + f"{CMD} GATE=0 RFID=E2003412         ...Same, for whichever spool is assigned to gate 0\n"
+        + f"{CMD} GATE=3 SPOOLID=87 REGISTER=1    ...Bind gate 3's already-known tag uid to newly-created spool 87\n"
+        + f"{CMD} GATE=LAST SPOOLID=87 REGISTER=1 ...Bind last gate preloaded already-known tag uid to spool 87\n"
+        + f"{CMD} SPOOLID=87 REGISTER=1           ...Bind currently selected gate's tag uid to spool 87\n"
+    )
+
+    def __init__(self, mmu):
+        super().__init__(mmu)
+        self.register(
+            name=self.CMD,
+            handler=self._run,
+            help_brief=self.HELP_BRIEF,
+            help_params=self.HELP_PARAMS,
+            help_supplement=self.HELP_SUPPLEMENT,
+            category=CATEGORY_GENERAL
+        )
+
+    def _run(self, gcmd):
+        # BaseCommand wrapper already logs commandline + handles HELP=1.
+        mmu = self.mmu
+
+        if self.check_if_disabled(): return
+        if self.check_if_spoolman_enabled(): return
+
+        quiet = bool(gcmd.get_int('QUIET', 0, minval=0, maxval=1))
+        spool_id = gcmd.get_int('SPOOLID', None, minval=1)
+
+        # GATE= is usually a plain int, but LAST resolves to the gate MMU_PRELOAD most
+        # recently completed - checked before the generic int parse since 'LAST' isn't one.
+        gate_str = gcmd.get('GATE', None)
+        if gate_str is not None and gate_str.strip().upper() == 'LAST':
+            gate = mmu.last_preloaded_gate
+            if gate < 0:
+                mmu.log_error("GATE=LAST needs a gate to have been preloaded first")
+                return
+        elif gate_str is not None:
+            try:
+                gate = int(gate_str)
+            except ValueError:
+                raise gcmd.error("Invalid GATE parameter: %s" % gate_str)
+            if not (-1 <= gate < mmu.num_gates):
+                raise gcmd.error("GATE must be between -1 and %d" % (mmu.num_gates - 1))
+        else:
+            gate = None
+
+        rfid = gcmd.get('RFID', None)        # Tag UID(s) to write onto a spool record
+        append = bool(gcmd.get_int('APPEND', 0, minval=0, maxval=1))
+        register = bool(gcmd.get_int('REGISTER', 0, minval=0, maxval=1))
+
+        # The two ways to supply/derive a UID are mutually exclusive
+        if register:
+            # Bind a gate's already-recorded NFC/RFID uid onto a spool_id created after the
+            # fact - unlike RFID= (below), no uid is supplied on the command line. GATE=
+            # defaults to the currently selected gate (register's own default only - the
+            # RFID= branch below keeps treating an omitted GATE= as "not given").
+            if gate is None:
+                gate = mmu.gate_selected
+            if spool_id is None or gate is None or gate < 0:
+                mmu.log_error("REGISTER=1 needs SPOOLID=<id> and a gate - specify GATE=<gate>, "
+                              "GATE=LAST, or select a gate first")
+                return
+            if mmu.p.spoolman_support == SPOOLMAN_PULL:
+                mmu.log_error("REGISTER=1 is not applicable with spoolman_support=pull - use RFID=<uid> "
+                              "to write a UID onto a spool directly, or re-scan the tag after creating it")
+                return
+            uid = mmu.gate_spool_rfid[gate]
+            if not uid:
+                mmu.log_error("Gate %d has no NFC/RFID tag UID recorded yet - scan one first, or "
+                              "use RFID=<uid> to supply it explicitly" % gate)
+                return
+            # No local assignment here - Moonraker confirms the write by calling back
+            # 'MMU_GATE_MAP GATE=<gate> SPOOLID=<spool_id>', so the gate map only updates
+            # once the uid has actually been registered, not optimistically.
+            mmu._spoolman_set_spool_uid(spool_id, uid, append=append, quiet=quiet, gate=gate)
+
+        elif rfid is not None:
+            # Write an NFC/RFID tag UID onto an EXISTING spool record in the spoolman db.
+            #
+            # Note the direction: this is the opposite of 'MMU_NFC ... REGISTER=1', which
+            # takes a UID and finds (or auto-creates) a spool for it. Here the spool
+            # already exists and the tag is bound onto it - the case auto-create cannot
+            # serve, e.g. sticking a blank tag on a spool spoolman already knows about.
+            if append and not rfid.strip():
+                mmu.log_error("APPEND=1 needs a tag UID to add. To clear all tags "
+                              "registered against a spool, use RFID='' without APPEND=1.")
+                return
+            target = spool_id
+            if target is None:
+                if gate is None or gate < 0:
+                    mmu.log_error("RFID= needs SPOOLID=<id>, or GATE=<gate> to use the spool "
+                                  "already assigned to that gate")
+                    return
+                target = mmu.gate_spool_id[gate]
+                if target is None or target <= 0:
+                    mmu.log_error("Gate %d has no spoolman spool assigned - use SPOOLID= to "
+                                  "name the spool explicitly" % gate)
+                    return
+                mmu.log_debug("Gate %d resolves to spool id %d for tag registration" % (gate, target))
+            mmu._spoolman_set_spool_uid(target, rfid.strip(), append=append, quiet=quiet)
+
+        else:
+            mmu.log_error("%s needs RFID=<uid> or REGISTER=1" % self.CMD)

--- a/extras/mmu/commands/mmu_spoolman_tag.py
+++ b/extras/mmu/commands/mmu_spoolman_tag.py
@@ -40,13 +40,14 @@ class MmuSpoolmanTagCommand(BaseCommand):
     )
     HELP_SUPPLEMENT = (
         "Examples:\n"
-        + f"{CMD} SPOOLID=45 RFID=E2003412     ...Register tag E2003412 against spool id 45 in the spoolman db (replaces any existing tags)\n"
+        + f"{CMD} SPOOLID=45 RFID=E2003412          ...Register tag E2003412 against spool id 45 in the spoolman db (replaces any existing tags)\n"
         + f"{CMD} SPOOLID=45 RFID=E2003499 APPEND=1 ...Register a second tag on the same spool (e.g. one on each side), keeping E2003412\n"
-        + f"{CMD} SPOOLID=45 RFID=''           ...Clear all tags registered against spool id 45\n"
-        + f"{CMD} GATE=0 RFID=E2003412         ...Same, for whichever spool is assigned to gate 0\n"
-        + f"{CMD} GATE=3 SPOOLID=87 REGISTER=1    ...Bind gate 3's already-known tag uid to newly-created spool 87\n"
-        + f"{CMD} GATE=LAST SPOOLID=87 REGISTER=1 ...Bind last gate preloaded already-known tag uid to spool 87\n"
-        + f"{CMD} SPOOLID=87 REGISTER=1           ...Bind currently selected gate's tag uid to spool 87\n"
+        + f"{CMD} SPOOLID=45 RFID=''                ...Clear all tags registered against spool id 45\n"
+        + f"{CMD} GATE=0 RFID=E2003412              ...Same, for whichever spool is assigned to gate 0\n"
+        + f"{CMD} GATE=3 SPOOLID=87 REGISTER=1      ...Bind gate 3's already-known tag uid to newly-created spool 87\n"
+        + f"{CMD} GATE=LAST SPOOLID=87 REGISTER=1   ...Bind last gate preloaded already-known tag uid to spool 87\n"
+        + f"{CMD} SPOOLID=87 REGISTER=1             ...Bind currently selected gate's tag uid to spool 87\n"
+        + "\nSee MMU_SPOOLMAN read or change gate-spool assignment in spoolman\n"
     )
 
     def __init__(self, mmu):

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -3509,9 +3509,9 @@ class MmuController(MmuFilamentMovement):
         """
         Write NFC/RFID tag UID(s) onto a spool record in Spoolman so future
         scans of those tags resolve to this spool_id. Called by
-        'MMU_SPOOLMAN SPOOLID=.. RFID=..', by a per-gate 'MMU_NFC REGISTER=1
+        'MMU_SPOOLMAN_TAG SPOOLID=.. RFID=..', by a per-gate 'MMU_NFC REGISTER=1
         APPEND=1' binding a newly scanned tag onto the gate's assigned spool, and
-        by 'MMU_SPOOLMAN GATE=.. SPOOLID=.. REGISTER=1'.
+        by 'MMU_SPOOLMAN_TAG GATE=.. SPOOLID=.. REGISTER=1'.
 
         This is the opposite direction to _spoolman_register_tag / MMU_NFC REGISTER=1
         (without APPEND), which takes a UID and finds (or auto-creates) a spool for it.

--- a/test/test_mmu_moonraker.py
+++ b/test/test_mmu_moonraker.py
@@ -494,7 +494,7 @@ class TestSetSpoolUid(MoonrakerTestCase):
     """
     Binding a tag onto an EXISTING spool - the opposite direction to get_spool_by_uid,
     which takes a UID and finds or auto-creates a spool. Reached from Klipper as
-    'MMU_SPOOLMAN SPOOLID=.. RFID=..'.
+    'MMU_SPOOLMAN_TAG SPOOLID=.. RFID=..'.
     """
 
     SPOOLS = (dict(uid=KNOWN_UID, material='PLA'),

--- a/test/test_mmu_nfc_scan.py
+++ b/test/test_mmu_nfc_scan.py
@@ -278,7 +278,7 @@ class TestPreloadNfcCompound(NfcScanTestCase):
         self.assertNotIn('nfc:', said)
 
     def test_last_preloaded_gate_is_recorded_on_success(self):
-        """MMU_SPOOLMAN GATE=LAST relies on this being set after a normal successful preload."""
+        """MMU_SPOOLMAN_TAG GATE=LAST relies on this being set after a normal successful preload."""
         self.hh.place_filament(0, position=-100.0)
         self.assertEqual(self.hh.mmu.last_preloaded_gate, -1, 'precondition: nothing preloaded yet')
         self.hh.run_gcode('MMU_PRELOAD GATE=0')

--- a/test/test_mmu_roundtrip.py
+++ b/test/test_mmu_roundtrip.py
@@ -404,7 +404,7 @@ class TestNfcCommandSurface(RoundTripTestCase):
 
 class TestSpoolmanRfidCommand(RoundTripTestCase):
     """
-    'MMU_SPOOLMAN ... RFID=' end to end: Klipper command -> _spoolman_set_spool_uid ->
+    'MMU_SPOOLMAN_TAG ... RFID=' end to end: Klipper command -> _spoolman_set_spool_uid ->
     webhook -> MmuServer.set_spool_uid -> the spoolman db.
 
     Direction matters: this BINDS a tag onto an existing spool. The other direction -
@@ -417,17 +417,17 @@ class TestSpoolmanRfidCommand(RoundTripTestCase):
 
     def test_explicit_spoolid_registers_the_tag(self):
         self.assertEqual(self.rt.db.spool_uid(2), '', 'precondition: spool 2 has no tag')
-        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 RFID=%s' % TAG_B)
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG SPOOLID=2 RFID=%s' % TAG_B)
         self.assertEqual(self.rt.db.spool_uid(2), TAG_B)
 
     def test_gate_resolves_to_its_assigned_spool(self):
         self.rt.run_gcode('MMU_GATE_MAP GATE=3 SPOOLID=2')
-        self.rt.run_gcode('MMU_SPOOLMAN GATE=3 RFID=%s' % TAG_B)
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG GATE=3 RFID=%s' % TAG_B)
         self.assertEqual(self.rt.db.spool_uid(2), TAG_B,
                          "GATE= must resolve through the gate map to spool 2")
 
     def test_separators_are_stripped(self):
-        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 RFID=bb:bb:22:22')
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG SPOOLID=2 RFID=bb:bb:22:22')
         self.assertEqual(self.rt.db.spool_uid(2), TAG_B, 'normalised uppercase, no separators')
 
     def test_does_not_unset_the_gate_assignment(self):
@@ -438,19 +438,19 @@ class TestSpoolmanRfidCommand(RoundTripTestCase):
         """
         self.rt.run_gcode('MMU_GATE_MAP GATE=3 SPOOLID=2')
         self.assertEqual(self.rt.db.spool_gate(2), 3, 'precondition: spool 2 is on gate 3')
-        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 RFID=%s' % TAG_B)
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG SPOOLID=2 RFID=%s' % TAG_B)
         self.assertEqual(self.rt.db.spool_gate(2), 3, 'gate assignment must survive')
         self.assertEqual(self.rt.db.spool_uid(2), TAG_B)
 
     def test_gate_with_no_spool_errors(self):
         errors_before = len(self.rt.errors)
-        self.rt.run_gcode('MMU_SPOOLMAN GATE=1 RFID=%s' % TAG_B)
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG GATE=1 RFID=%s' % TAG_B)
         self.assertGreater(len(self.rt.errors), errors_before)
         self.assertIn('no spoolman spool assigned', self.rt.errors[-1].lower())
 
     def test_neither_spoolid_nor_gate_errors(self):
         errors_before = len(self.rt.errors)
-        self.rt.run_gcode('MMU_SPOOLMAN RFID=%s' % TAG_B)
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG RFID=%s' % TAG_B)
         self.assertGreater(len(self.rt.errors), errors_before)
         self.assertIn('spoolid', self.rt.errors[-1].lower())
 
@@ -460,21 +460,21 @@ class TestSpoolmanRfidCommand(RoundTripTestCase):
         from a spool - it must succeed silently, not error (that used to be
         rejected outright; now RFID='' is how a spool's tag(s) get cleared).
         """
-        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 RFID=%s' % TAG_B)
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG SPOOLID=2 RFID=%s' % TAG_B)
         errors_before = len(self.rt.errors)
-        self.rt.run_gcode("MMU_SPOOLMAN SPOOLID=2 RFID=''")
+        self.rt.run_gcode("MMU_SPOOLMAN_TAG SPOOLID=2 RFID=''")
         self.assertEqual(len(self.rt.errors), errors_before)
         self.assertEqual(self.rt.db.spool_uid(2), '')
 
     def test_append_adds_a_second_tag_without_losing_the_first(self):
         """A spool can carry more than one physical tag (e.g. one on each side)."""
-        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 RFID=%s' % TAG_B)
-        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 RFID=%s APPEND=1' % TAG_C)
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG SPOOLID=2 RFID=%s' % TAG_B)
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG SPOOLID=2 RFID=%s APPEND=1' % TAG_C)
         self.assertEqual(set(self.rt.db.spool_uids(2)), {TAG_B, TAG_C})
 
     def test_the_registered_tag_then_resolves_on_a_scan(self):
         """The round trip: bind a tag, then scanning it must resolve to that spool."""
-        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 RFID=%s' % TAG_B)
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG SPOOLID=2 RFID=%s' % TAG_B)
         self.rt.present_tag(TAG_B, gate=0, deep=False)
         self.assertEqual(self.rt.mmu.gate_spool_id[0], 2,
                          'the freshly bound tag must resolve to spool 2')
@@ -484,7 +484,7 @@ class TestSpoolmanRfidCommand(RoundTripTestCase):
 
 class TestSpoolmanRegisterCommand(RoundTripTestCase):
     """
-    'MMU_SPOOLMAN GATE= SPOOLID= REGISTER=1': a spool with no Spoolman entry at scan
+    'MMU_SPOOLMAN_TAG GATE= SPOOLID= REGISTER=1': a spool with no Spoolman entry at scan
     time leaves its uid sitting in the gate map with no spool_id. Once the matching
     spool exists, REGISTER=1 binds the gate's already-known uid onto it - without any
     new tag read. The gate map only updates once Spoolman confirms the write (via the
@@ -501,58 +501,58 @@ class TestSpoolmanRegisterCommand(RoundTripTestCase):
 
     def test_registers_the_gates_known_uid_and_assigns_locally(self):
         self._scan_bare_uid()
-        self.rt.run_gcode('MMU_SPOOLMAN GATE=3 SPOOLID=2 REGISTER=1')
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG GATE=3 SPOOLID=2 REGISTER=1')
         self.assertEqual(self.rt.db.spool_uid(2), UNKNOWN_TAG)
         self.assertEqual(self.rt.mmu.gate_spool_id[3], 2)
 
     def test_failed_write_leaves_the_gate_map_untouched(self):
         self._scan_bare_uid()
         self.rt.db.offline = True
-        self.rt.run_gcode('MMU_SPOOLMAN GATE=3 SPOOLID=2 REGISTER=1')
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG GATE=3 SPOOLID=2 REGISTER=1')
         self.assertEqual(self.rt.mmu.gate_spool_id[3], -1,
                          'a failed remote write must not commit the local assignment')
 
     def test_no_recorded_uid_errors(self):
         errors_before = len(self.rt.errors)
-        self.rt.run_gcode('MMU_SPOOLMAN GATE=3 SPOOLID=2 REGISTER=1')
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG GATE=3 SPOOLID=2 REGISTER=1')
         self.assertGreater(len(self.rt.errors), errors_before)
         self.assertIn('no nfc/rfid tag uid recorded', self.rt.errors[-1].lower())
 
     def test_missing_gate_or_spoolid_errors(self):
         errors_before = len(self.rt.errors)
-        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 REGISTER=1')
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG SPOOLID=2 REGISTER=1')
         self.assertGreater(len(self.rt.errors), errors_before)
-        self.rt.run_gcode('MMU_SPOOLMAN GATE=3 REGISTER=1')
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG GATE=3 REGISTER=1')
         self.assertGreater(len(self.rt.errors), errors_before + 1)
 
     def test_bypass_gate_is_rejected(self):
         errors_before = len(self.rt.errors)
-        self.rt.run_gcode('MMU_SPOOLMAN GATE=-1 SPOOLID=2 REGISTER=1')
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG GATE=-1 SPOOLID=2 REGISTER=1')
         self.assertGreater(len(self.rt.errors), errors_before)
 
     def test_pull_mode_errors_instead_of_silently_finding_nothing(self):
         self._scan_bare_uid()
         self.rt.mmu.p.spoolman_support = 'pull'
         errors_before = len(self.rt.errors)
-        self.rt.run_gcode('MMU_SPOOLMAN GATE=3 SPOOLID=2 REGISTER=1')
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG GATE=3 SPOOLID=2 REGISTER=1')
         self.assertGreater(len(self.rt.errors), errors_before)
         self.assertIn('pull', self.rt.errors[-1].lower())
 
     def test_omitted_gate_defaults_to_the_selected_gate(self):
         self._scan_bare_uid()
         self.rt.run_gcode('MMU_SELECT GATE=3')
-        self.rt.run_gcode('MMU_SPOOLMAN SPOOLID=2 REGISTER=1')
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG SPOOLID=2 REGISTER=1')
         self.assertEqual(self.rt.mmu.gate_spool_id[3], 2)
 
     def test_gate_last_resolves_to_the_most_recently_preloaded_gate(self):
         self._scan_bare_uid()
         self.rt.mmu.last_preloaded_gate = 3
-        self.rt.run_gcode('MMU_SPOOLMAN GATE=LAST SPOOLID=2 REGISTER=1')
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG GATE=LAST SPOOLID=2 REGISTER=1')
         self.assertEqual(self.rt.mmu.gate_spool_id[3], 2)
 
     def test_gate_last_errors_when_nothing_has_been_preloaded(self):
         errors_before = len(self.rt.errors)
-        self.rt.run_gcode('MMU_SPOOLMAN GATE=LAST SPOOLID=2 REGISTER=1')
+        self.rt.run_gcode('MMU_SPOOLMAN_TAG GATE=LAST SPOOLID=2 REGISTER=1')
         self.assertGreater(len(self.rt.errors), errors_before)
         self.assertIn('preloaded', self.rt.errors[-1].lower())
 


### PR DESCRIPTION
## Summary
- `MMU_SPOOLMAN` overloaded `SPOOLID`/`GATE` with two unrelated meanings depending on which other params were present: gate-spool assignment (`SYNC`/`CLEAR`/`REFRESH`/`FIX`/`SPOOLID`+`GATE`) vs. tag-UID registration (`RFID=`/`APPEND=`/`REGISTER=`).
- Tag-UID registration is now its own command, `MMU_SPOOLMAN_TAG`, with identical behavior/validation/error messages - just split out so `SPOOLID`/`GATE` keep one meaning per command.
- `MMU_SPOOLMAN` retains: `QUIET`, `SYNC`, `CLEAR`, `REFRESH`, `FIX`, `SPOOLID`, `GATE`, `PRINTER`, `SPOOLINFO`.
- `MMU_SPOOLMAN_TAG` gets: `QUIET`, `SPOOLID`, `GATE`/`GATE=LAST`, `RFID=`, `APPEND=`, `REGISTER=`.
- Updated the two places that referenced the old `MMU_SPOOLMAN ... RFID=/REGISTER=` invocation (`MMU_NFC`'s APPEND error message, and the `_spoolman_set_spool_uid` docstring).

## Test plan
- [x] `make test` before/after: 982 tests, same baseline (skipped=1, expected failures=4), no regressions
- [x] Updated `test/test_mmu_roundtrip.py`, `test/test_mmu_moonraker.py`, `test/test_mmu_nfc_scan.py` to reference `MMU_SPOOLMAN_TAG` for the RFID/REGISTER cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)