### PR TITLE
Preserve dynamic Kconfig device selections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,8 @@ install_targets := \
 	$(KLIPPER_CONFIG_HOME)/$(MOONRAKER_CONFIG_FILE)
 
 kconfig_sources := \
-	$(wildcard $(SRC)/installer/Kconfig* $(SRC)/installer/**/Kconfig*)
+	$(wildcard $(SRC)/installer/Kconfig* $(SRC)/installer/**/Kconfig*) \
+	$(SRC)/installer/lib/kconfiglib/kconfigfunctions.py
 
 
 ############################

--- a/installer/Kconfig
+++ b/installer/Kconfig
@@ -11,9 +11,9 @@
 # changes them. Also when they are changed from default values menuconfig will mark as
 # "(NOT DEFAULT)" and allow the "r" keystroke to reset back to default value
 #   
-# Other names will be store and handled as normal Kconfig variables. Therefore if you
-# don't want the abilty to "reset to default" and you want past values to be "sticky" you
-# must use alternative names (or unamed choice)
+# Other names are stored and handled as normal Kconfig variables. For one of the special
+# names above, add the 'sticky' property when a default-valued assignment must remain
+# explicit across subsequent loads instead of following a recalculated default.
 #
 # Some Happy Hare augmented features:
 # Kconfig:
@@ -44,16 +44,17 @@
 # 2. Added float type
 # 3. Option 'force_show'to force display even if dependency isn't met
 # 4. Recording of default value with #~DEFAULT~# magic token
-# 5. repeat expansion macro to avoid multiple lines (can be nested):
+# 5. Option 'sticky' to persist a default-valued symbol without the #~DEFAULT~# marker
+# 6. repeat expansion macro to avoid multiple lines (can be nested):
 #      @repeat var=i min=0 max=3@
 #        config PARAM_MMU_CANBUS_UNIT_$(i)
 #          string "CANbus UUID for MMU unit $(i)"
 #      @endrepeat@
-# 6. help added to menus
-# 7. "if XX" construct is allowed on comment lines
-# 8. Added 'array_editor <separator> [size]' option for strings that represent lists
+# 7. help added to menus
+# 8. "if XX" construct is allowed on comment lines
+# 9. Added 'array_editor <separator> [size]' option for strings that represent lists
 #    E.g. `array_editor ";" PARAM_NUM_GATES
-# 9. Font manipulators like [[B]]xx[[/B] can be used in prompts and comments
+# 10. Font manipulators like [[B]]xx[[/B] can be used in prompts and comments
 #    and include: B,BOLD,DIM,U,UNDERLINE,REV,REVERSE,C:n,COLOR:n (color), RESET
 #
 # Menuconfig:

--- a/installer/Kconfig
+++ b/installer/Kconfig
@@ -11,9 +11,8 @@
 # changes them. Also when they are changed from default values menuconfig will mark as
 # "(NOT DEFAULT)" and allow the "r" keystroke to reset back to default value
 #   
-# Other names are stored and handled as normal Kconfig variables. For one of the special
-# names above, add the 'sticky' property when a default-valued assignment must remain
-# explicit across subsequent loads instead of following a recalculated default.
+# Other names are stored and handled as normal Kconfig variables. Unlike the special names
+# above, their saved values are always loaded as explicit assignments.
 #
 # Some Happy Hare augmented features:
 # Kconfig:
@@ -44,7 +43,8 @@
 # 2. Added float type
 # 3. Option 'force_show'to force display even if dependency isn't met
 # 4. Recording of default value with #~DEFAULT~# magic token
-# 5. Option 'sticky' to persist a default-valued symbol without the #~DEFAULT~# marker
+# 5. Preprocessor function 'saved-config-value' to read a symbol's previous assignment from
+#    KCONFIG_CONFIG before normal config loading, including lines marked with #~DEFAULT~#
 # 6. repeat expansion macro to avoid multiple lines (can be nested):
 #      @repeat var=i min=0 max=3@
 #        config PARAM_MMU_CANBUS_UNIT_$(i)

--- a/installer/connection/Kconfig.buffer_mcu
+++ b/installer/connection/Kconfig.buffer_mcu
@@ -63,6 +63,7 @@ if CHOICE_BUFFER_CONNECTION_TYPE_SERIAL
 
   config PARAM_BUFFER_SERIAL_DEVICE
     string
+    sticky
     @repeat var=i min=1 max=10@
     default "$(serial_device,$(i))" if $(buffer_serial_config,$(i))
     @endrepeat@
@@ -107,6 +108,7 @@ if CHOICE_BUFFER_CONNECTION_TYPE_CANBUS
 
   config PARAM_BUFFER_CANBUS_UUID
     string
+    sticky
     @repeat var=i min=1 max=10@
     default "$(canbus_uuid,$(i))" if $(buffer_canbus_config,$(i))
     @endrepeat@

