### PR TITLE
Route cross-repo issues, fix issue-workflow bugs, add v4 test CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,14 @@ labels: ["bug", "needs-triage"]
 body:
   - type: markdown
     attributes:
-      value: "Thanks! Please complete all required fields."
+      value: |
+        Thanks! Please complete all required fields.
+
+        This repo covers the Happy Hare Klipper/Moonraker extension itself. If
+        your bug is actually about the **documentation site**, the
+        **KlipperScreen** interface, or the **Mainsail/Fluidd** UI, please use
+        the links on the [issue chooser page](https://github.com/moggieuk/Happy-Hare/issues/new/choose)
+        instead - it'll get triaged faster in the right repo.
 
   - type: input
     id: summary
@@ -42,6 +49,8 @@ body:
     id: mmu_type
     attributes:
       label: MMU Type
+      description: Select every unit type on the printer - some setups combine more than one (e.g. an ERCF unit and a ViViD unit on the same machine).
+      multiple: true
       options: ["3D Chameleon", "3MS", "AngryBeaver", "BoxTurtle", "EMU", "ERCF", "KMS", "MMX", "QuattroBox", "NightOwl", "Pico", "Prusa", "Tradrack", "ViViD", "Other/Unknown"]
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,18 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Ask a usage question (join Happy Hare Discord)
+  - name: 📄 Documentation issue
+    url: https://github.com/moggieuk/Happy-Hare-Doc/issues/new/choose
+    about: Typo, broken link, unclear instructions, or missing page on the docs site? Report it in the Happy-Hare-Doc repo instead.
+  - name: 🖥️ KlipperScreen UI issue
+    url: https://github.com/moggieuk/KlipperScreen-Happy-Hare-Edition/issues/new/choose
+    about: Bug or request specific to the KlipperScreen-Happy-Hare-Edition interface? File it in that repo instead.
+  - name: 🖱️ Mainsail UI issue
+    url: https://github.com/moggieuk/mainsail-happy-hare-edition/issues/new/choose
+    about: Bug or request specific to the Mainsail-Happy-Hare-Edition interface? File it in that repo instead.
+  - name: 🖱️ Fluidd UI issue
+    url: https://github.com/moggieuk/fluidd-happy-hare-edition/issues/new/choose
+    about: Bug or request specific to the Fluidd-Happy-Hare-Edition interface? File it in that repo instead.
+  - name: 💬 Ask a usage question (join Happy Hare Discord)
     url: https://discord.gg/98TYYUf6f2
     about: Q&A and troubleshooting belong in Discussions
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,6 +9,12 @@ body:
       value: |
         Thanks for contributing! Please complete all required fields.
 
+        This repo covers the Happy Hare Klipper/Moonraker extension itself. If
+        your idea is specific to the **documentation site**, the
+        **KlipperScreen** interface, or the **Mainsail/Fluidd** UI, please
+        consider using the links on the [issue chooser page](https://github.com/moggieuk/Happy-Hare/issues/new/choose)
+        instead so it lands with the people who work on that codebase.
+
   - type: input
     id: summary
     attributes:
@@ -67,7 +73,7 @@ body:
     attributes:
       label: Checklist
       options:
-        - label: Have you running the lastest Happy Hare release
+        - label: Have you tried the latest Happy Hare release
           required: true
         - label: I searched existing issues
           required: true

--- a/.github/workflows/needs-info.yml
+++ b/.github/workflows/needs-info.yml
@@ -19,7 +19,7 @@ jobs:
             const lc = body.toLowerCase();
 
             // Simple heuristics: length + must-have sections/words
-            const required = ["summary", "steps to reproduce", "expected", "actual", "mmu-type", "hh-version", "klipper-version"];
+            const required = ["summary", "steps to reproduce", "expected", "actual", "mmu type", "happy hare version", "klipper version"];
             const missing = required.filter(s => !lc.includes(s));
 
             const insufficient = body.length < 100 || missing.length > 0;
@@ -36,17 +36,17 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number,
                 body:
-`Thanks! We need a bit more detail${missing.length ? ` (missing: ${missing.join(", ")})` : ""}.
+            `Thanks! We need a bit more detail${missing.length ? ` (missing: ${missing.join(", ")})` : ""}.
 
-Please edit the top comment to include:
-- Concise summary
-- Exact steps to reproduce
-- Expected vs. Actual
-- MMU Type (important)
-- Happy-Hare version
-- Klipper version
+            Please edit the top comment to include:
+            - Concise summary
+            - Exact steps to reproduce
+            - Expected vs. Actual
+            - MMU Type (important)
+            - Happy-Hare version
+            - Klipper version
 
-Once updated, this label will be removed automatically.`
+            Once updated, this label will be removed automatically.`
               });
             } else if (!insufficient && hasLabel("needs-info")) {
               await github.rest.issues.removeLabel({

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,7 +25,7 @@ jobs:
         days-before-issue-stale: 30
         days-before-close: 14
         remove-stale-when-updated: true
-        any-of-labels: believe fixed / answered, more info needed, wontfix, incomplete
+        any-of-labels: believe fixed / answered, more info needed, wontfix / as designed, Incomplete, needs-info
         stale-issue-message: "This issue is stale because it has been open for over 30 days with no activity. It will be closed in 14 days automatically unless there is activity."
         close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
         stale-issue-label: 'stale'

--- a/.github/workflows/test-v4.yml
+++ b/.github/workflows/test-v4.yml
@@ -1,0 +1,27 @@
+# Runs the test/ suite (test/README.md) on every PR against v4 and after merge.
+# Uses NO_VENV=1 per test/README.md's own CI guidance - a GitHub Actions runner is
+# already the throwaway, dependencies-installed-directly environment that mode is for,
+# so there's no reason to pay for venv creation on every run.
+name: Test Suite (v4)
+
+on:
+  push:
+    branches: [v4]
+  pull_request:
+    branches: [v4]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: pip install --disable-pip-version-check -r test/requirements.txt
+
+      - name: Run test suite
+        run: make NO_VENV=1 ALL=1 test

--- a/.github/workflows/test-v4.yml
+++ b/.github/workflows/test-v4.yml
@@ -20,6 +20,12 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Syntax check all Python files
+        # Fast net for files outside the unittest import graph (installer/,
+        # components/, utils/, doc_tools/) that `make test` never touches
+        # because nothing under test imports them.
+        run: python -m compileall -q .
+
       - name: Install test dependencies
         run: pip install --disable-pip-version-check -r test/requirements.txt
 


### PR DESCRIPTION
## Summary
- **Cross-repo routing**: add contact links (Documentation, KlipperScreen, Mainsail, Fluidd editions) to the issue chooser, plus inline notes on both templates, so reports meant for those repos land in the right tracker instead of here.
- **Fix `needs-info.yml`**: the required-field heuristic checked for hyphenated slugs (`mmu-type`, `hh-version`, `klipper-version`) that never appear in the rendered issue body - those three fields always registered as "missing" regardless of content.
- **Fix a pre-existing YAML bug in `needs-info.yml`**: the auto-comment's multi-line JS template literal was under-indented relative to its YAML block scalar, making the whole workflow file invalid YAML (confirmed broken on current `v4`, unrelated to the fix above).
- **Fix `stale.yml`**: two `any-of-labels` entries didn't match any real label in the repo (`wontfix` vs. the actual `wontfix / as designed`, `incomplete` vs. the actual `Incomplete`), so stale auto-closing silently never fired for issues carrying them. Also added `needs-info`, since `stale.yml` is the workflow actually on a schedule (`needs-info-stale.yml` is still dispatch-only).
- **`bug_report.yml`**: MMU Type dropdown is now multi-select, since combined multi-unit setups (e.g. ERCF + ViViD on one printer) are supported hardware configurations.
- Small typo fix in `feature_request.yml`'s checklist.
- **New: `test-v4.yml`** - runs `make NO_VENV=1 ALL=1 test` (the `NO_VENV` mode is `test/README.md`'s own documented recommendation for CI) on every PR against `v4` and every push to `v4`. There is currently no automated test run anywhere in this repo.

## Test plan
- [x] Validated every touched/added YAML file parses correctly
- [x] Confirmed the `needs-info.yml` indentation fix doesn't leak stray whitespace into the actual posted comment text
- [ ] This PR itself is a live test of `test-v4.yml`, since it targets `v4` from a same-repo branch - check the Actions tab on this PR for a green run
- [ ] Open a test issue via the chooser page to confirm the new contact links render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)