### PR TITLE
Skip startup selector homing on unresolved filament state; fix LinearMultiGearSelector Kconfig typo

### DIFF
--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -401,13 +401,12 @@ class MmuController(MmuFilamentMovement):
 
                 if u.p.startup_home_selector:
                     unit_loaded = (
-                        self.gate_selected != TOOL_GATE_UNKNOWN and
                         u.manages_gate(self.gate_selected) and
-                        self.filament_pos not in [FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN]
+                        self.filament_pos != FILAMENT_POS_UNLOADED
                     )
 
                     if unit_loaded:
-                        self.log_warning(f"Skipping autohome of {u.name} because it may have filament loaded")
+                        self.log_warning(f"Skipping autohome of {u.name} because it may have filament loaded (or filament state could not be confirmed)")
                         continue
 
                     try:

--- a/installer/Kconfig.selector_type
+++ b/installer/Kconfig.selector_type
@@ -26,8 +26,8 @@ choice CHOICE_SELECTOR_TYPE
     help
       This uses stepper for linear movement and servo for filament gripping
 
-  config CHOICE_SELECTOR_TYPE_LINEAR_MUTLI_GEAR_SELECTOR
-    bool "LinearMultiGearSelector" 
+  config CHOICE_SELECTOR_TYPE_LINEAR_MULTI_GEAR_SELECTOR
+    bool "LinearMultiGearSelector"
     help
       Use this for type-C MMU designs with separate gear motors and a stepper
       for gate selection
@@ -77,7 +77,7 @@ config LINEAR_SERVO_SELECTOR
   select MMU_HAS_SELECTOR_STEPPER
   select MMU_HAS_SELECTOR_SERVO
 
-config LINEAR_MUTLI_GEAR_SELECTOR
+config LINEAR_MULTI_GEAR_SELECTOR
   def_bool CHOICE_SELECTOR_TYPE_LINEAR_MULTI_GEAR_SELECTOR
   select MMU_HAS_SELECTOR_STEPPER
 
@@ -118,4 +118,4 @@ config PARAM_SELECTOR_TYPE
 
 config MULTIGEAR
   bool
-  default y                         if VIRTUAL_SELECTOR || LINEAR_MUTLI_GEAR_SELECTOR
+  default y                         if VIRTUAL_SELECTOR || LINEAR_MULTI_GEAR_SELECTOR

--- a/test/test_mmu_config.py
+++ b/test/test_mmu_config.py
@@ -241,5 +241,29 @@ class TestMultiUnitRender(unittest.TestCase):
                              'leaked out of _env()' % name)
 
 
+class TestSelectorTypeChoice(unittest.TestCase):
+    """
+    The CHOICE_SELECTOR_TYPE menu (installer/Kconfig.selector_type, depends on MMU_CUSTOM) is
+    not exercised by any Profile - every real machine picks its selector implicitly, through
+    its own mmu_types/Kconfig.<vendor> defaults, never through this menu. So a broken choice
+    here has no other test to catch it; hence going straight at kconfiglib rather than adding a
+    whole custom-MMU profile just to reach one menu.
+
+    LinearMultiGearSelector specifically had a typo'd symbol name (LINEAR_MUTLI_GEAR_SELECTOR)
+    at the choice-option declaration, while the PARAM_SELECTOR_TYPE default (and
+    Kconfig.speeds' depends on) used the correctly-spelled LINEAR_MULTI_GEAR_SELECTOR - a
+    symbol that therefore never existed, so selecting this option in the installer silently
+    fell through to the "VirtualSelector # Safety" catch-all instead.
+    """
+
+    def test_choosing_linear_multi_gear_selector_sets_the_matching_param(self):
+        with cfg._env({}):
+            kc = cfg._kconfig('linear-multi-gear-selector-choice', {
+                'MMU_CUSTOM': True,
+                'CHOICE_SELECTOR_TYPE_LINEAR_MULTI_GEAR_SELECTOR': True,
+            })
+        self.assertEqual(kc.syms['PARAM_SELECTOR_TYPE'].str_value, 'LinearMultiGearSelector')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_mmu_selector.py
+++ b/test/test_mmu_selector.py
@@ -826,6 +826,51 @@ class TestPersistedPositionRestore(unittest.TestCase):
         self.assertAlmostEqual(self.axis().carriage,
                                self.selector().selector_offsets[self.GATE], places=3)
 
