### PR TITLE
Spoolman: add printer context to spool list requests

### DIFF
--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -461,7 +461,9 @@ class MmuServer:
             errors = ""
             assignments = {}
             sids_to_fix = []
-            response = await self.http_client.get(url=f'{self.spoolman.spoolman_url}/v1/spool')
+            response = await self.http_client.get(
+                url=f'{self.spoolman.spoolman_url}/v1/spool',
+                headers={'X-Printer-Name': self.printer_hostname})
             if response.has_error():
                 raise RuntimeError(self.spoolman._get_response_error(response))
             for spool_info in response.json():

--- a/test/hh/moonraker.py
+++ b/test/hh/moonraker.py
@@ -76,9 +76,11 @@ class FakeHttpClient:
         self.spoolman = spoolman
         self.spoolmandb = spoolmandb
         self.requests = []          # [(method, url)] assertion surface
+        self.request_headers = []   # [(method, url, headers)] assertion surface
 
     async def request(self, method, url, body=None, **kwargs):
         self.requests.append((method, url))
+        self.request_headers.append((method, url, dict(kwargs.get('headers') or {})))
         if 'donkie.github.io' in url:
             return self._spoolmandb(url)
         return self.spoolman.handle(method.upper(), url, body)

--- a/test/test_mmu_moonraker.py
+++ b/test/test_mmu_moonraker.py
@@ -85,6 +85,12 @@ class TestInitialisation(MoonrakerTestCase):
         self.assertEqual(self.hh.mmu_server.spoolman_version, (0, 18, 1))
         self.assertTrue(self.hh.mmu_server.spoolman_has_extras)
 
+    def test_spool_list_request_identifies_printer(self):
+        headers = [headers for method, url, headers in self.hh.http.request_headers
+                   if method == 'GET' and url.endswith('/v1/spool')]
+        self.assertTrue(headers)
+        self.assertEqual(headers[-1], {'X-Printer-Name': 'testprinter'})
+
     def test_extra_fields_created_when_absent(self):
         """
         A virgin Spoolman needs printer_name / mmu_gate / rfid adding


### PR DESCRIPTION
## Motivation

Happy Hare fetches `GET /v1/spool` while building its spool-location cache. The request currently does not identify the originating printer.

For Spoolman-compatible backends serving multiple Happy Hare installations, this creates a bootstrap problem: the backend has no request context for selecting the appropriate printer-specific spool assignments on the initial fetch.

## Change

Include the current Happy Hare printer hostname in the spool-list request using the optional header:

`X-Printer-Name: <printer_hostname>`

The change is limited to `GET /v1/spool` and does not modify request bodies or Spoolman response formats.

The header provides client context only. Authentication and authorization remain the responsibility of the configured service.

Standard Spoolman ignores the optional header, preserving existing compatibility.

## Testing

- Added a regression test verifying that the spool-list request contains the current printer hostname.
- `python -m unittest test.test_mmu_moonraker` — 55 tests passed.
- `make ALL=1 test` — 993 tests passed, 1 skipped, 4 expected failures.