### PR TITLE
Add v3->v4 upgrade detection to install.sh and mmu_machine.py

### DIFF
--- a/extras/mmu/mmu_constants.py
+++ b/extras/mmu/mmu_constants.py
@@ -313,7 +313,7 @@ DRYING_STATE_CANCELLED = 'canceled'
 
 EMPTY_GATE_STATS_ENTRY = {'pauses': 0, 'loads': 0, 'load_distance': 0.0, 'load_delta': 0.0, 'unloads': 0, 'unload_distance': 0.0, 'unload_delta': 0.0, 'load_failures': 0, 'unload_failures': 0, 'quality': -1.}
 
-UPGRADE_REMINDER = "Sorry but Happy Hare requires you to re-run this to complete the update:\ncd ~/Happy-Hare\n./install.sh\nMore details: https://github.com/moggieuk/Happy-Hare/wiki/Upgrade-Notice"
+UPGRADE_REMINDER = "Sorry but Happy Hare requires you to re-run this to complete the update:\ncd ~/Happy-Hare\n./install.sh [-i]"
 
 # TMC chips to search for
 TMC_CHIPS = ["tmc2209", "tmc2130", "tmc2208", "tmc2660", "tmc5160", "tmc2240"]

--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -16,14 +16,34 @@
 
 import logging
 
-# Happy Hare imports
-from .mmu                        import mmu_unit
-from .mmu.mmu_unit               import MmuUnit
-from .mmu.mmu_constants          import *
-from .mmu.mmu_utils              import SaveVariableManager
-from .mmu.mmu_sensor_utils       import MmuSensorFactory
-from .mmu.mmu_machine_parameters import MmuMachineParameters
-from .mmu.mmu_controller         import MmuController
+# Happy Hare imports. Guarded because a Happy Hare update pulled in without re-running
+# install.sh (e.g. via Moonraker's update_manager) leaves these new/renamed modules
+# unlinked in klippy/extras, so the import itself is the first thing to fail. Report
+# that failure as a clean config.error from load_config() instead of letting Klipper
+# surface a raw ImportError.
+_IMPORT_ERROR = None
+try:
+    from .mmu                        import mmu_unit
+    from .mmu.mmu_unit               import MmuUnit
+    from .mmu.mmu_constants          import *
+    from .mmu.mmu_utils              import SaveVariableManager
+    from .mmu.mmu_sensor_utils       import MmuSensorFactory
+    from .mmu.mmu_machine_parameters import MmuMachineParameters
+    from .mmu.mmu_controller         import MmuController
+except Exception as e:
+    _IMPORT_ERROR = e
+
+# VERSION/UPGRADE_REMINDER come from the guarded import above, so the failure message
+# can't reference them - keep this literal and self-contained.
+_NOT_INSTALLED_MSG = (
+    "Happy Hare's Klipper modules failed to load (%s).\n"
+    "This usually means Happy Hare was updated (e.g. via Moonraker's update manager)\n"
+    "without re-running the installer. Please run:\n"
+    "  cd ~/Happy-Hare && ./install.sh\n"
+#PAUL    "To stay on the previous release instead, run:\n"
+#PAUL    "  cd ~/Happy-Hare && ./install.sh -b v3\n"
+#PAUL    "More details: https://moggieuk.github.io/Happy-Hare-Doc/Upgrade-v3-v4.md"
+)
 
 
 class MmuMachine:
@@ -44,7 +64,7 @@ class MmuMachine:
         if self.happy_hare_version is None:
             raise self.config.error("Looks like Happy Hare is not installed correctly - cannot find `happy_hare_version` in klipper config")
         elif major_minor(self.happy_hare_version) < major_minor(VERSION):
-            raise self.config.error("Looks like you upgraded (v%s -> v%s)?\n%s" % (self.p.happy_hare_version, VERSION, UPGRADE_REMINDER))
+            raise self.config.error("Looks like you upgraded (v%s -> v%s)?\n%s" % (self.happy_hare_version, VERSION, UPGRADE_REMINDER))
 
         self.unit_names = list(config.getlist('units'))
         self.num_units = len(self.unit_names)
@@ -128,4 +148,6 @@ class MmuMachine:
 
 
 def load_config(config):
+    if _IMPORT_ERROR is not None:
+        raise config.error(_NOT_INSTALLED_MSG % str(_IMPORT_ERROR))
     return MmuMachine(config)

