### PR TITLE
Harden NFC reader sharing between neighboring gate pairs

### DIFF
--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -196,6 +196,8 @@ nfc_reader               : [[PARAM_NFC_READER]]
 [% if MMU_HAS_PER_GATE_NFC_READERS %]
 # PER-GATE nfc_readers. Don't define 'nfc_reader' instead specify a comma separated list of nfc_readers
 # (length must match the number of gates)
+# A name may repeat to share one physical reader between neighboring gates, e.g.
+# 'a, a, b, b' puts one reader 'a' between gates 0/1 and another 'b' between gates 2/3
 [% set names = [] %]
 [% for i in range(0, PARAM_NUM_GATES|int) %]
 [% set _ = names.append((PARAM_NFC_READER_|d)[i]) %]

--- a/extras/mmu/mmu_unit.py
+++ b/extras/mmu/mmu_unit.py
@@ -213,6 +213,14 @@ class MmuUnit:
             if name and not config.has_section('mmu_nfc_reader %s' % name):
                 raise config.error("MMU NFC reader section [mmu_nfc_reader %s] not found!" % name)
 
+        # A name may repeat in 'nfc_readers' (e.g. 'a, a, b, b') - that's intentional,
+        # not an error: it shares one physical reader between neighboring gates (one
+        # antenna positioned between them). MmuNfcManager._lookup_or_create_reader()
+        # creates the Klipper object once and reuses it for every gate that names it;
+        # enable/active state stays independent per gate. Adjacency is a hardware-layout
+        # fact, not something validated here. See installer/boards/custom/Kconfig.vvd
+        # for the in-tree example (the ViViD machine).
+
 
         # ---------------------------------------------------------------------------------------------------
         # MMU Extruder

--- a/extras/mmu/unit/mmu_nfc_manager.py
+++ b/extras/mmu/unit/mmu_nfc_manager.py
@@ -464,7 +464,8 @@ class MmuNfcManager:
         """
         MMU bootup event. Schedule initialization after the I2C bus settles.
         """
