### PR TITLE
Fix fragile selector implementations and profiles

### DIFF
--- a/extras/mmu/unit/selectors/mmu_base_selectors.py
+++ b/extras/mmu/unit/selectors/mmu_base_selectors.py
@@ -278,10 +278,9 @@ class PhysicalSelector(BaseSelector, object):
             # (an upgrade or a renamed unit that never wrote the namespaced var), so the gate's
             # calibrated offset is where we are.
             #
-            # requires_homing only: type-C (LinearMultiGear*Selector) inherits this handler but
-            # is always-homed by MRO, so it never reports unhomed and has nothing to rescue -
-            # and it never re-homes to correct a wrong guess either. Its pre-existing last_pos
-            # restore below is untouched; only the INFERRED position is withheld.
+            # Only a physical selector that requires homing may infer a carriage position.
+            # Always-homed selectors such as VirtualSelector have no carriage position to
+            # reconstruct; their pre-existing explicit last_pos handling below is untouched.
             last_pos = self._persisted_gate_position()
             if last_pos is not None:
                 self.var_manager.set(VARS_MMU_SELECTOR_LAST_POS, last_pos, namespace=self.mmu_unit.name)

--- a/extras/mmu/unit/selectors/mmu_indexed_selector.py
+++ b/extras/mmu/unit/selectors/mmu_indexed_selector.py
@@ -231,7 +231,10 @@ class IndexedSelector(PhysicalSelector):
             endstop_name=self._get_gate_endstop_name(lgate),
         )
 
-        if abs(delta) > 0 and homed:
+        if not homed:
+            raise MmuError("Failed to locate selector index for gate %d" % self._logical_gate(lgate))
+
+        if abs(delta) > 0:
             # If we actually moved to home make sure we are centered on index endstop
             nudge = self.endstop_widths[lgate] / 2
             center_move = nudge * rotation_dir

--- a/extras/mmu/unit/selectors/mmu_linear_mg_selector.py
+++ b/extras/mmu/unit/selectors/mmu_linear_mg_selector.py
@@ -17,18 +17,16 @@
 #
 import logging
 
-from .mmu_base_selectors  import VirtualSelector
 from .mmu_linear_selector import LinearSelector
 
 
-class LinearMultiGearSelector(LinearSelector, VirtualSelector):
+class LinearMultiGearSelector(LinearSelector):
     """
     Linear selector for type-C MMUs with one gear stepper per gate.
 
-    Combines VirtualSelector (for selecting the per-gate gear driver) with
-    LinearSelector (for moving the physical selector mechanism with an endstop).
-    The MRO ensures gear selection occurs before selector movement when using
-    super() in select_gate().
+    Gate-specific drives are resolved by MmuUnit/MmuController. The selector
+    remains a physical LinearSelector and therefore must home normally before
+    making absolute-position moves.
     """
 
     def __init__(self, config, mmu_unit, params):

--- a/extras/mmu/unit/selectors/mmu_linear_mg_servo_selector.py
+++ b/extras/mmu/unit/selectors/mmu_linear_mg_servo_selector.py
@@ -18,19 +18,17 @@
 #
 import logging
 
-from .mmu_base_selectors        import VirtualSelector
 from .mmu_linear_servo_selector import LinearServoSelector
 
 
-class LinearMultiGearServoSelector(LinearServoSelector, VirtualSelector):
+class LinearMultiGearServoSelector(LinearServoSelector):
     """
     Linear selector for type-C MMUs with one gear stepper per gate and a servo
     for filament gripping.
 
-    Combines VirtualSelector (for selecting the per-gate gear driver) with
-    LinearServoSelector (for endstop-based selector movement plus servo grip/
-    release). The MRO ensures gear selection occurs before selector movement
-    when using super() in select_gate().
+    Gate-specific drives are resolved by MmuUnit/MmuController. The selector
+    remains a physical LinearServoSelector and therefore retains normal homing
+    and persisted-position semantics.
     """
 
     def __init__(self, config, mmu_unit, params):

