### PR TITLE
Fix Moonraker lane data synchronization for locally managed gates

### DIFF
--- a/components/mmu_server.py
+++ b/components/mmu_server.py
@@ -1763,9 +1763,9 @@ class MmuServer:
                 lane = gate
                 lane_key = f"lane{lane}"
 
-                # Check if gate is empty (status -1/unknown or 0/empty, or spool_id -1)
+                # A gate can have valid local filament metadata without a Spoolman spool
                 gate_status_val = gate_status[gate] if gate < len(gate_status) else -1
-                is_empty = gate_status_val in [-1, 0] or spool_id == -1
+                is_empty = gate_status_val in [-1, 0]
 
                 if is_empty:
                     # Empty gate format

--- a/extras/mmu/mmu_gate_maps.py
+++ b/extras/mmu/mmu_gate_maps.py
@@ -191,6 +191,7 @@ class MmuGateMaps:
 
         self.mmu.led_manager.gate_map_changed(None) # Force full LED update
         self.mmu.mmu_macro_event(MACRO_EVENT_GATE_MAP_CHANGED, "GATE=-1")
+        self.mmu._moonraker_push_lane_data()
 
 
 # -----------------------------------------------------------------------------------------------------------
@@ -292,6 +293,7 @@ class MmuGateMaps:
                 self.persist_gate_status()
                 self.mmu.led_manager.gate_map_changed(gate)
                 self.mmu.mmu_macro_event(MACRO_EVENT_GATE_MAP_CHANGED, "GATE=%d" % gate)
+                self.mmu._moonraker_push_lane_data([(gate, self.gate_spool_id[gate])])
 
 
     def reset_gate_map(self):

--- a/test/hh/moonraker.py
+++ b/test/hh/moonraker.py
@@ -215,6 +215,9 @@ class FakeDatabase:
             ns = ns.setdefault(part, {})
         ns[parts[-1]] = value
 
+    async def insert_batch(self, namespace, records):
+        self.store.setdefault(namespace, {}).update(records)
+
     async def delete_item(self, namespace, key, drop_empty_db=False):
         ns = self.store.setdefault(namespace, {})
         parts = key.split('.')

--- a/test/test_mmu_moonraker.py
+++ b/test/test_mmu_moonraker.py
@@ -486,6 +486,29 @@ class TestBackendGate(unittest.TestCase):
             hh.close()
 
 
+class TestLaneData(MoonrakerTestCase):
+
+    def test_available_gate_without_spool_id_keeps_local_metadata(self):
+        self.hh.klippy.extra_status = {
+            'gate_status': [1, 0, 0, 0],
+            'gate_filament_name': ['PLA Basic', '', '', ''],
+            'gate_material': ['PLA', '', '', ''],
+            'gate_vendor': ['Bambu Lab', '', '', ''],
+            'gate_color': ['00ae42', '', '', ''],
+            'gate_temperature': [210, 200, 200, 200],
+        }
+
+        self.hh.call_remote('moonraker_push_lane_data', gate_ids=[(0, -1)])
+
+        lane = self.hh.server.database.store['lane_data']['lane0']
+        self.assertEqual(lane['name'], 'PLA Basic')
+        self.assertEqual(lane['material'], 'PLA')
+        self.assertEqual(lane['vendor_name'], 'Bambu Lab')
+        self.assertEqual(lane['color'], '00ae42')
+        self.assertEqual(lane['nozzle_temp'], 210)
+        self.assertIsNone(lane['spool_id'])
+
+
 class TestGateAssignment(MoonrakerTestCase):
     SPOOLS = (dict(uid=KNOWN_UID, material='PLA'),
               dict(material='ABS', vendor='Polymaker'))

--- a/test/test_mmu_roundtrip.py
+++ b/test/test_mmu_roundtrip.py
@@ -358,6 +358,32 @@ class TestSpoolmanOff(RoundTripTestCase):
         self.assertEqual(self.rt.mmu.gate_material[1], '')
         self.assertEqual(self.rt.errors, [])
 