--- a/installer/connection/Kconfig.buffer_mcu
+++ b/installer/connection/Kconfig.buffer_mcu
@@ -35,10 +35,15 @@ if CHOICE_BUFFER_CONNECTION_TYPE_SERIAL
 
   choice CHOICE_BUFFER_SERIAL_CONNECTION
     prompt "Select serial device for sync-feedback buffer"
+    default CHOICE_BUFFER_SERIAL_DEVICE_PREVIOUS if "$(saved-config-value,PARAM_BUFFER_SERIAL_DEVICE)" != ""
     help
       MCU connection for sync-feedback buffer
       Select the serial device connected to the sync-feedback buffer  mcu
       or select "Other" and enter it manually.
+
+    config CHOICE_BUFFER_SERIAL_DEVICE_PREVIOUS
+      bool "Previous selection: $(saved-config-value,PARAM_BUFFER_SERIAL_DEVICE)"
+      depends on "$(saved-config-value,PARAM_BUFFER_SERIAL_DEVICE)" != ""
 
     @repeat var=i min=1 max=10@
     config $(buffer_serial_config,$(i))
@@ -63,7 +68,7 @@ if CHOICE_BUFFER_CONNECTION_TYPE_SERIAL
 
   config PARAM_BUFFER_SERIAL_DEVICE
     string
-    sticky
+    default "$(saved-config-value,PARAM_BUFFER_SERIAL_DEVICE)" if CHOICE_BUFFER_SERIAL_DEVICE_PREVIOUS
     @repeat var=i min=1 max=10@
     default "$(serial_device,$(i))" if $(buffer_serial_config,$(i))
     @endrepeat@
@@ -79,10 +84,15 @@ if CHOICE_BUFFER_CONNECTION_TYPE_CANBUS
 
   choice CHOICE_BUFFER_CANBUS_CONNECTION
     prompt "Select canbus UUID for BUFFER"
+    default CHOICE_BUFFER_CANBUS_UUID_PREVIOUS if "$(saved-config-value,PARAM_BUFFER_CANBUS_UUID)" != ""
     help
       MCU connection for BUFFER
       Select the CANbus uuid belonging to the BUFFER's mcu or select
       "Other" and enter it manually.
+
+    config CHOICE_BUFFER_CANBUS_UUID_PREVIOUS
+      bool "Previous selection: $(saved-config-value,PARAM_BUFFER_CANBUS_UUID)"
+      depends on "$(saved-config-value,PARAM_BUFFER_CANBUS_UUID)" != ""
 
     @repeat var=i min=1 max=10@
     config $(buffer_canbus_config,$(i))
@@ -108,7 +118,7 @@ if CHOICE_BUFFER_CONNECTION_TYPE_CANBUS
 
   config PARAM_BUFFER_CANBUS_UUID
     string
-    sticky
+    default "$(saved-config-value,PARAM_BUFFER_CANBUS_UUID)" if CHOICE_BUFFER_CANBUS_UUID_PREVIOUS
     @repeat var=i min=1 max=10@
     default "$(canbus_uuid,$(i))" if $(buffer_canbus_config,$(i))
     @endrepeat@

--- a/installer/connection/Kconfig.mmu_mcu
+++ b/installer/connection/Kconfig.mmu_mcu
@@ -65,6 +65,7 @@ if !MMU_HAS_PER_GATE_MCU
 
     config PARAM_MMU_SERIAL_DEVICE
       string
+      sticky
       @repeat var=i min=1 max=10@
       default "$(serial_device,$(i))" if $(mmu_serial_config,$(i))
       @endrepeat@
@@ -96,6 +97,7 @@ if !MMU_HAS_PER_GATE_MCU
 
     config PARAM_MMU_CANBUS_UUID
       string
+      sticky
       @repeat var=i min=1 max=10@
       default "$(canbus_uuid,$(i))" if $(mmu_canbus_config,$(i))
       @endrepeat@
@@ -142,6 +144,7 @@ if MMU_HAS_PER_GATE_MCU
 
       config PARAM_MMU_SERIAL_DEVICE_$(gate)
         string
+        sticky
         @repeat var=i min=1 max=10@
         default "$(serial_device,$(i))" if CHOICE_MMU_SERIAL_DEVICE_$(gate)_$(i)
         @endrepeat@
@@ -173,6 +176,7 @@ if MMU_HAS_PER_GATE_MCU
 
       config PARAM_MMU_CANBUS_UUID_$(gate)
         string
+        sticky
         @repeat var=i min=1 max=10@
         default "$(canbus_uuid,$(i))" if CHOICE_MMU_CANBUS_UUID_$(gate)_$(i)
         @endrepeat@

--- a/installer/connection/Kconfig.mmu_mcu
+++ b/installer/connection/Kconfig.mmu_mcu
@@ -45,7 +45,12 @@ if !MMU_HAS_PER_GATE_MCU
 
     choice CHOICE_MMU_SERIAL_CONNECTION
       prompt "Select serial device for MMU"
+      default CHOICE_MMU_SERIAL_DEVICE_PREVIOUS if "$(saved-config-value,PARAM_MMU_SERIAL_DEVICE)" != ""
       default CHOICE_MMU_SERIAL_DEVICE_OTHER if !$(serial_exists,1)
