### PR TITLE
Fix missing import in mmu_heater.py

### DIFF
--- a/extras/mmu/commands/mmu_heater.py
+++ b/extras/mmu/commands/mmu_heater.py
@@ -21,9 +21,10 @@
 #
 
 # Happy Hare imports
-from ..mmu_constants   import *
-from ..mmu_utils       import MmuError
-from .mmu_base_command import *
+from ..mmu_constants                import *
+from ..mmu_utils                    import MmuError
+from ..unit.mmu_environment_manager import ENV_CHECK_INTERVAL
+from .mmu_base_command              import *
 
 
 class MmuHeaterCommand(BaseCommand):


### PR DESCRIPTION
## Summary
- Add missing import of `ENV_CHECK_INTERVAL` from `mmu_environment_manager` in `mmu_heater.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)