+    def test_gate_map_changes_refresh_moonraker_lane_data(self):
+        calls_before = len(self.rt.remote_calls('moonraker_push_lane_data'))
+        self.rt.run_gcode(
+            'MMU_GATE_MAP GATE=1 AVAILABLE=1 NAME="PLA Basic" '
+            'MATERIAL=PLA VENDOR="Bambu Lab" COLOR=00AE42 TEMP=210'
+        )
+
+        calls = self.rt.remote_calls('moonraker_push_lane_data')
+        self.assertEqual(len(calls), calls_before + 1)
+        self.assertEqual(
+            calls[-1]['gate_ids'],
+            list(enumerate(self.rt.mmu.gate_spool_id))
+        )
+
+    def test_gate_status_changes_refresh_moonraker_lane_data(self):
+        self.rt.run_gcode(
+            'MMU_GATE_MAP GATE=1 AVAILABLE=1 MATERIAL=PLA COLOR=00AE42 TEMP=210'
+        )
+        calls_before = len(self.rt.remote_calls('moonraker_push_lane_data'))
+        self.rt.mmu.gate_maps.set_gate_status(1, 0)
+        self.rt.settle()
+
+        calls = self.rt.remote_calls('moonraker_push_lane_data')
+        self.assertEqual(len(calls), calls_before + 1)
+        self.assertEqual(calls[-1]['gate_ids'], [(1, -1)])
+
 
 class TestNfcCommandSurface(RoundTripTestCase):
     """


### PR DESCRIPTION
## Summary

Happy Hare publishes MMU gate information to Moonraker's `lane_data` database namespace for slicer integration. Gates containing valid local filament metadata were incorrectly exported as empty whenever they did not have an associated Spoolman ID.

This change uses gate occupancy as the source of truth and synchronizes `lane_data` whenever the Happy Hare gate map is persisted or an individual gate's availability changes.

## Problem

A gate can contain valid locally managed filament information without being assigned to a Spoolman spool. This is common when Happy Hare reads an NFC tag and stores its material, color, vendor, temperature, and filament name directly in the gate map while `gate_spool_id` remains `-1`.

In this state, Klipper reports the correct information through:

```http
GET /printer/objects/query?mmu
```

However, Moonraker's `lane_data` export treated the lane as empty because its empty check also required a valid `spool_id`:

```python
is_empty = gate_status_val in [-1, 0] or spool_id == -1
```

The resulting database entries contained only `null` filament fields:

```http
GET /server/database/item?namespace=lane_data
```

This affects slicer synchronization even though the underlying Happy Hare gate map is correct.

## OrcaSlicer relevance

OrcaSlicer first requests the generic Moonraker database namespace:

```http
GET /server/database/item?namespace=lane_data
```

It only falls back to the Happy Hare Klipper object when the `lane_data` request fails, its response is invalid, or it contains no valid lane entries. Existing lane entries are considered valid even when their filament metadata is empty.

```http
GET /printer/objects/query?mmu
```

The relevant OrcaSlicer changes are:

- `055f24ca7a` - Support Happy Hare as alternative to AFC for filament sync
- `189bcafee0` - Prefer generic Moonraker lane_data over direct Happy Hare status

OrcaSlicer currently consumes fields such as `lane`, `material`, `color`, `bed_temp`, and `nozzle_temp`. A Spoolman `spool_id` is not required for locally managed filament data to be useful.

## Changes

- Determine whether a lane is empty from `gate_status` only.
- Preserve local filament metadata when a gate is available but its `spool_id` is `-1`.
- Push a complete `lane_data` update from the gate-map persistence boundary.
- Push a targeted lane update when an individual gate's availability changes.
- Keep the synchronization in `MmuGateMaps` rather than duplicating update calls across NFC, Spoolman, and other feature-specific paths.
- Add regression tests for local metadata without a Spoolman ID and for complete and targeted lane-data synchronization.

The existing `/printer/objects/query?mmu` endpoint is unchanged and continues to work independently of Spoolman.

## Restart requirement discovered during testing

This change modifies code loaded by two different processes:

- `components/mmu_server.py` is loaded by Moonraker.
- `extras/mmu/mmu_gate_maps.py` is loaded by Klipper.

Both processes must reload their Python modules before the change can be tested.

Fluidd's Moonraker restart button calls Moonraker's `server.restart` endpoint. During testing, this restarted Moonraker's application internally but did not replace the systemd process or re-import the modified custom `mmu_server.py` component. Moonraker therefore continued using the old `is_empty` implementation even though the UI appeared to have restarted it.

This was confirmed by comparing the service PID and `ExecMainStartTimestamp`: they remained unchanged after Fluidd's restart action. A real service restart changed the start timestamp and loaded the updated component.

For development or testing after changing a Moonraker component, restart Moonraker through systemd:

```bash
sudo systemctl restart moonraker
```

Then restart Klipper so it reloads the Happy Hare extension and performs its startup lane-data synchronization:

```text
RESTART
```

After both processes were restarted, available gates without Spoolman IDs were immediately exported with their local filament metadata, while genuinely empty gates remained `null`.

## Verification

The affected test modules were run on a Raspberry Pi using Happy Hare's native Linux test environment:

```bash
~/klippy-env/bin/python -m unittest -v \
  test.test_mmu_moonraker \
  test.test_mmu_roundtrip
```

Result:

```text
Ran 108 tests in 39.678s

OK
```

The live Moonraker database was also checked after restarting both services. Populated gates without Spoolman assignments contained their local filament name, material, color, and nozzle temperature, while empty gates retained the expected `null` representation.