--- a/extras/mmu/unit/selectors/mmu_macro_selector.py
+++ b/extras/mmu/unit/selectors/mmu_macro_selector.py
@@ -30,8 +30,8 @@ from .mmu_base_selectors    import BaseSelector
 class MacroSelectorParameters(TunableParametersBase):
 
     _SPECS: Sequence[ParamSpec] = (
-        ParamSpec('select_tool_macro',        'str', _REQUIRED, section="SELECTOR", limits=dict(minval=1.0)),
-        ParamSpec('select_tool_num_switches', 'int',  1,        section="SELECTOR", limits=dict(minval=1), hidden=True),
+        ParamSpec('select_tool_macro',        'str', _REQUIRED, section="SELECTOR"),
+        ParamSpec('select_tool_num_switches', 'int',  0,        section="SELECTOR", limits=dict(minval=0), hidden=True),
     )
 
     def __init__(self, config, selector):
@@ -92,12 +92,14 @@ class MacroSelector(BaseSelector):
         """
         Select the specified gate by invoking the configured macro.
 
-        Always passes GATE=<n>. In binary mode, also passes S0=..Sn= bits for
+        Passes the machine-wide GATE=<n> used by existing macros and the
+        unit-local LGATE=<n>. In binary mode, also passes S0=..Sn= bits for
         demultiplexer-style selectors.
         """
         # Store parameters as list
-        params = ['LGATE=' + str(lgate)]
-        if self.binary_mode: # If demultiplexer, pass binary parameters to the macro in the form of S0=, S1=, S2=, etc.
+        gate = self._logical_gate(lgate) if lgate >= 0 else lgate
+        params = ['GATE=' + str(gate), 'LGATE=' + str(lgate)]
+        if self.binary_mode and lgate >= 0: # If demultiplexer, pass binary parameters to the macro in the form of S0=, S1=, S2=, etc.
             binary = list(reversed('{0:b}'.format(lgate).zfill(self.p.select_tool_num_switches)))
             for i in range(self.p.select_tool_num_switches):
                 char = binary[i]

--- a/extras/mmu/unit/selectors/mmu_servo_selector.py
+++ b/extras/mmu/unit/selectors/mmu_servo_selector.py
@@ -39,6 +39,8 @@ class ServoSelectorParameters(TunableParametersBase):
 
     def _validate_int_list(self, value, *, minval=None, maxval=None):
         expected = self._selector.mmu_unit.num_gates
+        if not value:
+            return # An empty list deliberately forces calibration
         if len(value) != expected:
             raise ValueError(f"Expected {expected} gate values, got {len(value)}")
 

--- a/installer/mmu_types/Kconfig.mmx
+++ b/installer/mmu_types/Kconfig.mmx
@@ -42,7 +42,7 @@ if MMU_TYPE_MMX_1_0
   config PARAM_GATE_HOMING_MAX
     default 1000
 
-  config PARAM_SELECTOR_GATE_ANGLES
+  config PARAM_SERVO_GATE_ANGLES
     default "60,0,180,120"
 
   comment "_"

--- a/installer/mmu_types/Kconfig.pico_mmu
+++ b/installer/mmu_types/Kconfig.pico_mmu
@@ -48,6 +48,13 @@ if MMU_TYPE_PICO_MMU_1_0
   config PARAM_GATE_PARKING_DISTANCE
     default -25
 
+  # Gate angles depend on the particular cam build. The generic four-gate
+  # default assumes 360 degree travel, but PicoMMU's ES3004 is limited to 140
+  # degrees. Leave them unseeded so Happy Hare boots safely and requires the
+  # user to calibrate the actual mechanism.
+  config PARAM_SERVO_GATE_ANGLES
+    default ""
+
   comment "_"
 
 endif 

--- a/test/README.md
+++ b/test/README.md
@@ -692,7 +692,7 @@ Green is not the same as covered. Roughly where things stand:
 
 | Area | State | Notes |
 |---|---|---|
