### PR TITLE
Fix standalone fan pin naming for EBB gen1 boards

### DIFF
--- a/installer/boards/per_gate/Kconfig.ebb_gen1
+++ b/installer/boards/per_gate/Kconfig.ebb_gen1
@@ -1,7 +1,10 @@
-config BOARD_TYPE_EBB_1_0
+config BOARD_TYPE_EBB_GEN1
   bool "EBB36/42 gen1 MCU"
+  help
+    This covers the gen 1 EBB36 and EBB42 boards
+    (v1.1 and v 1.2)
 
-if BOARD_TYPE_EBB_1_0
+if BOARD_TYPE_EBB_GEN1
   config PARAM_BOARD_TYPE
     default "EBB36/42 gen1"
 
@@ -41,6 +44,9 @@ if BOARD_TYPE_EBB_1_0
 
     config PIN_NEOPIXEL
       default "$(MCU_NAME):PD3"
+
+    config PIN_FAN_$(gate)
+      default "$(MCU_NAME):PA0"
 
     config PIN_BUFFER_TENSION
       default "^$(MCU_NAME):PB8"

--- a/installer/boards/per_gate/Kconfig.ebb_gen1
+++ b/installer/boards/per_gate/Kconfig.ebb_gen1
@@ -45,7 +45,7 @@ if BOARD_TYPE_EBB_GEN1
     config PIN_NEOPIXEL
       default "$(MCU_NAME):PD3"
 
-    config PIN_FAN_$(gate)
+    config PIN_FAN
       default "$(MCU_NAME):PA0"
 
     config PIN_BUFFER_TENSION


### PR DESCRIPTION
## Summary
- Renamed `installer/boards/per_gate/Kconfig.ebb` to `Kconfig.ebb_gen1` and `BOARD_TYPE_EBB_1_0` to `BOARD_TYPE_EBB_GEN1`, to distinguish gen 1 EBB36/42 boards from upcoming gen 2 boards
- Fixed the standalone fan Kconfig option name (`PIN_FAN_$(gate)` → `PIN_FAN`) so it no longer incorrectly varies per-gate

## Test plan
- [x] `make menuconfig` renders the EBB gen1 board option correctly
- [x] Generated config produces a valid `PIN_FAN` entry for the standalone fan pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)