### PR TITLE
Preserve filament ownership during selector homing

### DIFF
--- a/extras/mmu/commands/mmu_home.py
+++ b/extras/mmu/commands/mmu_home.py
@@ -28,7 +28,7 @@ class MmuHomeCommand(BaseCommand):
         f"{CMD}: {HELP_BRIEF}\n"
         + "UNIT         = #(int)|_name_|ALL Specify unit by name, number or all-units (optional if single unit)\n"
         + "TOOL         = #(int) Optionally select tool number after homing\n"
-        + "FORCE_UNLOAD = [0|1]  Force unloaded of filament\n"
+        + "FORCE_UNLOAD = [0|1]  Omit to unload when needed; 1 forces recovery; 0 homes without unloading\n"
         + "SKIP_HOMED   = [0|1]  Skip homing of units that are already homed\n"
         + "(no parameters: home selector on single unit setup and select T0)\n"
     )

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -403,8 +403,9 @@ class MmuController(MmuFilamentMovement):
 
                 if u.p.startup_home_selector:
                     unit_loaded = (
-                        u.manages_gate(self.gate_selected) and
-                        self.filament_pos != FILAMENT_POS_UNLOADED
+                        self.filament_pos != FILAMENT_POS_UNLOADED and
+                        (self.gate_selected == TOOL_GATE_UNKNOWN or
+                         self._unit_owns_selection(u, self.gate_selected))
                     )
 
                     if unit_loaded:
@@ -412,7 +413,7 @@ class MmuController(MmuFilamentMovement):
                         continue
 
                     try:
-                        self.home_unit(u) # Will reselect previous gate if on this unit
+                        self.home_unit(u, force_unload=False) # Startup never initiates filament movement
 
                     except Exception as e:
                         # This is recoverable so just report errors
@@ -2894,6 +2895,17 @@ class MmuController(MmuFilamentMovement):
             self.wrap_gcode_command("SET_GCODE_VARIABLE MACRO=%s VARIABLE=next_pos VALUE=False" % self.p.park_macro)
 
 
+    def _unit_owns_selection(self, mmu_unit, gate):
+        """Whether a real gate or the active unit's bypass belongs to mmu_unit."""
+        if mmu_unit.owns_gate(gate):
+            return True
+        if gate == TOOL_GATE_BYPASS:
+            # Bypass is a machine-wide sentinel. unit_selected supplies its otherwise
+            # missing ownership; manages_gate() cannot distinguish multiple bypass units.
+            return mmu_unit is self.mmu_unit(gate)
+        return False
+
+
     def home_unit(self, mmu_unit, force_unload=None, reselect=True):
         """
         Home the specific mmu unit
@@ -2901,45 +2913,71 @@ class MmuController(MmuFilamentMovement):
           force_unload - whether to unload current gate
             None  - intelligently unload if necessary (default)
             True  - always force an unload regardless of filament position state (safety)
-            False - never attempt filament unload, instead homing may fail
+            False - never unload; explicit override when gate ownership is unknown
           reselect - whether to reselect gate (default is True)
         """
