### PR TITLE
Fix NFC gate map webhook refresh

### DIFF
--- a/extras/mmu/mmu_gate_maps.py
+++ b/extras/mmu/mmu_gate_maps.py
@@ -358,6 +358,7 @@ class MmuGateMaps:
         """
         if not (0 <= gate < self.num_gates):
             return
+        self.renew_gate_map() # Copy before mutation so webhooks retains the previous values
         if name is not None:
             self.gate_filament_name[gate] = name
         if material is not None:
@@ -373,7 +374,6 @@ class MmuGateMaps:
         if rfid is not None:
             self.gate_spool_rfid[gate] = rfid
         self.update_gate_color_rgb()
-        self.renew_gate_map() # Ensure webhooks sees get_status() change
         self.persist_gate_map(spoolman_sync=False) # Local-only; nothing to push to Spoolman
 
 


### PR DESCRIPTION
# Fix NFC tag gate map webhook refresh

## Problem

When NFC deep-read metadata was applied directly to a gate, the gate map was updated internally, but Fluidd/Mainsail did not refresh. Spoolman-based updates were unaffected.

## Root cause

`renew_gate_map()` was called after mutating the gate map lists. Because Klipper webhooks retained references to those lists, the previous status snapshot had already been modified and no change was detected.

## Fix

Call `renew_gate_map()` before modifying any gate metadata. This preserves the previous list objects so Klipper webhooks can correctly detect and publish the updated gate map.

## Testing

Tested on a printer with an NFC deep-read tag. Material, vendor, color, temperature, and RFID data now appear in Fluidd immediately after scanning.