--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -4,6 +4,7 @@
 #                          moggieuk@hotmail.com
 #
 # Goal: Definition of logical MMU
+#   - checks for upgrade need
 #   - allows for specification and aggregation of multiple mmu_units
 #
 #
@@ -33,17 +34,40 @@ try:
 except Exception as e:
     _IMPORT_ERROR = e
 
-# VERSION/UPGRADE_REMINDER come from the guarded import above, so the failure message
-# can't reference them - keep this literal and self-contained.
+# VERSION/UPGRADE_REMINDER come from the guarded import above, so the failure messages
+# below can't reference them - keep these literal and self-contained.
 _NOT_INSTALLED_MSG = (
     "Happy Hare's Klipper modules failed to load (%s).\n"
     "This usually means Happy Hare was updated (e.g. via Moonraker's update manager)\n"
     "without re-running the installer. Please run:\n"
     "  cd ~/Happy-Hare && ./install.sh\n"
-#PAUL    "To stay on the previous release instead, run:\n"
-#PAUL    "  cd ~/Happy-Hare && ./install.sh -b v3\n"
-#PAUL    "More details: https://moggieuk.github.io/Happy-Hare-Doc/Upgrade-v3-v4.md"
+    "To stay on the previous release instead, run:\n"
+    "  cd ~/Happy-Hare && ./install.sh -b v3\n"
+    "More details: https://moggieuk.github.io/Happy-Hare-Doc/Upgrade-v3-v4.md"
 )
+
+# Same failure, different cause: an already-v4 install whose klippy/extras symlinks
+# were wiped out from under it (a "hard" Klipper update is the usual culprit - see
+# install.sh's own -f flag). No config migration needed here, just re-linking.
+_BROKEN_SYMLINKS_MSG = (
+    "Happy Hare's Klipper modules failed to load (%s).\n"
+    "This usually means a Klipper update wiped the extras/ symlinks Happy Hare needs.\n"
+    "Please run:\n"
+    "  cd ~/Happy-Hare && ./install.sh -f\n"
+    "to restore them. If that doesn't help, run ./install.sh to reinstall properly."
+)
+
+
+def _looks_like_v3(config):
+    """
+    True if the parsed config still carries a [mmu] section - v3's home for
+    happy_hare_version. A v4 config never has one (replaced by [mmu_machine] /
+    [mmu_parameters]), so its presence means this printer.cfg (and the mmu/*.cfg it
+    includes) predates the v4 rework, whatever the reason our own imports just failed.
+    has_section() reads off the whole parsed config regardless of this wrapper's own
+    section, exactly like the has_section('mmu_parameters') check further down.
+    """
+    return config.has_section('mmu')
 
 
 class MmuMachine:
@@ -149,5 +173,9 @@ class MmuMachine:
 
 def load_config(config):
     if _IMPORT_ERROR is not None:
-        raise config.error(_NOT_INSTALLED_MSG % str(_IMPORT_ERROR))
+        # v3 takes precedence: an old config always means "you upgraded without
+        # reinstalling", even if the extras/ symlinks also happen to be stale.
+        if _looks_like_v3(config):
+            raise config.error(_NOT_INSTALLED_MSG % str(_IMPORT_ERROR))
+        raise config.error(_BROKEN_SYMLINKS_MSG % str(_IMPORT_ERROR))
     return MmuMachine(config)

--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -41,7 +41,7 @@ _NOT_INSTALLED_MSG = (
     "This looks like it is because of a update to Happy Hare v4 while you are still configured for v3\n"
     "To see options please run:\n"
     "  cd ~/Happy-Hare && ./install.sh\n"
-    "If you know you want to stat on v3, run:\n"
+    "If you know you want to stay on v3, run:\n"
     "  cd ~/Happy-Hare && ./install.sh -b v3\n"
     "More details: https://moggieuk.github.io/Happy-Hare-Doc/Upgrade-v3-v4.md"
 )

--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -38,10 +38,10 @@ except Exception as e:
 # below can't reference them - keep these literal and self-contained.
 _NOT_INSTALLED_MSG = (
     "Happy Hare's Klipper modules failed to load (%s).\n"
-    "This usually means Happy Hare was updated (e.g. via Moonraker's update manager)\n"
-    "without re-running the installer. Please run:\n"
+    "This looks like it is because of a update to Happy Hare v4 while you are still running v3\n"
+    "To see options please run:\n"
     "  cd ~/Happy-Hare && ./install.sh\n"
-    "To stay on the previous release instead, run:\n"
+    "If you know you want to stat on v3, run:\n"
     "  cd ~/Happy-Hare && ./install.sh -b v3\n"
     "More details: https://moggieuk.github.io/Happy-Hare-Doc/Upgrade-v3-v4.md"
 )

