### PR TITLE
Default BOOL_SEQUENCE_AUTO_HOME to off

### DIFF
--- a/installer/macro_vars/Kconfig.sequence
+++ b/installer/macro_vars/Kconfig.sequence
@@ -224,9 +224,11 @@ menu "Sequence macros      (_MMU_SEQUENCE)"
 
   config BOOL_SEQUENCE_AUTO_HOME
     bool "Automatically home if necessary"
-    default y
+    default n
     help
-      Automatically home if necessary.
+      Automatically home printer if necessary (with G28 command)
+      so that toolchange toolhead movement can occur. If not homed
+      movement will simply be skipped.
 
   config VAR_SEQUENCE_AUTO_HOME
     string


### PR DESCRIPTION
## Summary
- `BOOL_SEQUENCE_AUTO_HOME` (`_MMU_SEQUENCE` macros) now defaults to `n` instead of `y`.
- Auto-homing during a toolchange without the user expecting it can cause unexpected/unsafe toolhead movement — the safer default is to skip the movement when unhomed rather than home automatically via `G28`.
- Expanded the Kconfig help text to describe what the option actually does and what happens when it's off.

## Test plan
- [ ] `make menuconfig` shows the new default and updated help text
- [ ] Existing installs are unaffected (this only changes the *default* for new/reconfigured installs; an existing `.mmu_config` keeps its explicit value)