-| Config rendering and load | **solid** | real templates, three machine profiles |
+| Config rendering and load | **solid** | real templates, eight shipped machine/unit profiles |
 | Bootup sequence | **solid** | including the error sentinel that stops bootup faking success |
 | Tag decoding, Spoolman round trip | **solid** | including auto-create and the miss cache |
 | Load / unload / tool change | **good** | the happy path and its common failures |
@@ -701,7 +701,7 @@ Green is not the same as covered. Roughly where things stand:
 | Endless spool and runout | **good** | including the clog-vs-runout decision |
 | LEDs | **good** | effects and overlays; not the neopixel protocol |
 | Sync feedback / buffer sensors | **partial** | EMU's analog sensor boots; the tension logic has a known bug |
-| Physical selector homing and selection | **good** | all three selector families home, select and move filament — `test_mmu_selector.py`. `RotarySelector` also expresses grip as a carriage position, so releasing to the opposing gate is covered there |
+| Selector homing and selection | **good** | `LinearSelector`, `LinearServoSelector`, `LinearMultiGearSelector`, `RotarySelector`, `IndexedSelector`, `ServoSelector`, and `VirtualSelector` are booted or exercised — `test_mmu_selector.py`. `MacroSelector` direct-mode dispatch is covered without executing a user macro |
 | Calibration | **partial** | seeded by default for speed, but `MMU_CALIBRATE_SELECTOR` (manual and `AUTO=1`) and `MMU_CALIBRATE_BOWDEN` run for real — `test_mmu_selector.py` |
 | Developer commands (`_MMU_TEST`) | **partial** | every option is run and must not raise — `test_mmu_dev_test.py`. What the stress probes *provoke* is step-generation timing the harness does not model |
 | Espooler, FlowGuard | **none** | |
@@ -824,6 +824,8 @@ templates** from them, so a broken template shows up as a test failure.
 | `boxturtle` | 4 gates, no NFC — the default for most tests |
 | `tradrack` | a physical (servo) selector, single unit, no encoder — the simplest physical-selector case |
 | `chameleon` | 3D Chameleon: the only `RotarySelector`, and the only machine with no servo — one gear motor reversed on half the gates, and "release" means driving the carriage to the opposing gate's offset |
+| `pico_mmu` | PicoMMU's `ServoSelector`; deliberately boots uncalibrated because its gate angles depend on the physical cam build |
+| `mmx` | MMX's `ServoSelector` with its vendor gate-angle order; also used for a full load/unload selector test |
 | `emu` | 5 gates and the only shipped profile with an analog buffer sensor |
 | `encoder` | BoxTurtle plus an encoder, homing to it instead of to the gate switch |
 | `nfc_single` | one common NFC reader |
@@ -844,7 +846,9 @@ the filament path, which is one scalar per gate and has no carriage. Two **endst
 because the shipped families disagree: the `LinearSelector` family (ERCF, Tradrack) has one home
 switch and reaches gates by plain moves to calibrated offsets, while `IndexedSelector` (ViViD)
 has no home switch at all and one index switch per gate, visited in `selector_gate_order`.
-`RotarySelector` (3D Chameleon) shares the first geometry but not its meaning: with no servo,
+`LinearMultiGearSelector` shares the linear geometry but uses one gear drive per gate and still
+has to home its physical selector axis. `RotarySelector` (3D Chameleon) shares the first
+geometry but not its meaning: with no servo,
 the carriage position *is* the grip — a released gate parks at another gate's offset
 (`selector_release_gates`), so gate → position is not a bijection.
 

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -308,6 +308,23 @@ CHAMELEON = Profile(
           'MMU_HAS_SENSOR_SHARED_EXIT': True},
     description='3D Chameleon 1.0 - 4 gates, the only RotarySelector')
 