--- a/extras/mmu_machine.py
+++ b/extras/mmu_machine.py
@@ -38,7 +38,7 @@ except Exception as e:
 # below can't reference them - keep these literal and self-contained.
 _NOT_INSTALLED_MSG = (
     "Happy Hare's Klipper modules failed to load (%s).\n"
-    "This looks like it is because of a update to Happy Hare v4 while you are still running v3\n"
+    "This looks like it is because of a update to Happy Hare v4 while you are still configured for v3\n"
     "To see options please run:\n"
     "  cd ~/Happy-Hare && ./install.sh\n"
     "If you know you want to stat on v3, run:\n"

--- a/install.sh
+++ b/install.sh
@@ -195,20 +195,24 @@ offer_v3_v4_choice() {
     echo
     echo "${C_WARNING}Happy Hare v4 is a major rework with breaking changes, and your existing${C_OFF}"
     echo "${C_WARNING}install looks like the previous (v3) release.${C_OFF}"
+    echo "${C_WARNING}Much like The Matrix you have a choice..${C_OFF}"
     echo
     echo "${C_WARNING}1) Stay on v3${C_OFF}"
-    echo "   Switches this checkout to the 'v3' branch and points Moonraker's update"
+    echo "   Take the Blue 'ignorance' pill."
+    echo "   This switches this checkout to the 'v3' branch and points Moonraker's update"
     echo "   manager at it, so future updates keep tracking v3 instead of v4."
+    echo "   You are free to upgrade at a later date."
     echo
     echo "${C_WARNING}2) Upgrade to v4${C_OFF}"
+    echo "   Take the Red 'awakening' pill."
     echo "   Backs up your current .cfg files, then walks you through a FRESH v4 setup."
     echo "   Your v3 settings are NOT carried over automatically - you'll reconfigure via"
     echo "   menuconfig, using the backed-up files as a reference."
     echo
-    echo "More details: https://github.com/moggieuk/Happy-Hare-Doc/blob/main/doc/Upgrade-v3-v4.md"
+    echo "More details: https://moggieuk.github.io/Happy-Hare-Doc/Upgrade-v3-v4.md"
     echo
 
-    sel=$(prompt_n 2 "Choose an option")
+    sel=$(prompt_n 2 "Choose your pill (option)")
     echo
 
     if [ "${sel}" = "1" ]; then

--- a/install.sh
+++ b/install.sh
@@ -154,6 +154,84 @@ time_elapsed() {
     echo
 }
 
+# Best-effort guess at the printer config directory, used only to detect a v3 install
+# before self-update/uninstall/menuconfig have touched anything. Kconfig resolves this
+# authoritatively later in the script; this just needs to be good enough for the
+# one-time upgrade prompt below.
+guess_klipper_config_home() {
+    if [ -n "${TESTDIR}" ]; then
+        echo "${TESTDIR}/printer_data/config"
+    elif [ -n "${CONFIG_KLIPPER_CONFIG_HOME}" ]; then
+        echo "${CONFIG_KLIPPER_CONFIG_HOME}"
+    elif [ -d "/usr/data/printer_data/config" ]; then
+        echo "/usr/data/printer_data/config"
+    else
+        echo "${HOME}/printer_data/config"
+    fi
+}
+
+# Detect a v3 install: no v4 Kconfig file yet, but a v3-era mmu_parameters.cfg already
+# on disk with a "happy_hare_version: 3.x" stamp (the value Happy Hare itself writes
+# and trusts for exactly this purpose).
+v3_detected() {
+    guessed_kconfig="${KCONFIG_CONFIG:-${SCRIPT_DIR}/.mmu_config}"
+    v3_cfg="$(guess_klipper_config_home)/mmu/base/mmu_parameters.cfg"
+    [ ! -e "${guessed_kconfig}" ] \
+        && [ -f "${v3_cfg}" ] \
+        && grep -qE '^happy_hare_version:[[:space:]]*3\.' "${v3_cfg}"
+}
+
+# The v3 -> v4 choice ("blue pill" stay on v3 / "red pill" upgrade to v4) has to be
+# settled before anything else in this script touches git, the filesystem, or Klipper/
+# Moonraker config - including self-update's own git pull, -f's symlink fix, and
+# uninstall. Runs for any invocation (default, -i, -u, -f, ...); the only exemptions
+# are -h/usage (already exited by then) and the internal re-exec after self-update or
+# after switching branches below (F_SKIP_UPDATE=force), so this never re-prompts itself
+# in a loop.
+offer_v3_v4_choice() {
+    klipper_config_home=$(guess_klipper_config_home)
+    moonraker_conf="${klipper_config_home}/moonraker.conf"
+
+    echo
+    echo "${C_WARNING}Happy Hare v4 is a major rework with breaking changes, and your existing${C_OFF}"
+    echo "${C_WARNING}install looks like the previous (v3) release.${C_OFF}"
+    echo
+    echo "${C_WARNING}1) Stay on v3${C_OFF}"
+    echo "   Switches this checkout to the 'v3' branch and points Moonraker's update"
+    echo "   manager at it, so future updates keep tracking v3 instead of v4."
+    echo
+    echo "${C_WARNING}2) Upgrade to v4${C_OFF}"
+    echo "   Backs up your current .cfg files, then walks you through a FRESH v4 setup."
+    echo "   Your v3 settings are NOT carried over automatically - you'll reconfigure via"
+    echo "   menuconfig, using the backed-up files as a reference."
+    echo
+    echo "More details: https://github.com/moggieuk/Happy-Hare-Doc/blob/main/doc/Upgrade-v3-v4.md"
+    echo
+
+    sel=$(prompt_n 2 "Choose an option")
+    echo
+
+    if [ "${sel}" = "1" ]; then
+        if [ -f "${moonraker_conf}" ] && grep -q '^\[update_manager happy-hare\]' "${moonraker_conf}"; then
+            echo "${C_INFO}Pointing Moonraker's update manager at the 'v3' branch...${C_OFF}"
+            awk '
+                /^\[update_manager happy-hare\]/ { in_section=1; print; next }
+                /^\[/ { in_section=0 }
+                in_section && /^primary_branch:/ { print "primary_branch: v3"; next }
+                { print }
+            ' "${moonraker_conf}" >"${moonraker_conf}.tmp" && mv "${moonraker_conf}.tmp" "${moonraker_conf}"
+        fi
+        echo "${C_INFO}Switching to the 'v3' branch...${C_OFF}"
+        export BRANCH=v3
+        "$SCRIPT_DIR/installer/self_update.sh" || exit 1
+        F_SKIP_UPDATE=force exec "$0" "$@"
+    else
+        echo "${C_WARNING}Proceeding with the v4 upgrade. Your v3 settings will NOT be carried over${C_OFF}"
+        echo "${C_WARNING}automatically - your old .cfg files will be backed up for reference.${C_OFF}"
+        echo
+    fi
+}
+
 # Convert long options to short options
 for arg in "$@"; do
     shift
@@ -194,6 +272,11 @@ while getopts "ehfiudzsb:nk:c:m:a:toqv" arg; do
     *) usage ;;
     esac
 done
+
+# Settle v3 vs v4 before anything else runs (see offer_v3_v4_choice for why).
+if [ "${F_SKIP_UPDATE}" != "force" ] && v3_detected; then
+    offer_v3_v4_choice
+fi
 
 # Handle git self update or branch change
 if [ "${F_SKIP_UPDATE}" = "force" ]; then

--- a/test/test_mmu_bootup.py
+++ b/test/test_mmu_bootup.py
@@ -103,6 +103,34 @@ class TestConfigLoad(unittest.TestCase):
         self.assertEqual(self.hh.errors, [])
 
 
+class TestVersionMismatch(unittest.TestCase):
+    """
+    extras/mmu_machine.py:44-47 is meant to turn a stale `happy_hare_version` into a
+    friendly "Looks like you upgraded" config.error. A prior bug (self.p.happy_hare_version
+    - self.p was never defined) turned that exact branch into an AttributeError instead,
+    which Klipper would have shown as a generic "Internal error during connect" rather
+    than the intended message. No Session/config-rendering needed: the check runs before
+    anything else in MmuMachine.__init__ touches the config.
+    """
+
+    def test_stale_version_raises_config_error_not_attribute_error(self):
+        from test.hh import install
+        install()
+
+        import configparser
+        from configfile import ConfigWrapper, error as ConfigError
+        import extras.mmu_machine as mmu_machine
+
+        fileconfig = configparser.RawConfigParser()
+        fileconfig.add_section('mmu_machine')
+        fileconfig.set('mmu_machine', 'happy_hare_version', '3.99.0')
+        config = ConfigWrapper(None, fileconfig, {}, 'mmu_machine')
+
+        with self.assertRaises(ConfigError) as cm:
+            mmu_machine.load_config(config)
+        self.assertIn('3.99.0', str(cm.exception))
+
+
 class TestPinBindings(unittest.TestCase):
     """
     A2: every pin description is recorded with the type it was bound as. This is the

--- a/test/test_mmu_import.py
+++ b/test/test_mmu_import.py
@@ -18,7 +18,9 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 import glob
+import importlib
 import os
+import sys
 import unittest
 import warnings
 
@@ -178,6 +180,63 @@ class TestHappyHareImports(unittest.TestCase):
         import chelper
         with self.assertRaises(AssertionError):
             chelper.get_ffi()
+
+
+class TestMmuMachineImportGuard(unittest.TestCase):
+    """
+    A Happy Hare update pulled in without re-running install.sh (e.g. via Moonraker's
+    update_manager) leaves new-in-this-release modules unlinked in klippy/extras, so
+    extras/mmu_machine.py's own top-level imports are the first thing to fail - before
+    load_config ever runs. Reproduce that by removing one such symlink from the fake
+    overlay and confirm the failure is caught and reported as a clean config.error
+    (pointing at ./install.sh) rather than a raw ImportError/AttributeError.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.klippy = install()
+        cls.victim = os.path.join(cls.klippy, 'extras', 'mmu', 'mmu_unit.py')
+        assert os.path.islink(cls.victim), (
+            'expected %s to be a symlink in the fake overlay' % cls.victim)
+        cls.victim_target = os.readlink(cls.victim)
+
+    def _evict_from_module_cache(self):
+        sys.modules.pop('extras.mmu_machine', None)
+        sys.modules.pop('extras.mmu.mmu_unit', None)
+
+    def _restore_symlink_and_reimport(self):
+        if not os.path.exists(self.victim):
+            os.symlink(self.victim_target, self.victim)
+        self._evict_from_module_cache()
+        # Leave the shared, process-wide overlay/module cache healthy for every test
+        # that runs after this one, regardless of suite ordering.
+        mod = importlib.import_module('extras.mmu_machine')
+        assert mod._IMPORT_ERROR is None, (
+            'failed to restore a working extras.mmu_machine after the test: %r'
+            % (mod._IMPORT_ERROR,))
+
+    def test_missing_module_yields_clean_config_error(self):
+        self.addCleanup(self._restore_symlink_and_reimport)
+
+        os.unlink(self.victim)
+        self._evict_from_module_cache()
+        mod = importlib.import_module('extras.mmu_machine')
+
+        self.assertIsNotNone(mod._IMPORT_ERROR,
+                              'extras.mmu_machine should have caught the import failure')
+
+        import configparser
+        from configfile import ConfigWrapper, error as ConfigError
+
+        fileconfig = configparser.RawConfigParser()
+        fileconfig.add_section('mmu_machine')
+        config = ConfigWrapper(None, fileconfig, {}, 'mmu_machine')
+
+        with self.assertRaises(ConfigError) as cm:
+            mod.load_config(config)
+        msg = str(cm.exception)
+        self.assertIn('./install.sh', msg)
+        self.assertIn('-b v3', msg)
 
 
 if __name__ == '__main__':

--- a/test/test_mmu_import.py
+++ b/test/test_mmu_import.py
@@ -189,7 +189,9 @@ class TestMmuMachineImportGuard(unittest.TestCase):
     extras/mmu_machine.py's own top-level imports are the first thing to fail - before
     load_config ever runs. Reproduce that by removing one such symlink from the fake
     overlay and confirm the failure is caught and reported as a clean config.error
-    (pointing at ./install.sh) rather than a raw ImportError/AttributeError.
+    rather than a raw ImportError/AttributeError - with the message depending on
+    whether the config looks like a v3 remnant (an old [mmu] section) or an
+    already-v4 install with merely broken symlinks (no [mmu] section).
     """
 
     @classmethod
@@ -215,21 +217,48 @@ class TestMmuMachineImportGuard(unittest.TestCase):
             'failed to restore a working extras.mmu_machine after the test: %r'
             % (mod._IMPORT_ERROR,))
 
-    def test_missing_module_yields_clean_config_error(self):
+    def _mmu_machine_with_broken_import(self):
+        """Break one v4-only symlink and return a freshly (re-)imported module,
+        restoring it and the shared module cache once the test is done."""
         self.addCleanup(self._restore_symlink_and_reimport)
-
         os.unlink(self.victim)
         self._evict_from_module_cache()
         mod = importlib.import_module('extras.mmu_machine')
-
         self.assertIsNotNone(mod._IMPORT_ERROR,
                               'extras.mmu_machine should have caught the import failure')
+        return mod
+
+    def test_missing_module_without_v3_config_reports_broken_symlinks(self):
+        """No [mmu] section: this is an already-v4 install, just missing symlinks."""
+        mod = self._mmu_machine_with_broken_import()
 
         import configparser
         from configfile import ConfigWrapper, error as ConfigError
 
         fileconfig = configparser.RawConfigParser()
         fileconfig.add_section('mmu_machine')
+        config = ConfigWrapper(None, fileconfig, {}, 'mmu_machine')
+
+        with self.assertRaises(ConfigError) as cm:
+            mod.load_config(config)
+        msg = str(cm.exception)
+        self.assertIn('./install.sh -f', msg)
+        self.assertNotIn('-b v3', msg)
+
+    def test_missing_module_with_v3_config_reports_v3_upgrade(self):
+        """
+        A [mmu] section means a v3 remnant config, and that must win even though the
+        import failure looks identical to the broken-symlinks case above.
+        """
+        mod = self._mmu_machine_with_broken_import()
+
+        import configparser
+        from configfile import ConfigWrapper, error as ConfigError
+
+        fileconfig = configparser.RawConfigParser()
+        fileconfig.add_section('mmu_machine')
+        fileconfig.add_section('mmu')
+        fileconfig.set('mmu', 'happy_hare_version', '3.42')
         config = ConfigWrapper(None, fileconfig, {}, 'mmu_machine')
 
         with self.assertRaises(ConfigError) as cm:


### PR DESCRIPTION
## Summary

Moonraker's `update_manager` for Happy Hare is a plain `type: git_repo` with no
`install_script` hook, so "Update" in Mainsail/Fluidd just `git pull`s and restarts
Klipper. Once v4 lands on `main`, that silently pulls v4 code onto v3 installs with
`install.sh` never re-run, leaving dangling `extras/` symlinks and a v3-format config.
This PR makes that failure loud and actionable instead of a confusing crash, and gives
`install.sh` a real choice for handling it.

- `extras/mmu_machine.py`'s own import cascade is now guarded: a failed import (missing
  v4-only modules) is caught and reported as a clean `config.error` instead of a raw
  `ImportError`, and further distinguishes *why* the import failed:
  - a `[mmu]` section still present (v3's home for `happy_hare_version`, never present
    in v4) → points at `./install.sh` (with `-b v3` to stay on v3)
  - no `[mmu]` section (already v4, just broken symlinks, e.g. after a hard Klipper
    update) → points at `./install.sh -f` instead
  - the v3 signal takes precedence if both somehow look true at once
- Also fixes a real pre-existing bug in the version-mismatch path
  (`self.p.happy_hare_version` - `self.p` was never defined - which turned the intended
  friendly message into an `AttributeError`)
- `install.sh` now detects a v3 install up front, before self-update/uninstall/menuconfig
  touch anything, and offers a choice: stay on v3 (switches branches and repoints
  Moonraker's `primary_branch` so it stops re-pulling v4) or upgrade to v4 (existing
  backup + fresh-menuconfig flow, with explicit messaging that settings are not migrated
  automatically)

Note: this depends on a `v3` branch existing (to be branched off `main` HEAD at the
actual v4 merge) - not yet created, since v4 hasn't merged to `main` yet.

## Test plan

- [x] `make ALL=1 test` - full suite green (`skipped=1, expected failures=4`, matching
      the documented baseline)
- [x] New regression tests for the `self.p` bug (red before fix, green after) and for
      the import-guard's two message branches + v3 precedence
- [x] `sh -n install.sh` syntax check
- [ ] Manual end-to-end test of `install.sh`'s v3-detection/blue-red-pill flow on a real
      v3 install (shell-level, git/branch-state dependent - not covered by the fake
      Klipper harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)