### PR TITLE
Fix installer settings loss on upgrade (as-is gcode parser swallowed comment quotes)

### DIFF
--- a/installer/Kconfig
+++ b/installer/Kconfig
@@ -98,7 +98,7 @@
 
 
 # IMPORTANT keep version string up-to-date and constistent with git tag
-happy_hare_version := $HH_VERSION
+happy_hare_version := $(HH_VERSION)
 
 hh_message  := $(shell, echo "Happy Hare v$(happy_hare_version)")
 unit_suffix := $(shell, [ -n "$$UNIT_NAME" ] && echo "Unit: [[B]]$(UNIT_NAME)[[/B]]" || echo "")

--- a/installer/build.py
+++ b/installer/build.py
@@ -95,12 +95,12 @@ hidden_params = [
 VAR_SECTION_MAP = {
     "var_software_":     "gcode_macro _MMU_SOFTWARE_VARS",
     "var_state_":        "gcode_macro _MMU_STATE_VARS",
-    "var_sequence_":     "gcode_macro _MMU_STATE_VARS",
+    "var_sequence_":     "gcode_macro _MMU_SEQUENCE_VARS",
     "var_client_":       "gcode_macro _MMU_CLIENT_VARS",
     "var_cut_tip_":      "gcode_macro _MMU_CUT_TIP_VARS",
     "var_form_tip_":     "gcode_macro _MMU_CUT_TIP_VARS",
     "var_servo_cutter_": "gcode_macro _MMU_SERVO_CUTTER_VARS",
-    "var_blobifer_":     "gcode_macro _BLOBIFIER_VARS",
+    "var_blobifier_":    "gcode_macro _BLOBIFIER_VARS",
     "var_purge_":        "gcode_macro _MMU_PURGE_VARS",
     "var_fan_":          "gcode_macro _MMU_FAN_VARS",
 }

--- a/installer/parser.py
+++ b/installer/parser.py
@@ -807,7 +807,15 @@ class Parser(object):
             # else and get swallowed into the gcode value
             elif as_is and peek.type == "section":
                 break
- 
+
+            # A comment's text is prose, not code: quotes/brackets inside it (e.g. a
+            # contraction like "don't") must never affect the brace/bracket/paren/quote
+            # balance used above to detect the end of the gcode value, or the value
+            # swallows everything up to the next [section] - silently absorbing any
+            # variable_* options that follow the gcode: line in the same section.
+            elif as_is and peek.type == "comment":
+                current_entry += next(tokenizer).value
+
             elif not as_is and peek.type == "placeholder":
                 if len(current_entry) > 0:
                     current_line.append(ValueEntryNode(current_entry))


### PR DESCRIPTION
## Summary

Users reported that selecting option 1 (upgrade/refresh, the default) in the installer resets customized settings in `mmu_macro_vars.cfg`. Root cause and two related bugs found while auditing all three upgrade modes:

- **Parser bug (the actual cause).** `installer/parser.py`'s as-is `gcode:` value parser tracks brace/bracket/paren/quote nesting to know where a macro body ends — but it scanned raw *comment* text too, not just real gcode. `_MMU_SEQUENCE_VARS`'s `gcode: # Leave empty` is followed by a doc comment containing "...you **don't** want to park on..." — that lone apostrophe flips the parser into "inside a quoted string" and it never recovers, silently swallowing all 27 `variable_*` options in that section into the `gcode` value. They vanish entirely from the parsed config (`has_option()` is `False` for every one), so on upgrade there's nothing to restore from and the fresh template default always wins — regardless of upgrade mode. Fixed by excluding comment-token text from the nesting scan.
- **Merge mode (option 3) bug.** `VAR_SECTION_MAP` in `installer/build.py` mapped `var_sequence_` to the wrong section (`_MMU_STATE_VARS` instead of `_MMU_SEQUENCE_VARS`) and misspelled `var_blobifer_`/`blobifier_`, so sequence vars and *all* Blobifier vars never merged with menuconfig values under option 3 — they behaved like "retain" instead.
- **Unrelated crash, found in passing.** `installer/Kconfig`'s `happy_hare_version := $HH_VERSION` used bare `$VAR`, which kconfiglib never expands (only `$(VAR)` is). This stamped the literal string `"$HH_VERSION"` into every fresh install's `mmu.cfg`, crashing the *next* install/upgrade's version check (`ValueError` in `major_minor()`).

## Test plan

- [x] `make test` (`ALL=1`) — 995 tests, `OK (skipped=1, expected failures=4)`, matching the known-clean baseline
- [x] Reproduced end-to-end against a scratch `/tmp` install via `install.sh -t`: installed, hand-edited `mmu_macro_vars.cfg` (`variable_check_gates`, `variable_park_travel_speed`), re-ran each of the three upgrade modes, confirmed:
  - Option 1 (refresh): both customizations now survive (previously `park_travel_speed` was reset)
  - Option 2 (replace): both correctly reset to Kconfig defaults (unchanged, as documented)
  - Option 3 (merge): both now correctly take the Kconfig-derived value (previously `park_travel_speed` incorrectly retained the stale customization)
- [x] Confirmed against the real shipped `config/base/mmu_macro_vars.cfg` that `_MMU_SEQUENCE_VARS` now parses all 27 `variable_*` options (was 0 before the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)