-        if mmu_unit.selector.requires_homing: # Make a no-op for MMU's that don't require homing (like class-B designs)
-            if mmu_unit.manages_gate(self.gate_selected):
-                if not force_unload and self.filament_pos not in [FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN]:
-                    raise MmuError("Cannot home %s because has filament loaded" % mmu_unit.name)
-                else:
-                    try:
-                        prev_gate = self.gate_selected
-                        self._set_gate_selected(TOOL_GATE_UNKNOWN)
-                        mmu_unit.selector.home(force_unload)
-                        if reselect:
-                            if prev_gate != TOOL_GATE_UNKNOWN:
-                                self.select_gate(prev_gate)
-                            else:
-                                self.select_gate(mmu_unit.first_gate)
-                    except MmuError as ee:
-                        self._set_gate_selected(TOOL_GATE_UNKNOWN)
-                        raise ee
-            else:
-                # Safe to just home selector
-                mmu_unit.selector.home()
+        selector = mmu_unit.selector
+        if not selector.requires_homing: return # Class-B and other non-physical selectors
+        if force_unload is not None:
+            force_unload = bool(force_unload) # G-Code supplies 0/1 integers
+
+        prev_gate = self.gate_selected
+        owns_selection = self._unit_owns_selection(mmu_unit, prev_gate)
+
+        # With no gate identity there is no safe drive or unit to unload. In particular,
+        # manages_gate(UNKNOWN) is true for every unit, so never use it to infer ownership.
+        if (
+            prev_gate == TOOL_GATE_UNKNOWN and
+            self.filament_pos != FILAMENT_POS_UNLOADED and
+            force_unload is not False
+        ):
+            raise MmuError(
+                "Cannot home %s because filament state or gate ownership is unknown. "
+                "Use MMU_RECOVER GATE=xx first, or FORCE_UNLOAD=0 to home without unloading" % mmu_unit.name)
+
+        # Filament policy belongs here, while the real gate still identifies its unit and
+        # drive. selector.home() is deliberately mechanical and must not infer ownership.
+        if owns_selection:
+            if force_unload is False:
+                if self.filament_pos not in [FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN]:
+                    raise MmuError("Cannot home %s because it has filament loaded" % mmu_unit.name)
+            elif force_unload is True:
+                self.unload_sequence(check_state=True)
+            elif self.filament_pos != FILAMENT_POS_UNLOADED:
+                self.unload_sequence()
+
+        # An unrelated unit can home without disturbing the active gate. For the owning unit
+        # (or an empty, as-yet-unselected machine), invalidate the logical selection before the
+        # physical move and restore it afterwards only when requested.
+        scoped_selection = owns_selection or prev_gate == TOOL_GATE_UNKNOWN
+        try:
+            if scoped_selection:
+                self._set_gate_selected(TOOL_GATE_UNKNOWN)
+            selector.home()
+            if scoped_selection and reselect:
+                self.select_gate(prev_gate if prev_gate != TOOL_GATE_UNKNOWN else mmu_unit.first_gate)
+        except MmuError:
+            if scoped_selection:
+                self._set_gate_selected(TOOL_GATE_UNKNOWN)
+            raise
 
 
     def select_gate(self, gate):
         mmu_unit = self.mmu_unit(gate)
         selector = mmu_unit.selector
+
+        # Keep homing outside the selection error handler. home_unit() preserves the owning
+        # gate when an unload fails and invalidates it itself when selector homing fails; the
+        # blanket unselect below would otherwise erase the recovery identity in the first case.
+        if gate != self.gate_selected and not selector.is_homed:
+            self.log_info(f"MMU selector for gate {gate} not homed, will home before continuing")
+            self.home_unit(mmu_unit, reselect=False)
+
         try:
             if gate == self.gate_selected:
                 selector.select_gate(gate) # Always give selector a chance to fix position
             else:
-                # Autohome if necessary
-                if not selector.is_homed:
-                    self.log_info(f"MMU selector for gate {gate} not homed, will home before continuing")
-                    selector.home()
-
                 self._next_gate = gate # Valid only during the gate selection process
-                _prev_gate = self.gate_selected
                 selector.select_gate(gate)
                 self._set_gate_selected(gate) # Will send gate/unit changed events
 

--- a/extras/mmu/unit/selectors/mmu_base_selectors.py
+++ b/extras/mmu/unit/selectors/mmu_base_selectors.py
@@ -333,31 +333,17 @@ class PhysicalSelector(BaseSelector, object):
 
     def home(self, force_unload = None):
         """
-        Home the selector, optionally unloading filament first.
+        Home the physical selector mechanism.
 
-        If bypass is active, homing is skipped. When requested (or required by
-        filament state), triggers an unload sequence before selector homing.
+        Filament unload policy is owned by MmuController.home_unit(), which can
+        make the decision while the selected gate still identifies the correct
+        unit and drive. The argument remains for selector interface compatibility.
         """
         if not self.requires_homing: return
         if self.check_if_unit_bypass(): return
 
         with self.mmu.wrap_action(ACTION_HOMING):
             self.mmu.log_info("Homing MMU %s..." % self.mmu_unit.name)