+# PicoMMU and MMX are the two shipped ServoSelector machines. Like Chameleon, neither
+# chooses a controller board or a gate-homing sensor on its own, so the harness supplies
+# the same complete, ordinary setup a user must choose in menuconfig.
+PICO_MMU = Profile(
+    'pico_mmu',
+    syms={'MMU_TYPE_PICO_MMU_1_0': True,
+          'BOARD_TYPE_MMB_2_0': True,
+          'MMU_HAS_SENSOR_SHARED_EXIT': True},
+    description='PicoMMU 1.0 - 4 gates, ServoSelector requiring calibration')
+
+MMX = Profile(
+    'mmx',
+    syms={'MMU_TYPE_MMX_1_0': True,
+          'BOARD_TYPE_MMB_2_0': True,
+          'MMU_HAS_SENSOR_SHARED_EXIT': True},
+    description='MMX 1.0 - 4 gates, ServoSelector with vendor gate angles')
+
 # EMU: 5 gates, and the only shipped profile that brings a PROPORTIONAL (analog) buffer
 # sensor with it. That makes it the profile that exercises MmuAdcHelper's ADC compat shim
 # for real, and the virtual compression/tension sensors derived from an analog reading
@@ -534,7 +551,7 @@ uart_pin: mcu:PB6
 run_current: 0.6
 """
 
-PROFILES = {p.name: p for p in (BOXTURTLE, TRADRACK, CHAMELEON, EMU, ENCODER, NFC_SINGLE,
+PROFILES = {p.name: p for p in (BOXTURTLE, TRADRACK, CHAMELEON, PICO_MMU, MMX, EMU, ENCODER, NFC_SINGLE,
                                 NFC_PER_GATE, NFC_NEIGHBOR_CHECK, NFC_NEIGHBOR_EVICT,
                                 NFC_PN5180, NFC_PN5180_PER_GATE,
                                 NFC_PN532, NFC_PN532_SW_I2C,

--- a/test/hh/selector.py
+++ b/test/hh/selector.py
@@ -75,11 +75,23 @@ class SelectorAxis:
         # stop there or step 3 measures a number the machine does not have.
         self.travel_min = self.home_position()
         offsets = self.nominal_gate_offsets()
+        positions = self.gate_positions()
+        # An IndexedSelector is a rotary ring, not a rail. Its last published index is not
+        # a hard stop: moving forward from it wraps through zero to the first indexes again.
+        # Keep the circumference separate from travel_max, which remains useful diagnostic
+        # output and is still a real hard limit for every linear-selector family.
+        self.circumference = None
+        if callable(getattr(self.selector, '_get_gate_endstop_name', None)):
+            spacing = self._cad('cad_gate_width') or 1.0
+            self.circumference = self.unit.num_gates * spacing
         if offsets:
             self.travel_max = offsets[-1] + (self._cad('cad_last_gate_offset') or 0.)
+        elif positions:
+            self.travel_max = max(positions.values())
+        elif self.circumference is not None:
+            self.travel_max = self.circumference - spacing
         else:
-            positions = self.gate_positions()
-            self.travel_max = max(positions.values()) if positions else None
+            self.travel_max = None
 
         # WHERE THE CARRIAGE POWERS ON. Nominal gate 0, NOT the home switch: a carriage
         # sitting on its own switch makes the first homing move travel zero, which trips
@@ -103,12 +115,17 @@ class SelectorAxis:
         """
         if not delta:
             return 0.
+        if self.circumference is not None:
+            self.carriage = self._clamp(self.carriage + delta)
+            return delta
         target = self._clamp(self.carriage + delta)
         moved = target - self.carriage
         self.carriage = target
         return moved
 
     def _clamp(self, position):
+        if self.circumference is not None:
+            return position % self.circumference
         if self.travel_min is not None:
             position = max(self.travel_min, position)
         if self.travel_max is not None:
@@ -213,7 +230,14 @@ class SelectorAxis:
         target = self.position(name)
         if target is None or not delta:
             return None
-        travel = target - start
+        if self.circumference is not None:
+            start %= self.circumference
+            if delta > 0:
+                travel = (target - start) % self.circumference
+            else:
+                travel = -((start - target) % self.circumference)
+        else:
+            travel = target - start
         if travel and (travel > 0) != (delta > 0):
             return None                             # switch is behind us
         if abs(travel) > abs(delta):

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -5,7 +5,7 @@
 # [% if %] guard or a missing template section shows up here rather than on a user's
 # printer.
 #