+
+      config CHOICE_MMU_SERIAL_DEVICE_PREVIOUS
+        bool "Previous selection: $(saved-config-value,PARAM_MMU_SERIAL_DEVICE)"
+        depends on "$(saved-config-value,PARAM_MMU_SERIAL_DEVICE)" != ""
 
       @repeat var=i min=1 max=10@
       config $(mmu_serial_config,$(i))
@@ -65,7 +70,7 @@ if !MMU_HAS_PER_GATE_MCU
 
     config PARAM_MMU_SERIAL_DEVICE
       string
-      sticky
+      default "$(saved-config-value,PARAM_MMU_SERIAL_DEVICE)" if CHOICE_MMU_SERIAL_DEVICE_PREVIOUS
       @repeat var=i min=1 max=10@
       default "$(serial_device,$(i))" if $(mmu_serial_config,$(i))
       @endrepeat@
@@ -77,7 +82,12 @@ if !MMU_HAS_PER_GATE_MCU
 
     choice CHOICE_MMU_CANBUS_CONNECTION
       prompt "Select canbus UUID for MMU"
+      default CHOICE_MMU_CANBUS_UUID_PREVIOUS if "$(saved-config-value,PARAM_MMU_CANBUS_UUID)" != ""
       default CHOICE_MMU_CANBUS_UUID_OTHER if $(canbus_uuid_count) = 0
+
+      config CHOICE_MMU_CANBUS_UUID_PREVIOUS
+        bool "Previous selection: $(saved-config-value,PARAM_MMU_CANBUS_UUID)"
+        depends on "$(saved-config-value,PARAM_MMU_CANBUS_UUID)" != ""
 
       @repeat var=i min=1 max=10@
       config $(mmu_canbus_config,$(i))
@@ -97,7 +107,7 @@ if !MMU_HAS_PER_GATE_MCU
 
     config PARAM_MMU_CANBUS_UUID
       string
-      sticky
+      default "$(saved-config-value,PARAM_MMU_CANBUS_UUID)" if CHOICE_MMU_CANBUS_UUID_PREVIOUS
       @repeat var=i min=1 max=10@
       default "$(canbus_uuid,$(i))" if $(mmu_canbus_config,$(i))
       @endrepeat@
@@ -124,7 +134,12 @@ if MMU_HAS_PER_GATE_MCU
 
       choice CHOICE_MMU_SERIAL_CONNECTION_$(gate)
         prompt "Select serial device for MMU gate $(gate)"
+        default CHOICE_MMU_SERIAL_DEVICE_PREVIOUS_$(gate) if "$(saved-config-value,PARAM_MMU_SERIAL_DEVICE_$(gate))" != ""
         default CHOICE_MMU_SERIAL_DEVICE_OTHER_$(gate) if !$(serial_exists,1)
+
+        config CHOICE_MMU_SERIAL_DEVICE_PREVIOUS_$(gate)
+          bool "Previous selection: $(saved-config-value,PARAM_MMU_SERIAL_DEVICE_$(gate))"
+          depends on "$(saved-config-value,PARAM_MMU_SERIAL_DEVICE_$(gate))" != ""
 
         @repeat var=i min=1 max=10@
         config CHOICE_MMU_SERIAL_DEVICE_$(gate)_$(i)
@@ -144,7 +159,7 @@ if MMU_HAS_PER_GATE_MCU
 
       config PARAM_MMU_SERIAL_DEVICE_$(gate)
         string
-        sticky
+        default "$(saved-config-value,PARAM_MMU_SERIAL_DEVICE_$(gate))" if CHOICE_MMU_SERIAL_DEVICE_PREVIOUS_$(gate)
         @repeat var=i min=1 max=10@
         default "$(serial_device,$(i))" if CHOICE_MMU_SERIAL_DEVICE_$(gate)_$(i)
         @endrepeat@
@@ -156,7 +171,12 @@ if MMU_HAS_PER_GATE_MCU
 
       choice CHOICE_MMU_CANBUS_CONNECTION_$(gate)
         prompt "Select canbus UUID for MMU gate $(gate)"
+        default CHOICE_MMU_CANBUS_UUID_PREVIOUS_$(gate) if "$(saved-config-value,PARAM_MMU_CANBUS_UUID_$(gate))" != ""
         default CHOICE_MMU_CANBUS_UUID_OTHER_$(gate) if $(canbus_uuid_count) = 0
+
+        config CHOICE_MMU_CANBUS_UUID_PREVIOUS_$(gate)
+          bool "Previous selection: $(saved-config-value,PARAM_MMU_CANBUS_UUID_$(gate))"
+          depends on "$(saved-config-value,PARAM_MMU_CANBUS_UUID_$(gate))" != ""
 
         @repeat var=i min=1 max=10@
         config CHOICE_MMU_CANBUS_UUID_$(gate)_$(i)