-
-            if force_unload is not None:
-                self.mmu.log_debug("(asked to %s)" % ("force unload" if force_unload else "not unload"))
-
-            if force_unload is True:
-                # Forced unload case for recovery
-                self.mmu.unload_sequence(check_state=True)
-
-            elif (
-                force_unload is None and
-                self.mmu_unit.manages_gate(self.mmu.gate_selected)
-                and self.mmu.filament_pos != FILAMENT_POS_UNLOADED
-            ):
-                # Automatic unload case
-                self.mmu.unload_sequence()
 
             self._home_selector()
 
@@ -378,7 +364,7 @@ class PhysicalSelector(BaseSelector, object):
         """
         Similar to MMU controller check but localized to specific selector
         """
-        if not self.mmu_unit.manages_gate(self.mmu.gate_selected):
+        if not self.mmu._unit_owns_selection(self.mmu_unit, self.mmu.gate_selected):
             return False
         if self.mmu.tool_selected == TOOL_GATE_BYPASS and self.mmu.filament_pos not in [FILAMENT_POS_UNLOADED]:
             self.mmu.log_error("Operation not possible. MMU is currently using bypass. Unload or select a different gate first")
@@ -520,7 +506,7 @@ class MmuSoaktestSelectorCommand(BaseCommand):
                     gate = random.randint(min_gate, max_gate)
 
                     if random.randint(0, 10) == 0 and home:
-                        mmu.home_unit(mmu_unit)
+                        mmu.home_unit(mmu_unit, force_unload=False)
 
                     if random.randint(0, 10) == 0 and mmu_unit.selector.has_bypass():
                         mmu.log_always("Testing loop %d / %d. Selecting bypass..." % (l + 1, loops))

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -1153,7 +1153,9 @@ class Session:
         homed = []
         for index, unit in enumerate(self.mmu.mmu_machine.units):
             if getattr(unit.selector, 'selector_stepper', None) is not None:
-                self.gcode.run_script('MMU_HOME UNIT=%d' % index)
+                # The harness knows its freshly-created selector paths are empty even when
+                # preloaded gate sensors make the machine-wide filament state ambiguous.
+                self.gcode.run_script('MMU_HOME UNIT=%d FORCE_UNLOAD=0' % index)
                 homed.append(unit.name)
         return homed
 

--- a/test/test_mmu_selector.py
+++ b/test/test_mmu_selector.py
@@ -34,6 +34,8 @@ logging.getLogger().setLevel(logging.CRITICAL)
 
 FILAMENT_POS_UNLOADED = 0
 FILAMENT_POS_LOADED = 10
+FILAMENT_POS_UNKNOWN = -1
+TOOL_GATE_UNKNOWN = -1
 TIP_AT_GATE = -40.0             # past the entry switch: where a user's push leaves it
 
 # mmu_constants.py:209-211, mirrored here for the same reason FILAMENT_POS_* is
@@ -781,11 +783,9 @@ class TestPersistedPositionRestore(unittest.TestCase):
         obey the same invariant as an explicit motors-off - otherwise the next boot would
         confidently restore a gate whose carriage is stuck somewhere else.
 
-        A GUARD, not a demonstration: this passes with or without the selector-side change,
-        because every route to a failed _home_selector already clears the gate through the
-        controller (home_unit unselects before homing, and select_gate's autohome unselects on
-        MmuError). It is here so that if either of those ever stops clearing, the invariant does
-        not quietly depend on them.
+        A GUARD, not a demonstration: every route to a failed _home_selector clears the gate
+        through home_unit(), including select_gate's autohome delegation. It is here so that if
+        either path ever stops clearing, the invariant does not quietly depend on it.
         """
         hh = self.boot(calibrate=True, selected_gate=self.GATE, selector_last_pos=True)
         selector = self.selector()
@@ -877,18 +877,10 @@ class TestPersistedPositionRestore(unittest.TestCase):
         is machine-wide, not per-unit, so on a multi-unit machine it reflects whichever gate is
         currently selected - here, one that belongs to unit0, not unit1.
 
-        home_unit() resets gate_selected to TOOL_GATE_UNKNOWN before calling selector.home() -
-        but only on the branch it already decided owns the selected gate
-        (manages_gate(gate_selected) was True to get there). manages_gate(TOOL_GATE_UNKNOWN) is
-        unconditionally True, so if that reset ever leaked into the OTHER branch (a unit that
-        does not own the selected gate), PhysicalSelector.home()'s automatic-unload check would
-        launder "not my gate" into "TOOL_GATE_UNKNOWN, so automatically mine" and unit1 homing
-        itself would trigger unit0's unload_sequence() - heating included - as a side effect.
-
-        It does not leak: the unowned branch (mmu_controller.py's "Safe to just home selector")
-        never touches gate_selected, so home()'s own re-check of manages_gate(gate_selected)
-        still sees the real, unchanged gate and still evaluates False. This test pins that by
-        construction rather than by inference: unit0 genuinely owns gate 3 with a real (not
+        home_unit() now owns all unload policy and checks real ownership before changing
+        gate_selected. PhysicalSelector.home() is mechanical only, so an unrelated unit never
+        gets a second opportunity to infer ownership from the machine-wide UNKNOWN sentinel.
+        This test pins that by construction: unit0 genuinely owns gate 3 with a real (not
         ambiguous) FILAMENT_POS_LOADED, and both units ask for startup homing at once.
         """
         unload_calls = []