-# There are 19 shipped machine types. Six boot in the harness today:
+# There are 19 shipped machine types. Eight boot in the harness today:
 #
 #   boxturtle  4 gates,  VirtualSelector       - Type B, the default everywhere else
 #   tradrack  10 gates,  LinearServoSelector   - a PHYSICAL selector, so the suite is not
@@ -13,6 +13,10 @@
 #   chameleon  4 gates,  RotarySelector        - a fourth selector class, and the only one
 #                                                with no servo: releasing drives the carriage
 #                                                to the OPPOSING gate's offset
+#   pico_mmu   4 gates,  ServoSelector         - boots uncalibrated because its 140-degree
+#                                                servo has no universally safe gate defaults
+#   mmx        4 gates,  ServoSelector         - vendor-supplied gate angles, including a
+#                                                full load/unload behavioral test
 #   emu        5 gates,  VirtualSelector       - the only shipped profile with a
 #                                                PROPORTIONAL (analog) buffer sensor
 #   ercf 1.1   9 gates,  LinearServoSelector   - unit0 of ercf_vvd; encoder gate homing
@@ -31,7 +35,7 @@
 #       no MMU attached. The answer is to omit it: the choice falls back to ..._OTHER and
 #       the harness fakes every [mcu] anyway.
 #
-# The remaining machines should mostly be a board selection away; nobody has tried.
+# The remaining machines should mostly be a board selection away.
 #
 #   ./venv/bin/python -m unittest test.test_mmu_profiles
 #
@@ -51,6 +55,8 @@ BOOTABLE = {
     # Needs two symbols the vendor Kconfig leaves open (a board and a gate homing sensor) or it
     # does not render at all - see the profile's own comment in test/hh/profiles.py.
     'chameleon': (4, 'RotarySelector'),
+    'pico_mmu': (4, 'ServoSelector'),
+    'mmx': (4, 'ServoSelector'),
     'emu': (5, 'VirtualSelector'),
     # The only multi-unit entry. 13 is a CROSS-UNIT SUM (unit0 9 + unit1 4), not one unit's
     # count, and the selector named here is unit0's - unit1 is an IndexedSelector and gets
@@ -108,6 +114,18 @@ class TestEveryBootableProfile(unittest.TestCase):
         selector = hh.mmu.mmu_unit(0).selector
         self.assertEqual(len(selector.p.selector_release_gates), 4)
         self.assertEqual(len(selector.p.selector_gate_directions), 4)
+
+    def test_pico_mmu(self):
+        """PicoMMU must boot safely and require calibration rather than exceed its 140 degree servo range."""
+        hh = self._check('pico_mmu')
+        selector = hh.mmu.mmu_unit(0).selector
+        self.assertEqual(selector.servo_gate_angles, [-1, -1, -1, -1])
+
+    def test_mmx(self):
+        """MMX's vendor-specific gate angles must override the unsafe generic 360 degree defaults."""
+        hh = self._check('mmx')
+        selector = hh.mmu.mmu_unit(0).selector
+        self.assertEqual(selector.servo_gate_angles, [60, 0, 180, 120])
 
     def test_emu(self):
         self._check('emu')
@@ -254,7 +272,7 @@ class TestMultiUnitMachine(unittest.TestCase):
 
 class TestSelectorCoverage(unittest.TestCase):
     """
-    9 selector classes exist; 4 are reachable through a bootable profile. Recorded as a
+    9 selector classes exist; 5 are reachable through a bootable profile. Recorded as a
     test so the gap is visible in the suite rather than only in a document.
     """
 
@@ -267,7 +285,8 @@ class TestSelectorCoverage(unittest.TestCase):
                      | EXERCISED_BY_LATER_UNITS)
         self.assertEqual(
             exercised,
-            {'VirtualSelector', 'LinearServoSelector', 'IndexedSelector', 'RotarySelector'},
+            {'VirtualSelector', 'LinearServoSelector', 'IndexedSelector', 'RotarySelector',
+             'ServoSelector'},
             'update this and the README coverage map when a profile adds another selector '
             'type')
 