@@ -176,7 +196,7 @@ if MMU_HAS_PER_GATE_MCU
 
       config PARAM_MMU_CANBUS_UUID_$(gate)
         string
-        sticky
+        default "$(saved-config-value,PARAM_MMU_CANBUS_UUID_$(gate))" if CHOICE_MMU_CANBUS_UUID_PREVIOUS_$(gate)
         @repeat var=i min=1 max=10@
         default "$(canbus_uuid,$(i))" if CHOICE_MMU_CANBUS_UUID_$(gate)_$(i)
         @endrepeat@

--- a/installer/lib/kconfiglib/kconfigfunctions.py
+++ b/installer/lib/kconfiglib/kconfigfunctions.py
@@ -1,0 +1,73 @@
+"""Happy Hare Kconfig preprocessor functions."""
+
+import io
+import os
+import re
+
+
+HH_DEFAULT_TOKEN = " #~DEFAULT~#"
+_STRING_VALUE_RE = re.compile(r'^"((?:[^\\"]|\\.)*)"$')
+_UNESCAPE_RE = re.compile(r"\\(.)")
+_config_cache = {}
+
+
+def _config_path(kconf):
+    filename = os.environ.get("KCONFIG_CONFIG", ".config")
+    if os.path.exists(filename):
+        return filename
+
+    srctree_filename = os.path.join(kconf.srctree, filename)
+    if os.path.exists(srctree_filename):
+        return srctree_filename
+
+    return filename
+
+
+def _saved_values(kconf):
+    filename = _config_path(kconf)
+    try:
+        stat = os.stat(filename)
+    except OSError:
+        return {}
+
+    stamp = (getattr(stat, "st_mtime_ns", stat.st_mtime), stat.st_size)
+    cache_key = (os.path.realpath(filename), stamp)
+    cached = _config_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    prefix = os.environ.get("CONFIG_", "CONFIG_")
+    values = {}
+    with io.open(filename, "r", encoding=kconf._encoding or "utf-8") as config:
+        for line in config:
+            line = line.rstrip()
+            if not line.startswith(prefix) or "=" not in line:
+                continue
+
+            name, value = line.split("=", 1)
+            if value.endswith(HH_DEFAULT_TOKEN):
+                value = value[:-len(HH_DEFAULT_TOKEN)]
+
+            match = _STRING_VALUE_RE.match(value)
+            if match:
+                value = _UNESCAPE_RE.sub(r"\1", match.group(1))
+
+            values[name[len(prefix):]] = value
+
+    _config_cache.clear()
+    _config_cache[cache_key] = values
+    return values
+
+
+def _escape_kconfig_string(value):
+    return value.replace("\\", r"\\").replace('"', r'\"')
+
+
+def saved_config_value(kconf, _, symbol):
+    """Return SYMBOL's last assignment, including #~DEFAULT~# assignments."""
+    return _escape_kconfig_string(_saved_values(kconf).get(symbol, ""))
+
+
+functions = {
+    "saved-config-value": (saved_config_value, 1, 1),
+}

--- a/installer/lib/kconfiglib/kconfiglib.py
+++ b/installer/lib/kconfiglib/kconfiglib.py
@@ -1701,7 +1701,6 @@ class Kconfig(object):
                 if (
                     isinstance(item, Symbol) and
                     not item._was_set and
-                    not item.sticky and
                     item.name.startswith(('PARAM_', 'VAR_', 'PIN_', 'BOOL_', 'MMU_HAS_', 'CHOICE_', 'UNSELECT_'))
                 ) or (
                     isinstance(item, Choice) and
@@ -3486,12 +3485,6 @@ class Kconfig(object):
 
                 node.forceshow = True
 
-            elif t0 is _T_STICKY: # Happy Hare: Added to retain default-valued Symbols
-                if node.item.__class__ is not Symbol:
-                    self._parse_error("sticky is only valid for symbols")
-
-                node.item.sticky = True
-
             elif t0 is _T_ARRAY_EDITOR: # Happy Hare: Added multi-line/array editor for STRING symbols
                 if node.item.__class__ is not Symbol:
                     self._parse_error("array_editor is only valid for symbols")
@@ -4710,13 +4703,6 @@ class Symbol(object):
       value. Must be given unquoted in the Kconfig file -- a quoted string
       there is parsed as a constant rather than a symbol reference.
 
-    sticky:
-      Happy Hare: Added. False for symbols without a 'sticky' property, and
-      True when the property is present. A sticky symbol whose value matches
-      its default is written to .config without Happy Hare's #~DEFAULT~#
-      marker, so the assignment is retained on subsequent loads instead of
-      being discarded in favor of a newly calculated default.
-
     is_allnoconfig_y:
       True if the symbol has 'option allnoconfig_y' set on it. This has no
       effect internally (except when printing symbols), but can be checked by
@@ -4756,7 +4742,6 @@ class Symbol(object):
         "ranges",
         "rev_dep",
         "selects",
-        "sticky", # Happy Hare: Added
         "user_value",
         "weak_rev_dep",
     )
