### PR TITLE
Rename Kconfig.ebb to Kconfig.ebb_gen1

### DIFF
--- a/installer/boards/per_gate/Kconfig.ebb_gen1
+++ b/installer/boards/per_gate/Kconfig.ebb_gen1
@@ -1,7 +1,10 @@
-config BOARD_TYPE_EBB_1_0
+config BOARD_TYPE_EBB_GEN1
   bool "EBB36/42 gen1 MCU"
+  help
+    This covers the gen 1 EBB36 and EBB42 boards
+    (v1.1 and v 1.2)
 
-if BOARD_TYPE_EBB_1_0
+if BOARD_TYPE_EBB_GEN1
   config PARAM_BOARD_TYPE
     default "EBB36/42 gen1"
 
@@ -41,6 +44,9 @@ if BOARD_TYPE_EBB_1_0
 
     config PIN_NEOPIXEL
       default "$(MCU_NAME):PD3"
+
+    config PIN_FAN_$(gate)
+      default "$(MCU_NAME):PA0"
 
     config PIN_BUFFER_TENSION
       default "^$(MCU_NAME):PB8"


### PR DESCRIPTION
## Summary
- Renames `installer/boards/per_gate/Kconfig.ebb` to `Kconfig.ebb_gen1` to distinguish the current EBB36/42 boards (v1.1/v1.2) from upcoming gen 2 boards.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>