--- a/test/test_mmu_selector.py
+++ b/test/test_mmu_selector.py
@@ -28,7 +28,7 @@ import logging
 import unittest
 
 from test.hh import session
-from test.hh.profiles import PROFILES, clone_across_units
+from test.hh.profiles import PROFILES, Profile, clone_across_units
 
 logging.getLogger().setLevel(logging.CRITICAL)
 
@@ -39,6 +39,35 @@ TIP_AT_GATE = -40.0             # past the entry switch: where a user's push lea
 # mmu_constants.py:209-211, mirrored here for the same reason FILAMENT_POS_* is
 FILAMENT_RELEASE_STATE = 0
 FILAMENT_DRIVE_STATE = 1
+
+
+# The installer exposes LinearMultiGearSelector only for custom machines. MMB 2.0 has
+# enough gear outputs but reuses its normal selector pins for those extra gears, so this
+# fixture supplies a separate selector driver explicitly, as a real custom build must.
+LINEAR_MULTI_GEAR = Profile(
+    'linear_multi_gear',
+    syms={
+        'MMU_CUSTOM': True,
+        'CHOICE_SELECTOR_TYPE_LINEAR_MULTI_GEAR_SELECTOR': True,
+        'BOARD_TYPE_MMB_2_0': True,
+        'MMU_HAS_SENSOR_SHARED_EXIT': True,
+        'PIN_SELECTOR_STEP': 'unit0:PA8',
+        'PIN_SELECTOR_DIR': 'unit0:PA9',
+        'PIN_SELECTOR_ENABLE': 'unit0:PA10',
+        'PIN_SELECTOR_UART': 'unit0:PA11',
+        'PIN_SELECTOR_ENDSTOP': 'unit0:PA12',
+    },
+    description='custom four-gate LinearMultiGearSelector with a separate selector driver')
+
+MACRO_SELECTOR = Profile(
+    'macro_selector',
+    syms={
+        'MMU_CUSTOM': True,
+        'CHOICE_SELECTOR_TYPE_MACRO_SELECTOR': True,
+        'BOARD_TYPE_MMB_2_0': True,
+        'MMU_HAS_SENSOR_SHARED_EXIT': True,
+    },
+    description='custom four-gate MacroSelector in direct (zero-switch) mode')
 
 
 class SelectorTestCase(unittest.TestCase):
@@ -144,6 +173,74 @@ class TestLinearSelector(SelectorTestCase):
         before = axis.carriage
         self.load_and_unload(5)
         self.assertAlmostEqual(axis.carriage, before, places=3)
