### PR TITLE
Fix stale UI on gate map spool_id writes: renew_gate_map() before persist

### DIFF
--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -1787,9 +1787,12 @@ class MmuController(MmuFilamentMovement):
 
         if spool_id > 0 and self.p.spoolman_support != SPOOLMAN_PULL:
             self.log_info("Spool ID: %s automatically assigned to gate %d" % (spool_id, gate))
+            self.gate_maps.renew_gate_map() # Ensure webhooks sees get_status() change
             mod_gate_ids = self.gate_maps.assign_spool_id(gate, spool_id)
             if tag is not None:
-                self.gate_maps.set_gate_filament_from_tag(gate, rfid=tag[0])
+                self.gate_maps.set_gate_filament_from_tag(gate, rfid=tag[0]) # Also persists
+            else:
+                self.gate_maps.persist_gate_map(spoolman_sync=False) # Local-only; spoolman sync below
 
             # Request sync and update of filament attributes from Spoolman
             if self.p.spoolman_support == SPOOLMAN_PUSH:

--- a/extras/mmu/mmu_gate_maps.py
+++ b/extras/mmu/mmu_gate_maps.py
@@ -373,6 +373,7 @@ class MmuGateMaps:
         if rfid is not None:
             self.gate_spool_rfid[gate] = rfid
         self.update_gate_color_rgb()
+        self.renew_gate_map() # Ensure webhooks sees get_status() change
         self.persist_gate_map(spoolman_sync=False) # Local-only; nothing to push to Spoolman
 
 


### PR DESCRIPTION
## Summary
- `set_gate_filament_from_tag` mutated gate map lists in-place without calling `renew_gate_map()` first, so webhooks (Fluidd/Mainsail) never saw the change and the spool color/label didn't refresh in the UI.
- Found and fixed the same gap in `_check_pending_filament`'s manual `NEXT_SPOOLID` (no scanned tag) path, which goes through `assign_spool_id()`. In `spoolman_support: push` mode this path previously never persisted the assignment at all, since there's no round-trip back into `MMU_GATE_MAP` the way `readonly` mode gets.
- Audited every other call site of `assign_spool_id()` / `persist_gate_map()` in the gate-map code — all already renew before persisting.

## Test plan
- [x] `./venv/bin/python -m unittest test.test_mmu_nfc test.test_mmu_nfc_scan test.test_mmu_local_gate test.test_mmu_moonraker test.test_mmu_save_variables test.test_mmu_leds test.test_mmu_endless_spool` — 205 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)