### PR TITLE
Fix MMU status display alignment and bypass state

### DIFF
--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -1060,11 +1060,15 @@ class MmuController(MmuFilamentMovement):
         msg_selct = "Selct: "
         bypass_shown = False
 
-        if self.filament_pos < FILAMENT_POS_START_BOWDEN:
-            bypass_fil_swatch = bypass_ext_swatch = UI_SEPARATOR
-        else:
+        bypass_has_filament = (
+            self.gate_selected == TOOL_GATE_BYPASS and
+            self.filament_pos >= FILAMENT_POS_START_BOWDEN
+        )
+        if bypass_has_filament:
             bypass_fil_swatch = UI_SOLID_SQUARE
             bypass_ext_swatch = UI_SOLID_TRIANGLE
+        else:
+            bypass_fil_swatch = bypass_ext_swatch = UI_SEPARATOR
 
         for unit in self.mmu_machine.units:
             show_bypass = unit is self.mmu_machine.unit_with_bypass
@@ -1111,7 +1115,10 @@ class MmuController(MmuFilamentMovement):
             msg_gates += sep
             msg_avail += sep
             msg_tools += "".join(tool_strings) + sep
-            msg_selct += ("".join(select_strings) + selct_char)[:len(gate_indices) * 4 + 1] + (divider if not is_last else "")
+            unit_selection = "".join(select_strings)
+            if self.gate_selected not in gate_indices:
+                unit_selection += selct_char
+            msg_selct += unit_selection + (divider if not is_last else "")
             msg_selct = msg_selct.replace("*", fil_swatch)
 
         if self.gate_selected == TOOL_GATE_BYPASS and not bypass_shown:

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -1102,7 +1102,9 @@ class MmuController(MmuFilamentMovement):
                     tool_strings.append(("|%s " % (tool_str if tool_str else " {} ".format(UI_SEPARATOR)))[:4])
 
                 if g == self.gate_selected:
-                    if self.filament_pos < FILAMENT_POS_START_BOWDEN:
+                    if g == TOOL_GATE_BYPASS:
+                        ext_swatch = bypass_ext_swatch
+                    elif self.filament_pos < FILAMENT_POS_START_BOWDEN:
                         ext_swatch = UI_SEPARATOR
                     else:
                         ext_swatch = self._get_filament_char(g, show_swatch=True, symbol=UI_SOLID_TRIANGLE)


### PR DESCRIPTION
## Summary

- preserve selector-row alignment when selected filament has color markup
- show bypass availability only when filament is actually loaded through bypass
- render the loaded bypass selector with the triangle marker

## Tests

- PYTHONPATH=installer/lib/kconfiglib venv/bin/python -m unittest test.test_mmu_console.TestTheDefaultProfile
- manual make console verification for normal-gate and bypass display states