@@ -5316,7 +5301,6 @@ class Symbol(object):
         # Symbol gets a .config entry.
 
         self.is_allnoconfig_y = \
-        self.sticky = \
         self._was_set = \
         self._write_to_conf = False
 
@@ -7613,12 +7597,11 @@ except AttributeError:
     _T_RSOURCE,
     _T_SELECT,
     _T_SOURCE,
-    _T_STICKY, # Happy Hare: Added
     _T_STRING,
     _T_TRISTATE,
     _T_UNEQUAL,
     _T_VISIBLE,
-) = range(1, 57) # Happy Hare: 51->57
+) = range(1, 56) # Happy Hare: 51->56
 
 # Keyword to token map, with the get() method assigned directly as a small
 # optimization
@@ -7668,7 +7651,6 @@ _get_keyword = {
     "rsource":        _T_RSOURCE,
     "select":         _T_SELECT,
     "source":         _T_SOURCE,
-    "sticky":         _T_STICKY, # Happy Hare: Added
     "string":         _T_STRING,
     "tristate":       _T_TRISTATE,
     "visible":        _T_VISIBLE,

--- a/installer/lib/kconfiglib/kconfiglib.py
+++ b/installer/lib/kconfiglib/kconfiglib.py
@@ -1701,6 +1701,7 @@ class Kconfig(object):
                 if (
                     isinstance(item, Symbol) and
                     not item._was_set and
+                    not item.sticky and
                     item.name.startswith(('PARAM_', 'VAR_', 'PIN_', 'BOOL_', 'MMU_HAS_', 'CHOICE_', 'UNSELECT_'))
                 ) or (
                     isinstance(item, Choice) and
@@ -3485,6 +3486,12 @@ class Kconfig(object):
 
                 node.forceshow = True
 
+            elif t0 is _T_STICKY: # Happy Hare: Added to retain default-valued Symbols
+                if node.item.__class__ is not Symbol:
+                    self._parse_error("sticky is only valid for symbols")
+
+                node.item.sticky = True
+
             elif t0 is _T_ARRAY_EDITOR: # Happy Hare: Added multi-line/array editor for STRING symbols
                 if node.item.__class__ is not Symbol:
                     self._parse_error("array_editor is only valid for symbols")
@@ -4703,6 +4710,13 @@ class Symbol(object):
       value. Must be given unquoted in the Kconfig file -- a quoted string
       there is parsed as a constant rather than a symbol reference.
 
+    sticky:
+      Happy Hare: Added. False for symbols without a 'sticky' property, and
+      True when the property is present. A sticky symbol whose value matches
+      its default is written to .config without Happy Hare's #~DEFAULT~#
+      marker, so the assignment is retained on subsequent loads instead of
+      being discarded in favor of a newly calculated default.
+
     is_allnoconfig_y:
       True if the symbol has 'option allnoconfig_y' set on it. This has no
       effect internally (except when printing symbols), but can be checked by
@@ -4742,6 +4756,7 @@ class Symbol(object):
         "ranges",
         "rev_dep",
         "selects",
+        "sticky", # Happy Hare: Added
         "user_value",
         "weak_rev_dep",
     )
@@ -5301,6 +5316,7 @@ class Symbol(object):
         # Symbol gets a .config entry.
 
         self.is_allnoconfig_y = \
+        self.sticky = \
         self._was_set = \
         self._write_to_conf = False
 
@@ -7597,11 +7613,12 @@ except AttributeError:
     _T_RSOURCE,
     _T_SELECT,
     _T_SOURCE,
+    _T_STICKY, # Happy Hare: Added
     _T_STRING,
     _T_TRISTATE,
     _T_UNEQUAL,
     _T_VISIBLE,
-) = range(1, 56) # Happy Hare: 51->56
+) = range(1, 57) # Happy Hare: 51->57
 
 # Keyword to token map, with the get() method assigned directly as a small
 # optimization
@@ -7651,6 +7668,7 @@ _get_keyword = {
     "rsource":        _T_RSOURCE,
     "select":         _T_SELECT,
     "source":         _T_SOURCE,
+    "sticky":         _T_STICKY, # Happy Hare: Added
     "string":         _T_STRING,
     "tristate":       _T_TRISTATE,
     "visible":        _T_VISIBLE,

--- a/test/test_mmu_config.py
+++ b/test/test_mmu_config.py
@@ -13,7 +13,9 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+import os
 import re
+import tempfile
 import unittest
 
 from test.hh import cfg, profiles
@@ -263,6 +265,96 @@ class TestSelectorTypeChoice(unittest.TestCase):
                 'CHOICE_SELECTOR_TYPE_LINEAR_MULTI_GEAR_SELECTOR': True,
             })
         self.assertEqual(kc.syms['PARAM_SELECTOR_TYPE'].str_value, 'LinearMultiGearSelector')