+    def test_startup_home_selector_skips_rather_than_guess_on_unresolved_filament_state(self):
+        """
+        An unresolved filament_pos at boot (a sensor read failure, a fresh install with no
+        persisted state - anything that leaves cmd_MMU_BOOTUP's own recovery attempt short of a
+        definite answer) must not be treated as "safe to auto-home". Before the fix,
+        FILAMENT_POS_UNKNOWN was explicitly exempted from the boot skip-check, so bootup would
+        proceed into home_unit() -> PhysicalSelector.home(), whose "automatic unload case" branch
+        then runs a real unload_sequence() - which can heat the extruder - based on nothing more
+        than an ambiguous read. The fix (mmu_controller.py's autohoming loop) must skip and warn
+        instead, leaving the unload untouched.
+
+        No gate is seeded here: an unresolved filament_pos is most likely exactly when no gate
+        has ever been selected either (a fresh install), and that combination is what let the old
+        check's `gate_selected != TOOL_GATE_UNKNOWN` clause slip past it too.
+
+        Not using self.boot(): a genuinely unresolved state legitimately produces two
+        informational errors of its own (the rigged sensor failure itself, and
+        report_necessary_recovery's "Filament detected but tool/gate is unknown" guidance,
+        mmu_filament_movement.py:3351-3352) - orthogonal to this fix, which is only about what
+        the autohoming loop does next. Pinning the exact pair below still catches anything ELSE
+        going wrong (e.g. an unload attempt blowing up) as a third, unexpected error.
+        """
+        unload_calls = []
+
+        def rig_unresolved_filament_state():
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 startup_home_selector=1')
+
+            def explode(*args, **kwargs):
+                raise Exception('harness: filament state sensors unavailable')
+            self.hh.mmu.recover_filament_pos = explode
+            self.hh.mmu.unload_sequence = lambda *args, **kwargs: unload_calls.append((args, kwargs))
+
+        self.hh = session('tradrack')
+        self.hh.boot(calibrate=True, pre_bootup=rig_unresolved_filament_state)
+        hh = self.hh
+
+        self.assertEqual(unload_calls, [], 'an unresolved filament state must never trigger an automatic unload')
+        self.assertIn('may have filament loaded', '\n'.join(hh.console),
+                      'bootup did not warn about the unresolved filament state')
+        self.assertFalse(self.selector().is_homed, 'the selector must not be homed on an unresolved state either')
+        self.assertEqual(hh.errors, [
+            '!! harness: filament state sensors unavailable',
+            '!! Filament detected but tool/gate is unknown. Please use MMU_RECOVER GATE=xx to correct state',
+        ], 'only the rigged sensor failure and the resulting recovery guidance should be reported')
+
 
 class TestTipFormingEffect(unittest.TestCase):
     """


### PR DESCRIPTION
Supersedes #1064, which was opened from `private_v4` and ended up carrying the in-flight NFC "noisy neighbor" commits (already covered by #1061) along with this fix. This PR is cherry-picked from a clean `v4` base so it contains only the startup change and the selector_type fix.

## Summary
- `startup_home_selector`'s boot-time skip-check exempted `FILAMENT_POS_UNKNOWN` and short-circuited whenever no gate had ever been selected, so an unresolved filament state at boot (a sensor read failure, a fresh install) could fall through into `PhysicalSelector.home()`'s automatic `unload_sequence()` — which can heat the extruder and run tip-forming — based on nothing more than an ambiguous read. Any state other than a confirmed `FILAMENT_POS_UNLOADED` now skips the autohome with a warning instead.
- Toolhead XYZ homing (`_MMU_AUTO_HOME`) was confirmed to be a separate, unaffected path (ships disabled by default) — not touched here.
- Also fixes an unrelated typo'd Kconfig symbol (`LINEAR_MUTLI_GEAR_SELECTOR`) that made the `LinearMultiGearSelector` installer menu choice silently fall back to `VirtualSelector` instead of ever taking effect.

## Test plan
- [x] New regression test in `test/test_mmu_selector.py` (`test_startup_home_selector_skips_rather_than_guess_on_unresolved_filament_state`) — confirmed it fails on the old code and passes on the fix.
- [x] New regression test in `test/test_mmu_config.py` (`test_choosing_linear_multi_gear_selector_sets_the_matching_param`) — confirmed it fails on the old code and passes on the fix.
- [x] Existing `test_startup_home_selector_homes_first_and_then_reselects_the_gate` still passes unmodified (no regression on the happy path).
- [x] Verified clean on this branch: `test.test_mmu_selector.TestPersistedPositionRestore` + `test.test_mmu_config.TestSelectorTypeChoice` all pass against a fresh `v4` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)