### PR TITLE
Change per-lane MCU eject pins to also be inverted

### DIFF
--- a/installer/boards/per_gate/Kconfig.ebb_gen1
+++ b/installer/boards/per_gate/Kconfig.ebb_gen1
@@ -104,7 +104,7 @@ if BOARD_TYPE_EBB_GEN1
         default "^$(MCU_NAME)_gate$(gate):PB5"
 
       config PIN_EJECT_BUTTON_$(gate)
-        default "^$(MCU_NAME)_gate$(gate):PB6"
+        default "^!$(MCU_NAME)_gate$(gate):PB6"
 
       config PIN_NEOPIXEL_$(gate)
         default "$(MCU_NAME)_gate$(gate):PD3"

--- a/installer/boards/per_gate/Kconfig.slb
+++ b/installer/boards/per_gate/Kconfig.slb
@@ -105,7 +105,7 @@ if BOARD_TYPE_SLB_1_0
         default "^$(MCU_NAME)_gate$(gate):PA0"
 
       config PIN_EJECT_BUTTON_$(gate)
-        default "^$(MCU_NAME)_gate$(gate):PB2"
+        default "^!$(MCU_NAME)_gate$(gate):PB2"
 
       config PIN_NEOPIXEL_$(gate)
         default "$(MCU_NAME)_gate$(gate):PA4"


### PR DESCRIPTION
The single-MCU defaults were already inverted, this change equalizes the per-lane defaults.

This matches normally closed switches, and is correct particularly for the EMU[^1].

[^1]: Previously two variants, normally open PCB eject buttons and normally closed D2F-based DIY buttons. The latter are being changed to also be normally open, so the defaults will fit both variants.