@@ -916,6 +908,188 @@ class TestPersistedPositionRestore(unittest.TestCase):
         self.assertEqual(hh.mmu.gate_selected, self.GATE,
                          "unit1's homing must not disturb unit0's gate selection")
         self.assertEqual(hh.errors, [])
+
+
+class TestHomeUnitUnloadPolicy(unittest.TestCase):
+    """Controller owns filament policy; selector.home() owns only selector motion."""
+
+    GATE = 3
+
+    def setUp(self):
+        self.hh = session('tradrack')
+        self.hh.boot()
+        self.hh.calibrate()
+        self.hh.run_gcode('MMU_HOME UNIT=0')
+        self.hh.heat_extruder(220)
+        self.mmu = self.hh.mmu
+        self.unit = self.mmu.mmu_unit(self.GATE)
+        self.selector = self.unit.selector
+
+    def tearDown(self):
+        self.hh.close()
+
+    def _select_loaded_gate(self, state=FILAMENT_POS_LOADED):
+        self.hh.run_gcode('MMU_SELECT GATE=%d' % self.GATE)
+        self.mmu.set_filament_pos_state(state, silent=True)
+
+    def _record_successful_unload(self):
+        calls = []
+
+        def unload(*args, **kwargs):
+            calls.append((self.mmu.gate_selected, args, kwargs))
+            self.mmu.set_filament_pos_state(FILAMENT_POS_UNLOADED, silent=True)
+
+        self.mmu.unload_sequence = unload
+        return calls
+
+    def test_automatic_policy_unloads_before_forgetting_the_owning_gate(self):
+        self._select_loaded_gate()
+        calls = self._record_successful_unload()
+
+        self.mmu.home_unit(self.unit, force_unload=None, reselect=False)
+
+        self.assertEqual(calls, [(self.GATE, (), {})])
+        self.assertEqual(self.mmu.gate_selected, TOOL_GATE_UNKNOWN)
+        self.assertTrue(self.selector.is_homed)
+
+    def test_automatic_policy_can_recover_unknown_filament_when_gate_is_known(self):
+        self._select_loaded_gate(FILAMENT_POS_UNKNOWN)
+        calls = self._record_successful_unload()
+
+        self.mmu.home_unit(self.unit, force_unload=None, reselect=False)
+
+        self.assertEqual(calls, [(self.GATE, (), {})])
+        self.assertEqual(self.mmu.gate_selected, TOOL_GATE_UNKNOWN)
+
+    def test_forced_policy_preserves_gate_identity_during_state_recovery(self):
+        self._select_loaded_gate(FILAMENT_POS_UNKNOWN)
+        calls = self._record_successful_unload()
+
+        self.mmu.home_unit(self.unit, force_unload=True, reselect=False)
+
+        self.assertEqual(calls, [(self.GATE, (), {'check_state': True})])
+        self.assertEqual(self.mmu.gate_selected, TOOL_GATE_UNKNOWN)
+
+    def test_gcode_force_unload_one_uses_forced_policy(self):
+        self._select_loaded_gate()
+        calls = self._record_successful_unload()
+
+        self.hh.run_gcode('MMU_HOME UNIT=0 FORCE_UNLOAD=1')
+
+        self.assertEqual(calls, [(self.GATE, (), {'check_state': True})])
+        self.assertEqual(self.hh.errors, [])
+
+    def test_gcode_force_unload_zero_never_unloads(self):
+        self._select_loaded_gate()
+        calls = self._record_successful_unload()
+
+        self.hh.run_gcode('MMU_HOME UNIT=0 FORCE_UNLOAD=0')
+
+        self.assertEqual(calls, [])
+        self.assertEqual(self.mmu.gate_selected, self.GATE)
+        self.assertTrue(any('has filament loaded' in error for error in self.hh.errors))
+
+    def test_default_gcode_home_performs_a_real_automatic_unload(self):
+        self.hh.place_filament(self.GATE, position=TIP_AT_GATE)
+        self.hh.run_gcode('MMU_PRELOAD GATE=%d' % self.GATE)
+        self.hh.run_gcode('MMU_SELECT GATE=%d' % self.GATE)
+        self.hh.run_gcode('MMU_LOAD')
+        self.assertEqual(self.mmu.filament_pos, FILAMENT_POS_LOADED)
+
+        self.hh.run_gcode('MMU_HOME UNIT=0')
+
+        self.assertEqual(self.mmu.filament_pos, FILAMENT_POS_UNLOADED)
+        self.assertTrue(self.selector.is_homed)
+        self.assertEqual(self.hh.errors, [])
+
+    def test_failed_unload_keeps_the_owning_gate_for_recovery(self):
+        self._select_loaded_gate()
+        calls = []
+
+        def fail_unload(*args, **kwargs):
+            calls.append(self.mmu.gate_selected)
+            from extras.mmu.mmu_utils import MmuError
+            raise MmuError('simulated unload failure')
+
+        self.mmu.unload_sequence = fail_unload
+
+        with self.assertRaisesRegex(Exception, 'simulated unload failure'):
+            self.mmu.home_unit(self.unit, force_unload=None, reselect=False)
+
+        self.assertEqual(calls, [self.GATE])
+        self.assertEqual(self.mmu.gate_selected, self.GATE)
+
+    def test_autohome_unload_failure_also_keeps_the_owning_gate(self):
+        self._select_loaded_gate()
+        self.selector.is_homed = False
+
+        def fail_unload(*args, **kwargs):
+            from extras.mmu.mmu_utils import MmuError
+            raise MmuError('simulated autohome unload failure')
+
+        self.mmu.unload_sequence = fail_unload
+
+        with self.assertRaisesRegex(Exception, 'simulated autohome unload failure'):
+            self.mmu.select_gate(self.GATE + 1)
+
+        self.assertEqual(self.mmu.gate_selected, self.GATE)
+
+    def test_unknown_gate_with_unresolved_filament_requires_recovery(self):
+        self.mmu.unselect_gate()
+        self.mmu.set_filament_pos_state(FILAMENT_POS_UNKNOWN, silent=True)
+        unload_calls = self._record_successful_unload()
+        home_calls = []
+        self.selector._home_selector = lambda: home_calls.append(True)
+
+        with self.assertRaisesRegex(Exception, 'MMU_RECOVER GATE'):
+            self.mmu.home_unit(self.unit, force_unload=None, reselect=False)
+
+        self.assertEqual(unload_calls, [])
+        self.assertEqual(home_calls, [])
+        self.assertEqual(self.mmu.gate_selected, TOOL_GATE_UNKNOWN)
+
+    def test_explicit_never_unload_can_home_with_unknown_ownership(self):
+        self.mmu.unselect_gate()
+        self.mmu.set_filament_pos_state(FILAMENT_POS_UNKNOWN, silent=True)
+        unload_calls = self._record_successful_unload()
+        home_calls = []
+        self.selector._home_selector = lambda: home_calls.append(True)
+
+        self.mmu.home_unit(self.unit, force_unload=False, reselect=False)
+
+        self.assertEqual(unload_calls, [])
+        self.assertEqual(home_calls, [True])
+        self.assertEqual(self.mmu.gate_selected, TOOL_GATE_UNKNOWN)
+
+    def test_selector_home_is_mechanical_and_never_infers_filament_ownership(self):
+        self._select_loaded_gate()
+        unload_calls = self._record_successful_unload()
+        home_calls = []
+        self.selector._home_selector = lambda: home_calls.append(self.mmu.gate_selected)
+
+        self.selector.home()
+
+        self.assertEqual(unload_calls, [])
+        self.assertEqual(home_calls, [self.GATE])
+        self.assertEqual(self.mmu.gate_selected, self.GATE)
+
+    def test_homing_another_unit_never_unloads_the_active_units_gate(self):
+        self.hh.close()
+        self.hh = session('ercf_vvd')
+        self.hh.boot()
+        self.hh.calibrate()
+        self.mmu = self.hh.mmu
+        self.hh.run_gcode('MMU_HOME UNIT=0')
+        self.hh.run_gcode('MMU_SELECT GATE=3')
+        self.mmu.set_filament_pos_state(FILAMENT_POS_LOADED, silent=True)
+        unload_calls = self._record_successful_unload()
+        sibling = self.mmu.mmu_machine.units[1]
+
+        self.mmu.home_unit(sibling, force_unload=True, reselect=False)
+
+        self.assertEqual(unload_calls, [])
+        self.assertEqual(self.mmu.gate_selected, self.GATE)
+        self.assertTrue(sibling.selector.is_homed)
 
 
 class TestTipFormingEffect(unittest.TestCase):