+
+
+class TestLinearMultiGearSelector(SelectorTestCase):
+    """A type-C selector is still a physical axis and must home before absolute moves."""
+
+    PROFILE = LINEAR_MULTI_GEAR
+
+    def test_it_retains_physical_selector_homing(self):
+        selector = self.selector('unit0')
+        axis = self.axis('unit0')
+        self.assertTrue(selector.requires_homing)
+        self.assertTrue(selector.is_homed)
+        self.assertAlmostEqual(axis.carriage, axis.home_position(), places=3)
+
+    def test_selection_uses_the_homed_coordinate_frame(self):
+        selector = self.selector('unit0')
+        axis = self.axis('unit0')
+        self.hh.run_gcode('MMU_SELECT GATE=3')
+        self.assertAlmostEqual(axis.carriage, selector.selector_offsets[3], places=3)
+        self.assertEqual(self.hh.errors, [])
+
+    def test_per_gate_drives_do_not_depend_on_virtual_selector(self):
+        """Type-C gear dispatch belongs to MmuUnit, independently of selector inheritance."""
+        unit = self.hh.mmu.mmu_unit(0)
+        self.assertTrue(unit.multigear)
+        self.assertEqual(len({id(drive) for drive in unit.drives}), unit.num_gates)
+        for lgate, expected_drive in enumerate(unit.drives):
+            gate = unit.logical_gate(lgate)
+            self.assertIs(self.hh.mmu.drive(gate), expected_drive)
+
+    def test_full_load_and_unload(self):
+        loaded, unloaded = self.load_and_unload(2)
+        self.assertEqual(loaded, FILAMENT_POS_LOADED)
+        self.assertEqual(unloaded, FILAMENT_POS_UNLOADED)
+        self.assertEqual(self.hh.errors, [])
+
+
+class TestServoSelector(SelectorTestCase):
+    """MMX provides valid vendor angles and exercises the otherwise-unused ServoSelector."""
+
+    PROFILE = 'mmx'
+    HOME_UNITS = ()
+
+    def test_vendor_gate_angles_are_loaded(self):
+        self.assertEqual(self.selector('unit0').servo_gate_angles, [60, 0, 180, 120])
+
+    def test_full_load_and_unload(self):
+        loaded, unloaded = self.load_and_unload(2)
+        self.assertEqual(loaded, FILAMENT_POS_LOADED)
+        self.assertEqual(unloaded, FILAMENT_POS_UNLOADED)
+        self.assertEqual(self.hh.errors, [])
+
+
+class TestMacroSelector(SelectorTestCase):
+    """The generated zero-switch config is direct mode and preserves the v3 GATE contract."""
+
+    PROFILE = MACRO_SELECTOR
+    HOME_UNITS = ()
+
+    def test_direct_mode_boots_and_passes_both_gate_numbering_schemes(self):
+        selector = self.selector('unit0')
+        calls = []
+        self.hh.mmu.wrap_gcode_command = calls.append
+
+        selector.select_gate(2)
+
+        self.assertFalse(selector.binary_mode)
+        self.assertEqual(calls, ['select_tool_macro GATE=2 LGATE=2'])
 
 
 class TestRotarySelector(SelectorTestCase):
@@ -514,6 +611,32 @@ class TestMultiUnitSelectors(SelectorTestCase):
             name = self.selector('unit1')._get_gate_endstop_name(lgate)
             self.assertAlmostEqual(positions[name], slot * spacing, places=3,
                                    msg='gate %d should sit in slot %d' % (lgate, slot))
+
+    def test_indexed_selector_rejects_a_missed_target_index(self):
+        """A missed sensor must not turn into a successful logical gate change."""
+        selector = self.selector('unit1')
+        self.hh.run_gcode('MMU_SELECT GATE=9')
+
+        def miss_index(*args, **kwargs):
+            raise self.hh.printer.command_error('simulated missed selector index')
+
+        selector.selector_stepper.do_homing_move = miss_index
+        self.hh.run_gcode('MMU_SELECT GATE=10')
+
+        self.assertEqual(self.hh.mmu.gate_selected, -1)
+        self.assertEqual(selector.lgate_selected, 0,
+                         'the selector cache must retain the last physically located gate')
+        self.assertTrue(any('Failed to locate selector index for gate 10' in error
+                            for error in self.hh.errors))
+
+    def test_indexed_selector_wraps_through_zero(self):
+        """The fake ViViD ring must not turn its final index into a linear hard stop."""
+        for gate in (9, 10, 11, 12):
+            self.hh.run_gcode('MMU_SELECT GATE=%d' % gate)
+
+        self.assertEqual(self.hh.mmu.gate_selected, 12, self.hh.errors)
+        self.assertEqual(self.selector('unit1').lgate_selected, 3)
+        self.assertEqual(self.hh.errors, [])
 
     def test_unit0_loads_and_unloads(self):
         """


### PR DESCRIPTION
## Summary
- reject missed IndexedSelector target sensors without corrupting the cached physical gate
- restore physical homing and calibration semantics for Type-C linear multi-gear selectors
- repair MacroSelector direct mode and preserve the machine-wide GATE parameter while adding LGATE
- fix MMX ServoSelector angles and make PicoMMU boot safely pending calibration
- add boot and behavioral coverage for previously unexercised selector types, including indexed-ring wraparound

## Validation
- make ALL=1 test
- 1071 tests passed (1 skipped, 4 expected failures)

The separate home_unit() P2 design issue is intentionally not changed in this PR.