+
+
+class TestStickyKconfigSymbols(unittest.TestCase):
+    """The sticky property pins selected hardware identifiers across installer runs."""
+
+    KCONFIG_TEMPLATE = '''\
+mainmenu "Sticky property test"
+
+config PARAM_FOLLOWS_DEFAULT
+  string
+  default "%s"
+
+config PARAM_STICKY
+  string
+  sticky
+  default "%s"
+'''
+
+    @classmethod
+    def setUpClass(cls):
+        cfg._prepare_imports()
+        import kconfiglib
+        cls.kconfiglib = kconfiglib
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.kconfig_path = os.path.join(self.tmpdir.name, 'Kconfig')
+        self.config_path = os.path.join(self.tmpdir.name, '.config')
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _parse(self, default):
+        with open(self.kconfig_path, 'w') as f:
+            f.write(self.KCONFIG_TEMPLATE % (default, default))
+        return self.kconfiglib.Kconfig(self.kconfig_path, warn=False)
+
+    def test_sticky_default_is_saved_as_an_explicit_assignment(self):
+        kc = self._parse('first')
+        kc.write_config(self.config_path, save_old=False)
+
+        with open(self.config_path) as f:
+            saved = f.read()
+
+        self.assertIn('CONFIG_PARAM_FOLLOWS_DEFAULT="first" #~DEFAULT~#', saved)
+        self.assertIn('CONFIG_PARAM_STICKY="first"\n', saved)
+        self.assertNotIn('CONFIG_PARAM_STICKY="first" #~DEFAULT~#', saved)
+        self.assertFalse(kc.syms['PARAM_FOLLOWS_DEFAULT'].sticky)
+        self.assertTrue(kc.syms['PARAM_STICKY'].sticky)
+
+    def test_reload_keeps_sticky_assignment_but_recalculates_normal_default(self):
+        self._parse('first').write_config(self.config_path, save_old=False)
+        kc = self._parse('second')
+        kc.load_config(self.config_path)
+
+        normal = kc.syms['PARAM_FOLLOWS_DEFAULT']
+        sticky = kc.syms['PARAM_STICKY']
+        self.assertIsNone(normal.user_value)
+        self.assertEqual(normal.str_value, 'second')
+        self.assertEqual(sticky.user_value, 'first')
+        self.assertTrue(sticky._was_set)
+        self.assertFalse(sticky._was_default)
+
+    def test_all_connection_parameters_opt_in_to_sticky(self):
+        env = {
+            'F_PER_GATE_MCU': 'y',
+            'UNIT_NAME': 'unit0',
+            'MCU_NAME': 'unit0',
+            'UNIT_INDEX': '0',
+            'F_MULTI_UNIT': '',
+            'F_MULTI_UNIT_ENTRY_POINT': '',
+        }
+        with cfg._env(env):
+            kc = cfg._kconfig('sticky-connection-parameters', {})
+
+        names = [
+            'PARAM_MMU_SERIAL_DEVICE',
+            'PARAM_MMU_CANBUS_UUID',
+            'PARAM_BUFFER_SERIAL_DEVICE',
+            'PARAM_BUFFER_CANBUS_UUID',
+        ]
+        for gate in range(10):
+            names.extend((
+                'PARAM_MMU_SERIAL_DEVICE_%d' % gate,
+                'PARAM_MMU_CANBUS_UUID_%d' % gate,
+            ))
+
+        for name in names:
+            self.assertIn(name, kc.syms)
+            self.assertTrue(kc.syms[name].sticky, '%s must be sticky' % name)
 
 
 if __name__ == '__main__':

--- a/test/test_mmu_config.py
+++ b/test/test_mmu_config.py
@@ -267,20 +267,38 @@ class TestSelectorTypeChoice(unittest.TestCase):
         self.assertEqual(kc.syms['PARAM_SELECTOR_TYPE'].str_value, 'LinearMultiGearSelector')
 
 
-class TestStickyKconfigSymbols(unittest.TestCase):
-    """The sticky property pins selected hardware identifiers across installer runs."""
+class TestPreviousKconfigSelections(unittest.TestCase):
+    """Unavailable dynamic devices remain selectable through a stable previous option."""
 
     KCONFIG_TEMPLATE = '''\
-mainmenu "Sticky property test"
+mainmenu "Previous selection test"
 
-config PARAM_FOLLOWS_DEFAULT
-  string
-  default "%s"
+config CURRENT_AVAILABLE
+  bool
+  default %s
 
-config PARAM_STICKY
+choice DEVICE_CHOICE
+  prompt "Select device"
+  default DEVICE_PREVIOUS if "$(saved-config-value,PARAM_DEVICE)" != ""
+  default DEVICE_CURRENT if CURRENT_AVAILABLE
+
+  config DEVICE_PREVIOUS
+    bool "Previous selection: $(saved-config-value,PARAM_DEVICE)"
+    depends on "$(saved-config-value,PARAM_DEVICE)" != ""
+
+  config DEVICE_CURRENT
+    bool "Current device"
+    depends on CURRENT_AVAILABLE
+
+  config DEVICE_OTHER
+    bool "Other"
+endchoice
+
+config PARAM_DEVICE
   string
-  sticky
-  default "%s"
+  default "$(saved-config-value,PARAM_DEVICE)" if DEVICE_PREVIOUS
+  default "/dev/current" if DEVICE_CURRENT
+  default "/dev/other" if DEVICE_OTHER
 '''
 
     @classmethod