### PR DESCRIPTION
## Summary
- move selector-homing unload policy into home_unit() so the owning gate remains known through automatic and forced unloads
- make PhysicalSelector.home() mechanical-only and route selector autohoming through the controller
- preserve gate identity when unloading fails, isolate sibling units, and scope bypass ownership to the active unit
- normalize FORCE_UNLOAD=0/1 behavior and require explicit FORCE_UNLOAD=0 when homing with unknown ownership without unloading
- add focused coverage for automatic, forced, failed, unknown-state, sibling-unit, and G-code homing paths

## Validation
- make ALL=1 test
- 1072 tests passed (1 skipped, 4 expected failures)

This PR is independent of the selector implementation fixes in #1069.

---

## Independent review (Claude)

Reviewed against Happy Hare's recent `startup_home_selector` boot-time safety work (#1065, #1066), since this PR touches the same `home_unit()` / `PhysicalSelector.home()` boundary.

- **Compatible with, and strengthens, the startup-movement fix.** Traced every branch of the new `home_unit()` against all boot-time cases (owning unit unloaded / owning unit loaded-or-unknown / sibling unit any state). The boot autohoming loop now calls `home_unit(u, force_unload=False)` explicitly, making it structurally impossible for the boot path to ever reach `unload_sequence()` - stronger than #1065, which relied on an upstream filter making that path merely unreachable in practice.
- **Does not touch `recover_filament_pos()` / `cmd_MMU_BOOTUP`'s `can_heat=False` sanity check.** The issue #449 fix (no automatic extruder heating on a plain restart) is untouched by this PR.
- **Verified, not just read:** checked out this branch (`a1bec45e`) into an isolated worktree and ran the full suite independently - `1072 tests, OK (skipped=1, expected failures=4)`, matching the clean baseline. Both `test_startup_home_selector_skips_rather_than_guess_on_unresolved_filament_state` and `test_startup_home_selector_does_not_launder_a_sibling_units_loaded_gate` pass unmodified in behavior (this PR only updated their docstrings to describe the new architecture).
- **One behavior change worth flagging explicitly for reviewers/users**, not a bug: a bare `MMU_HOME` (or the autohome `MMU_SELECT` triggers on an unhomed selector) with no gate currently selected and filament position unresolved now raises `MmuError` requiring `MMU_RECOVER GATE=xx` or explicit `FORCE_UNLOAD=0`, instead of silently attempting a guess-and-unload as before. This is deliberate and covered by `test_unknown_gate_with_unresolved_filament_requires_recovery`, and is arguably correct for the same reason #1065 was needed - but it is new required user action in an edge case that used to "just work" silently, so it's worth calling out for anyone whose macros lean on the old behavior.
- No other correctness issues found. `owns_gate()` (used by the new `_unit_owns_selection()` helper) is a pre-existing method, not new, so there's no undefined-method risk.
