### PR TITLE
Send X-Printer-Name header on all Spoolman requests

### DIFF
--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -75,7 +75,7 @@ if TYPE_CHECKING:
     from ..common import WebRequest
     from ..common import RequestType
     from ..confighelper import ConfigHelper
-    from .http_client import HttpClient, HttpResponse
+    from .http_client import HttpResponse
     from .database import MoonrakerDatabase
     from .announcements import Announcements
     from .klippy_apis import KlippyAPI as APIComp
@@ -86,6 +86,8 @@ MMU_NAME_FIELD   = 'printer_name'
 MMU_GATE_FIELD   = 'mmu_gate_map'
 MMU_RFID_FIELD   = 'rfid_tag'      # NFC/RFID tag UID registered against a spool
 MIN_SM_VER       = (0, 18, 1)
+
+PRINTER_NAME_HEADER = 'X-Printer-Name'  # sent with every request to the configured Spoolman server
 
 NFC_UID_MISS_TTL = 10.0            # Seconds to remember a UID that isn't in Spoolman (avoids re-querying on every scan)
 
@@ -115,6 +117,40 @@ DB_NAMESPACE     = "moonraker"
 ACTIVE_SPOOL_KEY = "spoolman.spool_id"
 
 
+class _SpoolmanHeaderHttpClient:
+    '''
+    Wraps Moonraker's shared HttpClient to add X-Printer-Name: <hostname> on
+    any request targeting the configured Spoolman server, leaving all other
+    traffic (notably the two donkie.github.io SpoolmanDB fetches, which share
+    this same http_client) untouched.
+    '''
+    def __init__(self, http_client, owner):
+        self._http_client = http_client
+        self._owner = owner
+
+    def _inject(self, url, headers):
+        spoolman = self._owner.spoolman
+        spoolman_url = getattr(spoolman, "spoolman_url", None) if spoolman else None
+        printer_name = getattr(self._owner, "printer_hostname", None)
+        if spoolman_url and printer_name and url.startswith(spoolman_url):
+            merged = dict(headers) if headers else {}
+            merged.setdefault(PRINTER_NAME_HEADER, printer_name)
+            return merged
+        return headers
+
+    async def get(self, url, headers=None, **kwargs):
+        return await self._http_client.get(url, headers=self._inject(url, headers), **kwargs)
+
+    async def post(self, url, body=None, headers=None, **kwargs):
+        return await self._http_client.post(url, body=body, headers=self._inject(url, headers), **kwargs)
+
+    async def request(self, method, url, body=None, headers=None, **kwargs):
+        return await self._http_client.request(method, url, body=body, headers=self._inject(url, headers), **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._http_client, name) # Passthrough for anything else (get_file, etc.)
+
+
 class MmuServer:
 
     def __init__(self, config: ConfigHelper):
@@ -126,7 +162,7 @@ class MmuServer:
             self.spoolman: SpoolManager = self.server.load_component(config, "spoolman", None)
         self.spoolman: SpoolManager = self.server.lookup_component("spoolman", None)
         self.klippy_apis: APIComp = self.server.lookup_component("klippy_apis")
-        self.http_client: HttpClient = self.server.lookup_component("http_client")
+        self.http_client = _SpoolmanHeaderHttpClient(self.server.lookup_component("http_client"), self)
         self.database: MoonrakerDatabase = self.server.lookup_component("database")
 
         # Full cache of spool_ids and location + key attributes (printer, gate, attr_dict))
@@ -359,7 +395,7 @@ class MmuServer:
         '''
         Retrieve an individual spool_info record
         '''