@@ -297,39 +315,56 @@ config PARAM_STICKY
     def tearDown(self):
         self.tmpdir.cleanup()
 
-    def _parse(self, default):
+    def _parse(self, current_available):
         with open(self.kconfig_path, 'w') as f:
-            f.write(self.KCONFIG_TEMPLATE % (default, default))
-        return self.kconfiglib.Kconfig(self.kconfig_path, warn=False)
+            f.write(self.KCONFIG_TEMPLATE % ('y' if current_available else 'n'))
+        with cfg._env({'KCONFIG_CONFIG': self.config_path}):
+            return self.kconfiglib.Kconfig(self.kconfig_path, warn=False)
 
-    def test_sticky_default_is_saved_as_an_explicit_assignment(self):
-        kc = self._parse('first')
+    def test_previous_option_survives_discovery_changes_and_tracks_new_selection(self):
+        kc = self._parse(current_available=True)
+        self.assertEqual(kc.named_choices['DEVICE_CHOICE'].selection.name,
+                         'DEVICE_CURRENT')
         kc.write_config(self.config_path, save_old=False)
 
         with open(self.config_path) as f:
             saved = f.read()
+        self.assertIn('CONFIG_PARAM_DEVICE="/dev/current" #~DEFAULT~#', saved)
 
-        self.assertIn('CONFIG_PARAM_FOLLOWS_DEFAULT="first" #~DEFAULT~#', saved)
-        self.assertIn('CONFIG_PARAM_STICKY="first"\n', saved)
-        self.assertNotIn('CONFIG_PARAM_STICKY="first" #~DEFAULT~#', saved)
-        self.assertFalse(kc.syms['PARAM_FOLLOWS_DEFAULT'].sticky)
-        self.assertTrue(kc.syms['PARAM_STICKY'].sticky)
-
-    def test_reload_keeps_sticky_assignment_but_recalculates_normal_default(self):
-        self._parse('first').write_config(self.config_path, save_old=False)
-        kc = self._parse('second')
+        kc = self._parse(current_available=False)
         kc.load_config(self.config_path)
+        self.assertEqual(kc.named_choices['DEVICE_CHOICE'].selection.name,
+                         'DEVICE_PREVIOUS')
+        self.assertEqual(kc.syms['PARAM_DEVICE'].str_value, '/dev/current')
+        self.assertEqual(kc.syms['DEVICE_PREVIOUS'].nodes[0].prompt[0],
+                         'Previous selection: /dev/current')
 
-        normal = kc.syms['PARAM_FOLLOWS_DEFAULT']
-        sticky = kc.syms['PARAM_STICKY']
-        self.assertIsNone(normal.user_value)
-        self.assertEqual(normal.str_value, 'second')
-        self.assertEqual(sticky.user_value, 'first')
-        self.assertTrue(sticky._was_set)
-        self.assertFalse(sticky._was_default)
+        kc.syms['DEVICE_OTHER'].set_value(2)
+        kc.write_config(self.config_path, save_old=False)
+        kc = self._parse(current_available=False)
+        kc.load_config(self.config_path)
+        self.assertEqual(kc.named_choices['DEVICE_CHOICE'].selection.name,
+                         'DEVICE_OTHER')
+        self.assertEqual(kc.syms['PARAM_DEVICE'].str_value, '/dev/other')
 
-    def test_all_connection_parameters_opt_in_to_sticky(self):
+    def test_all_real_connection_choices_expose_their_previous_values(self):
+        values = {
+            'PARAM_MMU_SERIAL_DEVICE': '/dev/previous-main',
+            'PARAM_MMU_CANBUS_UUID': 'abc123def456',
+            'PARAM_BUFFER_SERIAL_DEVICE': '/dev/previous-buffer',
+            'PARAM_BUFFER_CANBUS_UUID': 'def456abc123',
+        }
+        for gate in range(5):
+            values['PARAM_MMU_SERIAL_DEVICE_%d' % gate] = \
+                '/dev/previous-gate-%d' % gate
+            values['PARAM_MMU_CANBUS_UUID_%d' % gate] = \
+                'abc123def4%02d' % gate
+        with open(self.config_path, 'w') as f:
+            for name, value in values.items():
+                f.write('CONFIG_%s="%s" #~DEFAULT~#\n' % (name, value))
+
         env = {
+            'KCONFIG_CONFIG': self.config_path,
             'F_PER_GATE_MCU': 'y',
             'UNIT_NAME': 'unit0',
             'MCU_NAME': 'unit0',
@@ -337,24 +372,68 @@ config PARAM_STICKY
             'F_MULTI_UNIT': '',
             'F_MULTI_UNIT_ENTRY_POINT': '',
         }