-        num_readers = (1 if self.shared_reader is not None else 0) + sum(1 for r in self.gate_readers if r is not None)
+        num_readers = ((1 if self.shared_reader is not None else 0) +
+                       sum(1 for r, _ in self._unique_readers() if r is not self.shared_reader))
         self.mmu.log_debug("NFC: bootup on %s - scheduling %d reader(s) in %.1fs" %
                            (self.mmu_unit.name, num_readers, NFC_INIT_DELAY))
         self.reactor.update_timer(self._bootup_init_timer,
@@ -554,22 +555,43 @@ class MmuNfcManager:
         return self.mmu_unit.first_gate + lg if lg is not None else '?'
 
 
-    def _all_readers(self):
-        readers = []
-        if self.shared_reader is not None:
-            readers.append(self.shared_reader)
-        readers.extend(r for r in self.gate_readers if r is not None)
-        return readers
+    def _unique_readers(self):
+        """
+        [(reader, [global_gate, ...])] in first-appearance order, deduped by object
+        identity. One physical reader may be named by more than one gate slot (a
+        reader shared between neighboring gates - see mmu_unit.py's 'nfc_readers'),
+        and may also double as the unit's shared reader. Anything that drives
+        HARDWARE per boot/event must iterate this, not gate_readers directly, or
+        the chip gets the same transaction N times.
+        """
+        by_id = {}
+        result = []
+        for lgate, reader in enumerate(self.gate_readers):
+            if reader is None:
+                continue
+            global_gate = self.mmu_unit.first_gate + lgate
+            idx = by_id.get(id(reader))
+            if idx is None:
+                by_id[id(reader)] = len(result)
+                result.append((reader, [global_gate]))
+            else:
+                result[idx][1].append(global_gate)
+        return result
 
 
     def _init_all_readers(self):
         # The shared reader is labelled with the unit name; per-gate readers with
-        # their logical gate number (local index + first_gate).
+        # their first logical gate number (a reader shared between two gates is
+        # only inited once here, not once per gate slot - see _unique_readers()).
         if self.shared_reader is not None:
             self._init_reader(self.shared_reader, self.mmu_unit.name)
-        for lgate, reader in enumerate(self.gate_readers):
-            if reader is not None:
-                self._init_reader(reader, self.mmu_unit.first_gate + lgate)
+        for reader, gates in self._unique_readers():
+            if reader is self.shared_reader:
+                continue # Dual shared/per-gate role - already inited above
+            if len(gates) > 1:
+                self.mmu.log_debug("NFC: reader '%s' serves gates %s - initializing once" %
+                                   (getattr(reader, 'name', '?'), ",".join(map(str, gates))))
+            self._init_reader(reader, gates[0])
 
 
     def _init_reader(self, reader, gate):

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -251,11 +251,14 @@ class Session:
         return self.nfc_chips
 
     def chip(self, name_or_gate):
-        """A virtual chip by reader name, or by gate index for a per-gate reader."""
+        """
+        A virtual chip by reader name, or by gate index for a per-gate reader. A chip
+        shared between neighboring gates matches on any gate in its _gates list.
+        """
         if name_or_gate in self.nfc_chips:
             return self.nfc_chips[name_or_gate]
         for chip in self.nfc_chips.values():
-            if chip._gate == name_or_gate:
+            if chip._gate == name_or_gate or name_or_gate in chip._gates:
                 return chip
         raise KeyError('no virtual NFC chip for %r; have: %s'
                        % (name_or_gate, ', '.join(sorted(self.nfc_chips))))

--- a/test/hh/nfc_fixtures.py
+++ b/test/hh/nfc_fixtures.py
@@ -267,6 +267,10 @@ class VirtualNfcChip:
     _release_current_target. Optionally also the non-blocking presence-probe contract
     - see probe_support below. Note the chip's own _gate is set by virtualise() and is
     functional (it selects the tag to show); MmuNfcReader no longer writes to it.
+    _gates (plural) is the full list a chip is bound to - more than one entry when
+    the chip is shared between neighboring gates (see virtualise()); _visible_tag()
+    checks each in order and returns the first tag found, an arbitrary tie-break for
+    a chip serving two gates at once.
 
     Targets report protocol='uid_only', so _classify_target returns 'uid_only' and
     read_tag_data yields (uid, None) - a UID read with no metadata. That is deliberate:
@@ -286,8 +290,10 @@ class VirtualNfcChip:
     of the contract, so it needs to be reachable in a test.
     """
 
-    def __init__(self, model=None, gate=None, label=None, probe_support=False):
+    def __init__(self, model=None, gate=None, gates=None, label=None, probe_support=False):
         self._gate = gate if gate is not None else label
+        self._gates = ([g for g in gates if isinstance(g, int)] if gates
+                       else ([self._gate] if isinstance(self._gate, int) else []))
         self.model = model
         self.presented = None       # explicit override, for shared/common readers
         self.reads = 0              # assertion surface
@@ -418,10 +424,15 @@ class VirtualNfcChip:
     def _visible_tag(self):
         if self.presented is not None:
             return self.presented
-        # A per-gate reader sees its own gate's filament; a common reader has an
-        # integer-less label, so it only ever reports an explicitly presented tag.
-        if self.model is not None and isinstance(self._gate, int):
-            return self.model.tag_detected(self._gate)
+        # A per-gate reader sees its own gate's filament; a reader shared between
+        # neighboring gates checks each of _gates in order (first tag found wins -
+        # tests should present one tag at a time). A common reader has no int gate
+        # at all, so it only ever reports an explicitly presented tag.
+        if self.model is not None:
+            for gate in self._gates:
+                tag = self.model.tag_detected(gate)
+                if tag is not None:
+                    return tag
         return None
 
     def __repr__(self):
@@ -441,6 +452,11 @@ def virtualise(printer, model=None, probe_support=False):
     care set it explicitly; a chip's flag can also be flipped afterwards, since
     has_probe_support() consults probe_supported() on each call.
 
+    A reader shared between neighboring gates (mmu_unit.py's 'nfc_readers' repeating a
+    name) appears more than once in gate_readers by object identity; it gets exactly
+    ONE chip serving every gate it's bound to (VirtualNfcChip._gates), not one chip
+    per slot - which would silently drop all but the last-processed gate.
+
     Returns {reader_name: VirtualNfcChip}.
     """
     machine = printer.lookup_object('mmu_machine', None)
@@ -456,13 +472,27 @@ def virtualise(printer, model=None, probe_support=False):
         # the chip's label with the global gate and paper over the difference; it no
         # longer does, and every NFC profile today is single-unit (first_gate == 0), so
         # this was latent rather than live.
-        readers = [(unit.first_gate + lgate, r) for lgate, r in enumerate(
-            getattr(manager, 'gate_readers', ()) or ()) if r is not None]
+        #
+        # Dedupe by reader identity first, so a shared-pair reader collects BOTH gates
+        # onto one entry instead of producing two entries that would spawn two chips
+        # (the second silently winning as reader.reader, per gate-slot info lost).
+        by_id = {}
+        entries = []
+        for lgate, r in enumerate(getattr(manager, 'gate_readers', ()) or ()):
+            if r is None:
+                continue
+            gate = unit.first_gate + lgate
+            idx = by_id.get(id(r))
+            if idx is None:
+                by_id[id(r)] = len(entries)
+                entries.append([r, [gate]])
+            else:
+                entries[idx][1].append(gate)
         shared = getattr(manager, 'shared_reader', None)
         if shared is not None:
-            readers.append((None, shared))
-        for gate, reader in readers:
-            chip = VirtualNfcChip(model=model, gate=gate, label=reader.name,
+            entries.append([shared, [None]])
+        for reader, gates in entries:
+            chip = VirtualNfcChip(model=model, gate=gates[0], gates=gates, label=reader.name,
                                   probe_support=probe_support)
             reader.reader = chip
             chips[reader.name] = chip

--- a/test/test_mmu_nfc.py
+++ b/test/test_mmu_nfc.py
@@ -278,5 +278,96 @@ class TestPn5180Wiring(unittest.TestCase):
             hh.close()
 
 
+class TestSharedGatePairReader(unittest.TestCase):
+    """
+    RUNTIME REGRESSION GUARD for one physical NFC reader serving a PAIR of neighboring
+    gates - the ViViD machine: gates 9/10 share reader 'unit1_nfc01', gates 11/12 share
+    'unit1_nfc23' (installer/boards/custom/Kconfig.vvd:119-133). test_mmu_profiles.py's
+    test_per_gate_nfc_readers_are_shared_across_a_gate_pair already covers config
+    rendering; this exercises the live MmuNfcManager: reader identity sharing, single-init
+    hardware hygiene (the regression this pass fixes), independent per-gate enable/active
+    state, and reads.
+    """
+
+    TAG = '04A1B2C3'
+
+    def setUp(self):
+        # A fresh boot per test, not setUpClass: several tests toggle enabled/active,
+        # and re-enabling triggers a real reader re-init (chip.inits) - state that must
+        # not leak into test_shared_reader_is_hardware_inited_exactly_once.
+        self.hh = session('ercf_vvd', virtual_nfc=True)
+        self.hh.boot()
+        self.assertEqual(self.hh.errors, [], 'bootup was not clean')
+        self.mgr = {u.name: u for u in self.hh.mmu.mmu_machine.units}['unit1'].nfc_manager
+
+    def tearDown(self):
+        self.hh.close()
+
+    def test_reader_identity_is_shared_within_a_pair_not_across_pairs(self):
+        self.assertIs(self.mgr.gate_readers[0], self.mgr.gate_readers[1])
+        self.assertIs(self.mgr.gate_readers[2], self.mgr.gate_readers[3])
+        self.assertIsNot(self.mgr.gate_readers[0], self.mgr.gate_readers[2])
+
+    def test_shared_reader_is_hardware_inited_exactly_once(self):
+        """
+        Before the _init_all_readers dedupe fix, a reader shared by two gate slots was
+        passed through reader.init() once per slot - two redundant hardware
+        transactions at every boot for what is physically one chip.
+        """
+        self.assertEqual(self.hh.chip(9).inits, 1)
+        self.assertEqual(self.hh.chip(11).inits, 1)
+
+    def test_enabled_is_independent_per_gate_of_a_shared_pair(self):
+        self.mgr.set_enabled(False, gate=9)
+        try:
+            self.assertFalse(self.mgr.is_enabled(gate=9))
+            self.assertTrue(self.mgr.is_enabled(gate=10),
+                            'disabling gate 9 must not disable its paired gate 10')
+        finally:
+            self.mgr.set_enabled(True, gate=9)
+
+    def test_active_is_independent_per_gate_of_a_shared_pair(self):
+        self.mgr.set_active(False, gate=9)
+        try:
+            self.assertFalse(self.mgr.is_active(gate=9))
+            self.assertTrue(self.mgr.is_active(gate=10),
+                            'deactivating gate 9 must not deactivate its paired gate 10')
+        finally:
+            self.mgr.set_active(True, gate=9)
+
+    def test_status_shares_reader_state_but_keeps_enabled_active_independent(self):
+        """
+        Documents the intended shape, not a bug: paired gates 9/10 report the SAME
+        underlying reader's 'alive' (one chip) but independent 'active'.
+        """
+        self.mgr.set_active(False, gate=10)
+        try:
+            status = self.mgr.get_status()
+            self.assertEqual(sorted(status['gates']), [9, 10, 11, 12])
+            self.assertEqual(status['gates'][9]['alive'], status['gates'][10]['alive'])
+            self.assertTrue(status['gates'][9]['active'])
+            self.assertFalse(status['gates'][10]['active'])
+        finally:
+            self.mgr.set_active(True, gate=10)
+
+    def test_a_gate_reads_the_shared_reader_independently_of_its_pair_partner(self):
+        chip = self.hh.chip(9)
+        chip.present(self.TAG)
+        try:
+            self.mgr.set_active(False, gate=10)
+            self.assertIsNone(self.mgr.read_gate(10),
+                              'gate 10 must not auto-read while inactive, even though '
+                              'its paired reader has a tag presented')
+
+            uid = self.mgr.read_gate(9)
+            self.assertEqual(uid, self.TAG)
+            self.assertEqual(self.hh.mmu.gate_maps.gate_spool_rfid[9], self.TAG)
+            self.assertFalse(self.hh.mmu.gate_maps.gate_spool_rfid[10],
+                             "a read dispatched for gate 9 must not touch gate 10's map entry")
+        finally:
+            self.mgr.set_active(True, gate=10)
+            chip.clear()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- One physical NFC reader shared between two neighboring gates (e.g. the ViViD machine) was already supported at the config-parsing and object-reuse level, but the shared reader's hardware was re-initialized once per gate slot instead of once, and the pattern was undocumented where a user configuring `nfc_readers:` would look.
- The test harness's virtual chip (`test/hh/nfc_fixtures.py`) also couldn't represent a chip bound to two gates at once, which was silently masking runtime shared-pair behavior from ever being exercised by a test.

## Changes
- `extras/mmu/unit/mmu_nfc_manager.py`: dedupe reader init so a shared reader is hardware-initialized exactly once per boot, not once per referencing gate slot.
- `extras/mmu/mmu_unit.py` / `config/base/mmu_hardware.cfg`: document that repeating a reader name in `nfc_readers` intentionally shares one reader between neighboring gates.
- `test/hh/nfc_fixtures.py` / `test/hh/bootstrap.py`: fix `virtualise()` so a shared-pair reader's virtual chip can see both bound gates instead of only the last-processed one.
- `test/test_mmu_nfc.py`: new `TestSharedGatePairReader` runtime test class against the real ViViD profile - reader identity sharing, single-init regression guard, independent per-gate enable/active flags, status shape, and reads.

## Test plan
- [x] `make test` - 988 tests, same baseline as main (4 expected failures, 1 skipped)
- [x] Confirmed the new single-init assertion fails without the fix and passes with it
- [x] `test/test_mmu_profiles.py::TestMultiUnitMachine` (existing config-level regression guard for this feature) still passes unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)