### PR TITLE
Kconfig: convert log_startup_status to bool option, clean up help text

### DIFF
--- a/extras/mmu/mmu_machine_parameters.py
+++ b/extras/mmu/mmu_machine_parameters.py
@@ -134,7 +134,7 @@ class MmuMachineParameters(TunableParametersBase):
         ParamSpec('log_file_level',                'int',      2, section="LOGGING", limits=dict(minval=-1, maxval=4)),
         ParamSpec('log_statistics',                'int',      0, section="LOGGING", limits=dict(minval=0, maxval=1)),
         ParamSpec('log_visual',                    'int',      1, section="LOGGING", limits=dict(minval=0, maxval=1)),
-        ParamSpec('log_startup_status',            'int',      1, section="LOGGING", limits=dict(minval=0, maxval=2)),
+        ParamSpec('log_startup_status',            'int',      1, section="LOGGING", limits=dict(minval=0, maxval=1)),
         ParamSpec('log_m117_messages',             'int',      1, section="LOGGING", limits=dict(minval=0, maxval=1)),
 
         # Cosmetic console stuff

--- a/installer/Kconfig.options
+++ b/installer/Kconfig.options
@@ -239,7 +239,7 @@ menu "Software Options"
     bool "Log visual representation of filament?"
     default y
     help
-      1 log visual representation of filament, 0 = disable
+      Whether to log visual representation of filament in console
 
   config PARAM_LOG_VISUAL
     int
@@ -349,7 +349,7 @@ menu "Software Options"
     bool "Reset tool-to-gate map on startup?"
     default n
     help
-      1 = reset TTG map on startup, 0 = do nothing
+      Whether to reset TTG map on startup
 
   config PARAM_STARTUP_RESET_TTG_MAP
     int
@@ -360,7 +360,7 @@ menu "Software Options"
     bool "Show pop-up dialog on error?"
     default y
     help
-      1 = show pop-up dialog in addition to console message, 0 = show error in console
+      Select to show pop-up dialog in addition to console message
 
   config PARAM_SHOW_ERROR_DIALOG
     int
@@ -383,7 +383,7 @@ menu "Software Options"
     bool "Check filament position on pause/error?"
     default y
     help
-      1 = Run a quick check to determine current filament position on pause/error, 0 = disable
+      Whether to run a quick check to determine current filament position on pause/error
 
   config PARAM_FILAMENT_RECOVERY_ON_PAUSE
     int

--- a/installer/Kconfig.options
+++ b/installer/Kconfig.options
@@ -246,12 +246,16 @@ menu "Software Options"
     default 1 if BOOL_LOG_VISUAL
     default 0
 
-  config PARAM_LOG_STARTUP_STATUS
-    int "Log tool to gate status on startup"
-    range 0 2
-    default 1
+  config BOOL_LOG_STARTUP_STATUS
+    bool "Log tool to gate status on startup"
+    default y
     help
-      Whether to log tool to gate status on startup, 1 = summary (default), 0 = disable
+      Whether to log tool summary and gate status on startup
+
+  config PARAM_LOG_STARTUP_STATUS
+    int
+    default 1 if BOOL_LOG_STARTUP_STATUS
+    default 0
 
   config BOOL_LOG_M117_MESSAGES
     bool "Send toolchange message via M117 to screen?"


### PR DESCRIPTION
## Summary
- Convert `PARAM_LOG_STARTUP_STATUS` from an int (range 0-2) to a bool-backed option (`BOOL_LOG_STARTUP_STATUS`), matching the pattern used for `PARAM_LOG_VISUAL`. The `2` value was never distinguished from `1` in code (`mmu_controller.py` only does a truthy check), so it's dropped as dead range.
- Reword the remaining "1 = X, 0 = Y" style help text in `Kconfig.options` to plain yes/no prose for consistency with the other boolean options.

## Test plan
- [x] Run menuconfig and confirm "Log tool to gate status on startup" now presents as a checkbox with correct default (on)
- [x] Confirm generated `mmu_parameters.cfg` still emits `log_startup_status: 1` by default
- [ ] Verify existing installs with `log_startup_status: 2` in `mmu_parameters.cfg` don't hit param validation errors (falls within new maxval=1... confirm behavior on upgrade)