+        emu_syms = dict(profiles.get('emu').syms)
+        emu_syms['CHOICE_MMU_CONNECTION_TYPE_SERIAL'] = True
         with cfg._env(env):
-            kc = cfg._kconfig('sticky-connection-parameters', {})
+            kc = cfg._kconfig('previous-connection-selections', emu_syms)
 
-        names = [
-            'PARAM_MMU_SERIAL_DEVICE',
-            'PARAM_MMU_CANBUS_UUID',
-            'PARAM_BUFFER_SERIAL_DEVICE',
-            'PARAM_BUFFER_CANBUS_UUID',
-        ]
-        for gate in range(10):
-            names.extend((
-                'PARAM_MMU_SERIAL_DEVICE_%d' % gate,
-                'PARAM_MMU_CANBUS_UUID_%d' % gate,
-            ))
+        for gate in range(5):
+            choice = kc.named_choices['CHOICE_MMU_SERIAL_CONNECTION_%d' % gate]
+            self.assertEqual(choice.selection.name,
+                             'CHOICE_MMU_SERIAL_DEVICE_PREVIOUS_%d' % gate)
+            name = 'PARAM_MMU_SERIAL_DEVICE_%d' % gate
+            self.assertEqual(kc.syms[name].str_value, values[name])
+            canbus = kc.syms['CHOICE_MMU_CANBUS_UUID_PREVIOUS_%d' % gate]
+            self.assertEqual(canbus.nodes[0].prompt[0],
+                             'Previous selection: %s' %
+                             values['PARAM_MMU_CANBUS_UUID_%d' % gate])
 
-        for name in names:
-            self.assertIn(name, kc.syms)
-            self.assertTrue(kc.syms[name].sticky, '%s must be sticky' % name)
+        vvd = profiles.get('ercf_vvd').units[1]
+        buffer_env = {
+            'KCONFIG_CONFIG': self.config_path,
+            'F_PER_GATE_MCU': '',
+            'UNIT_NAME': vvd.name,
+            'MCU_NAME': vvd.mcu_name,
+            'UNIT_INDEX': str(vvd.index),
+            'F_MULTI_UNIT': 'y',
+            'F_MULTI_UNIT_ENTRY_POINT': '',
+        }
+        buffer_syms = dict(vvd.syms)
+        buffer_syms['CHOICE_BUFFER_CONNECTION_TYPE_SERIAL'] = True
+        with cfg._env(buffer_env):
+            kc = cfg._kconfig('previous-buffer-selection', buffer_syms)
+
+        buffer_choice = kc.named_choices['CHOICE_BUFFER_SERIAL_CONNECTION']
+        self.assertEqual(buffer_choice.selection.name,
+                         'CHOICE_BUFFER_SERIAL_DEVICE_PREVIOUS')
+        self.assertEqual(kc.syms['PARAM_BUFFER_SERIAL_DEVICE'].str_value,
+                         values['PARAM_BUFFER_SERIAL_DEVICE'])
+        buffer_canbus = kc.syms['CHOICE_BUFFER_CANBUS_UUID_PREVIOUS']
+        self.assertEqual(buffer_canbus.nodes[0].prompt[0],
+                         'Previous selection: %s' %
+                         values['PARAM_BUFFER_CANBUS_UUID'])
+
+        base_env = dict(buffer_env)
+        base_env.update({
+            'UNIT_NAME': 'unit0',
+            'MCU_NAME': 'unit0',
+            'UNIT_INDEX': '0',
+            'F_MULTI_UNIT': '',
+        })
+        base_syms = dict(profiles.get('boxturtle').syms)
+        base_syms['CHOICE_MMU_CONNECTION_TYPE_CANBUS'] = True
+        with cfg._env(base_env):
+            kc = cfg._kconfig('previous-base-canbus-selection', base_syms)
+
+        base_choice = kc.named_choices['CHOICE_MMU_CANBUS_CONNECTION']
+        self.assertEqual(base_choice.selection.name,
+                         'CHOICE_MMU_CANBUS_UUID_PREVIOUS')
+        self.assertEqual(kc.syms['PARAM_MMU_CANBUS_UUID'].str_value,
+                         values['PARAM_MMU_CANBUS_UUID'])
+        base_serial = kc.syms['CHOICE_MMU_SERIAL_DEVICE_PREVIOUS']
+        self.assertEqual(base_serial.nodes[0].prompt[0],
+                         'Previous selection: %s' %
+                         values['PARAM_MMU_SERIAL_DEVICE'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- read previously saved connection parameter values before Kconfig builds its dynamic device choices
- add stable `Previous selection` entries for MMU, per-gate, and buffer serial/CAN connections
- keep the hidden connection parameters entirely default-driven
- retain unavailable devices across interactive and noninteractive Kconfig runs
- include the preprocessor helper in Kconfig staleness tracking
- replace the earlier sticky-symbol implementation

## Tests

- `./venv/bin/python -m unittest -v test.test_mmu_config`
- `make ALL=1 test` — 1073 tests, 1 skipped, 4 expected failures