-        response = await self.spoolman.http_client.request(
+        response = await self.http_client.request(
             method="GET",
             url=f'{self.spoolman.spoolman_url}/v1/spool/{spool_id}',
             body=None)

--- a/test/hh/moonraker.py
+++ b/test/hh/moonraker.py
@@ -75,10 +75,10 @@ class FakeHttpClient:
     def __init__(self, spoolman, spoolmandb=True):
         self.spoolman = spoolman
         self.spoolmandb = spoolmandb
-        self.requests = []          # [(method, url)] assertion surface
+        self.requests = []          # [(method, url, headers)] assertion surface
 
-    async def request(self, method, url, body=None, **kwargs):
-        self.requests.append((method, url))
+    async def request(self, method, url, body=None, headers=None, **kwargs):
+        self.requests.append((method, url, dict(headers) if headers else {}))
         if 'donkie.github.io' in url:
             return self._spoolmandb(url)
         return self.spoolman.handle(method.upper(), url, body)
@@ -106,14 +106,16 @@ class FakeHttpClient:
         return spoolman_mod.Response(404)
 
     def requests_to(self, fragment):
-        return [(m, u) for m, u in self.requests if fragment in u]
+        return [(m, u, h) for m, u, h in self.requests if fragment in u]
 
 
 class FakeSpoolmanComponent:
     """
     Moonraker's own [spoolman] component. mmu_server reaches through it for
-    spoolman_url, its http_client (_fetch_spool_info uses
-    self.spoolman.http_client.request, :361) and _get_response_error.
+    spoolman_url and _get_response_error. Its own http_client reference
+    mirrors production (spoolman.py looks the component up independently) but
+    mmu_server no longer calls through it - every Spoolman request goes via
+    mmu_server's own (wrapped) self.http_client instead.
     """
 
     def __init__(self, http_client, url=SPOOLMAN_URL):

--- a/test/test_mmu_moonraker.py
+++ b/test/test_mmu_moonraker.py
@@ -85,6 +85,12 @@ class TestInitialisation(MoonrakerTestCase):
         self.assertEqual(self.hh.mmu_server.spoolman_version, (0, 18, 1))
         self.assertTrue(self.hh.mmu_server.spoolman_has_extras)
 
+    def test_spool_list_request_identifies_printer(self):
+        headers = [headers for method, url, headers in self.hh.http.requests
+                   if method == 'GET' and url.endswith('/v1/spool')]
+        self.assertTrue(headers)
+        self.assertEqual(headers[-1], {'X-Printer-Name': 'testprinter'})
+
     def test_extra_fields_created_when_absent(self):
         """
         A virgin Spoolman needs printer_name / mmu_gate / rfid adding

--- a/test/test_mmu_moonraker.py
+++ b/test/test_mmu_moonraker.py
@@ -243,7 +243,7 @@ class TestMissCache(MoonrakerTestCase):
     SPOOLS = (dict(uid=KNOWN_UID, material='PLA'),)
 
     def _spool_list_fetches(self):
-        return len([1 for m, u in self.hh.http.requests
+        return len([1 for m, u, h in self.hh.http.requests
                     if m == 'GET' and u.endswith('/v1/spool')])
 
     def test_cached_miss_still_sends_terminal_result(self):
@@ -280,6 +280,39 @@ class TestMissCache(MoonrakerTestCase):
                             gate=None, silent=True, report_only=True)
         self.assertGreater(self._spool_list_fetches(), before,
                           'an explicit REGISTER request must get a live answer')
+
+
+class TestPrinterNameHeader(MoonrakerTestCase):
+    """
+    X-Printer-Name identifies this printer to a Spoolman-compatible service on
+    every request, not just the initial bootstrap fetch (mmu_server.py -
+    _SpoolmanHeaderHttpClient). It must NOT leak onto the two SpoolmanDB
+    (donkie.github.io) fetches, which share the same underlying http_client.
+    """
+
+    def test_header_present_on_spoolman_absent_on_spoolmandb(self):
+        # is_bambu=True with a PETG tag exercises both SpoolmanDB fixtures (no
+        # PETG entry in SPOOLMANDB_BAMBU, so density resolution falls through
+        # to materials.json too) plus vendor/filament/spool creation against
+        # the real (fake) Spoolman server.
+        self.hh.call_remote('spoolman_get_spool_by_uid', uid=UNKNOWN_UID, gate=None,
+                            metadata=dict(TAG_METADATA, is_bambu=True), save=True,
+                            silent=True)
+
+        header = self.hh.mmu_server_mod.PRINTER_NAME_HEADER
+        spoolman_url = self.hh.mmu_server.spoolman.spoolman_url
+        seen_spoolman = seen_spoolmandb = False
+        for method, url, headers in self.hh.http.requests:
+            if url.startswith(spoolman_url):
+                seen_spoolman = True
+                self.assertEqual(headers.get(header), self.hh.mmu_server.printer_hostname,
+                                 'missing/wrong %s on %s %s' % (header, method, url))
+            elif 'donkie.github.io' in url:
+                seen_spoolmandb = True
+                self.assertNotIn(header, headers,
+                                 '%s leaked onto SpoolmanDB call %s' % (header, url))
+        self.assertTrue(seen_spoolman and seen_spoolmandb,
+                        'scenario did not exercise both Spoolman and SpoolmanDB traffic')
 
 
 class TestAutoCreate(MoonrakerTestCase):


### PR DESCRIPTION
## Summary
- Adds an `X-Printer-Name: <hostname>` header to every request `mmu_server.py` makes to the configured Spoolman server, so a Spoolman-compatible service (hosted/multi-printer gateway, etc.) can attribute any request to its originating printer — not just the initial bootstrap sync (`GET /v1/spool`).
- Standard Spoolman ignores the unrecognized header, so this is purely additive.
- Implemented as a small wrapper around the shared `http_client`, gated on `spoolman_url`, so none of the 15 existing Spoolman call sites need to change, and the two unrelated SpoolmanDB (`donkie.github.io`) reference-data fetches are correctly excluded.
- Fixed one call site (`_fetch_spool_info`) that reached Spoolman through a separate `http_client` reference and would otherwise have silently bypassed the header.

## Credit

@WeLizard opened #1050 independently proposing the same header for the `GET /v1/spool` bootstrap request. This PR generalizes that to every Spoolman request, and incorporates their original commit (`41f8209`, preserved with their authorship) plus their regression test, adapted to this PR's unified request-log shape. Thank you for the contribution and for prompting the broader fix — closing #1050 in favor of this one.

## Test plan
- [x] `make test` — full suite passes: 997 tests, OK (4 expected failures, 1 skipped — the known clean baseline)
- [x] `TestPrinterNameHeader` asserts the header is present (with correct value) on every Spoolman request and absent on SpoolmanDB requests, in one scenario exercising both
- [x] `test_spool_list_request_identifies_printer` (from #1050) asserts the header specifically on the `GET /v1/spool` bootstrap request
- [x] Confirmed both fail against the pre-change code and pass after

🤖 Generated with [Claude Code](https://claude.com/claude-code)