### PR TITLE
Redesign filament position status line rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ restart_klipper = 0
 .SECONDEXPANSION:
 .DEFAULT_GOAL := build
 .PRECIOUS: $(KCONFIG_CONFIG) $(KCONFIG_CONFIG)_%
-.PHONY: menuconfig install uninstall check_version diff test console shots venv installer_venv clean_venv build clean variables python_deps fix_links gen_kconfig kconfig_needs_update olddefconfig verify_pickle
+.PHONY: menuconfig install uninstall check_version diff test console filament_display shots venv installer_venv clean_venv build clean variables python_deps fix_links gen_kconfig kconfig_needs_update olddefconfig verify_pickle
 .SECONDARY: \
 	$(call backup_name,$(KLIPPER_CONFIG_HOME)/mmu) \
 	$(call backup_name,$(KLIPPER_CONFIG_HOME)/$(MOONRAKER_CONFIG_FILE)) \
@@ -577,6 +577,12 @@ venv: $(VENV_STAMP)
 installer_venv: $(INSTALLER_STAMP)
 	@:
 
+
+
+###########################
+##### Testing targets #####
+###########################
+
 # Opens the interactive file picker, everything pre-ticked, so Enter runs the whole suite as
 # before. Skipped for UT/ALL/LAST or when stdin isn't a tty - test/select.py decides. Extra
 # unittest flags go through ARGS, e.g. make test ARGS='-k homing'
@@ -594,6 +600,15 @@ console: $(test_prereqs)
 	$(Q)$(using_klippy_env)
 	$(Q)PYTHONPATH="$(SRC)/installer/lib/kconfiglib:$(PYTHONPATH)" \
 		$(TEST_PY) -m test.console $(ARGS)
+
+# Bulk sensor/position/gate_homing_endstop sweep for get_filament_position_string(),
+# Pass flags through ARGS, e.g. make filament_display ARGS='-k UNKNOWN'
+# HH_FILAMENT_DISPLAY_REVIEW gates filament_display_review.py's load_tests hook: unset,
+# `make test`'s pattern='*' discovery loads the module and gets nothing back from it
+filament_display: $(test_prereqs)
+	$(Q)$(using_klippy_env)
+	$(Q)HH_FILAMENT_DISPLAY_REVIEW=1 PYTHONPATH="$(SRC)/installer/lib/kconfiglib:$(PYTHONPATH)" \
+		$(TEST_PY) -m unittest test.filament_display_review -v $(ARGS)
 
 variables:
 	@echo "========================="

--- a/extras/mmu/mmu_constants.py
+++ b/extras/mmu/mmu_constants.py
@@ -370,6 +370,7 @@ UI_GATE_MARK          = '\u2524'  # ┤
 
 UI_SENSOR_EMPTY       = '\u25EF'  # ◯
 UI_SENSOR_TRIGGERED   = '\u25C9'  # ◉
+UI_ENCODER_VIRTUAL_TRIGGER = '\u00EA'  # ê - encoder has no physical trigger; virtual "triggered" marker
 
 UI_HOME_LIGHT         = '\u252B'  # ┫
 UI_LINE_LIGHT         = '\u2501'  # ━

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -903,11 +903,16 @@ class MmuController(MmuFilamentMovement):
         def gate_presence_marker():
             # Filament can be present at the gate even when the entry sensor
             # itself hasn't triggered (not fitted, or fitted but not yet reached)
-            # -- gate_status is the one source of truth for that, shown here as
-            # plain presence, never as a promotable tip.
+            # -- gate_status is the one source of truth for that. Returns `arrow`
+            # (not `line`) like every other fill helper: whenever nothing further
+            # along the line shows real progress, this presence marker IS the
+            # leading edge of what's known, so the global tip-restoration pass
+            # should be free to promote it to a tip glyph -- same convention as
+            # everywhere else in thin style. It only stays a plain arrow-turned-
+            # line when something later in the string is the genuine last arrow.
             if pos <= FILAMENT_POS_UNLOADED and _gate_empty():
                 return space
-            return line
+            return arrow
 
         def entry_marker():
             if self.sensor_manager.has_sensor(SENSOR_ENTRY_PREFIX):

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -947,6 +947,12 @@ class MmuController(MmuFilamentMovement):
                 left = width - width // 2
                 right = width // 2
                 return arrow * left + space * right
+            # Strictly below UNLOADED (i.e. FILAMENT_POS_UNKNOWN) has no evidence
+            # of any progress at all -- pos == UNLOADED falls through here too
+            # (the branch above only returns early when NOT yet reached), and
+            # that "reached" case legitimately wants the arrow fill below.
+            if pos < FILAMENT_POS_UNLOADED:
+                return space * width
             return arrow * width
 
         def gate_area_segment():

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -799,10 +799,6 @@ class MmuController(MmuFilamentMovement):
                 return space
             return arrow if pos >= target_pos else space
 
-        def sensor_label(sensor, label=""):
-            marker = trig_sensor if self.sensor_manager.check_sensor(sensor) else empty_sensor
-            return marker + label
-
         def homed_segment(target_pos, label):
             if pos > target_pos:
                 return arrow + label + arrow
@@ -821,7 +817,8 @@ class MmuController(MmuFilamentMovement):
 
         def optional_sensor(sensor, target_pos, width=3):
             if self.sensor_manager.has_sensor(sensor):
-                return homed_segment(target_pos, sensor_label(sensor))
+                marker = trig_sensor if self.sensor_manager.check_sensor(sensor) else empty_sensor
+                return homed_segment(target_pos, marker)
             return pad(target_pos, width)
 
         # Physical order of the gate-area endstops, gate-ward to extruder-ward --
@@ -831,16 +828,12 @@ class MmuController(MmuFilamentMovement):
         GATE_SENSOR_ORDER = (SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT, SENSOR_ENCODER, SENSOR_EXTRUDER_ENTRY)
 
         # encoder/extruder are shared across a unit's gates (and the encoder is a
-        # movement latch, not a presence sensor) -- a trigger there says nothing
-        # about THIS gate specifically. shared_exit is ALSO shared hardware, but
-        # unlike those two it's a real-time switch: get_filament_position_string()
-        # only ever renders the currently selected/engaged gate, so its reading
-        # right now genuinely reflects that gate's own progress (this is a
-        # different question from _gate_empty()'s "is this gate empty", which
-        # deliberately still excludes it -- a stale reading left over from
-        # whichever gate was selected before this one is a real risk for an
-        # at-rest presence check, not for inferring how far THIS gate's tip has
-        # travelled once its own entry/exit already confirm it's moved at all).
+        # movement latch, not a presence sensor), so a trigger there says nothing
+        # about THIS gate. shared_exit is shared hardware too, but it's a
+        # real-time switch and only the currently selected gate is ever rendered
+        # here, so its reading is real evidence for THIS gate specifically
+        # (unlike _gate_empty()'s at-rest presence check below, which excludes it
+        # since a stale cross-gate reading is a real risk there).
         PER_GATE_SENSORS = (SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT)
 
         def _furthest_triggered_gate_sensor_index():
@@ -851,16 +844,12 @@ class MmuController(MmuFilamentMovement):
             return index
 
         def _parked_forward_cap():
-            # At UNLOADED, absent any real trigger, parking convention assumes
-            # filament sits as far forward as possible -- but only up to the
-            # nearest point real evidence could contradict. A fitted, confirmed-
-            # clear entry sensor is the strongest such evidence (nothing has
-            # passed entry at all, full stop -- matches the entry_exit_gap()
-            # token-sliver rule). Otherwise the cap is one short of whichever
-            # GATE_SENSOR_ORDER sensor is fitted nearest the gate: everything
-            # strictly before it is unfitted (no evidence either way) so the
-            # assumption may cover it, but the fitted sensor itself keeps its own
-            # real reading (via gate_sensor_marker()), never overridden here.
+            # At UNLOADED, absent any trigger, parking convention assumes
+            # filament sits as far forward as possible, capped at the nearest
+            # point real evidence could contradict: a fitted, clear entry sensor
+            # caps it at nothing (matches entry_exit_gap()'s token-sliver rule);
+            # otherwise the cap is one short of the nearest fitted
+            # GATE_SENSOR_ORDER sensor, whose own reading is never overridden here.
             if self.sensor_manager.check_sensor(SENSOR_ENTRY_PREFIX) is False:
                 return -1
             for i, s in enumerate(GATE_SENSOR_ORDER):
@@ -869,17 +858,11 @@ class MmuController(MmuFilamentMovement):
             return len(GATE_SENSOR_ORDER) - 1
 
         def _gate_empty():
-            # gate_status is persisted and can go stale (e.g. a failed home marks
-            # a gate GATE_EMPTY even when filament is still physically present) --
-            # a triggered entry or exit sensor always overrides it, same as
-            # gate_sensor_marker() never lets gate_status hide a real reading.
-            # Deliberately its own entry/exit-only check, NOT
-            # _furthest_triggered_gate_sensor_index() (which now also allows
-            # shared_exit, for a different purpose -- see PER_GATE_SENSORS above):
-            # a stale shared_exit reading left over from whichever gate was
-            # selected before this one is a real risk for an at-rest presence
-            # check specifically, so this question stays limited to sensors that
-            # can only ever mean THIS gate.
+            # gate_status can go stale (e.g. a failed home marks a gate EMPTY
+            # despite filament still being present) -- a triggered entry/exit
+            # sensor always overrides it. Narrower than PER_GATE_SENSORS above:
+            # this question stays limited to sensors that can only ever mean
+            # THIS gate.
             if gate_status != GATE_EMPTY:
                 return False
             if self.sensor_manager.check_sensor(SENSOR_ENTRY_PREFIX) is True:
@@ -889,22 +872,17 @@ class MmuController(MmuFilamentMovement):
             return True
 
         def _passed_gate_sensor(sensor):
-            # UNKNOWN shares UNLOADED's total absence of positional information --
-            # real sensor evidence is all there is either way -- but NOT the
-            # parked-forward assumption below: that's a parking-specific
-            # convention, meaningless before a position has even been determined.
+            # UNKNOWN and UNLOADED both carry no positional info, so both rely
+            # on real sensor evidence; only UNLOADED additionally falls back to
+            # the parked-forward assumption below (a parking-specific
+            # convention, meaningless before a position has even been determined).
             if pos in (FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN):
-                # Forward-parked: a triggered downstream sensor implies every
-                # upstream point was passed too, regardless of this sensor's own
-                # (possibly absent) reading -- avoids a false gap in the line.
-                # Strictly further-than, not as-far-as (see _reached_gate_sensor).
+                # A triggered downstream sensor implies every upstream point
+                # was passed too, regardless of this sensor's own reading.
                 if _furthest_triggered_gate_sensor_index() > GATE_SENSOR_ORDER.index(sensor):
                     return True
                 if pos != FILAMENT_POS_UNLOADED:
                     return False
-                # No real trigger anywhere -- fall back to the parked-forward
-                # assumption, capped at the nearest fitted sensor/entry evidence
-                # (see _parked_forward_cap()), never past a real "clear" reading.
                 return not _gate_empty() and _parked_forward_cap() >= GATE_SENSOR_ORDER.index(sensor)
             if pos > FILAMENT_POS_HOMED_GATE:
                 return True
@@ -916,13 +894,12 @@ class MmuController(MmuFilamentMovement):
             return False
 
         def _reached_gate_sensor(sensor):
-            # Like _passed_gate_sensor but >= rather than > -- "arrived, maybe not
-            # past yet". Decides whether a gap reads as "just arrived" vs "long
-            # since passed" (gate_sensor_gap).
+            # Same as _passed_gate_sensor but >= rather than > -- "arrived,
+            # maybe not past yet" (decides gate_sensor_gap()'s "just arrived"
+            # split vs full fill).
             if pos in (FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN):
-                # `sensor`'s own fitted, directly-triggered reading is the
-                # strongest possible evidence it's been reached -- checked before
-                # any inference from a different sensor.
+                # A sensor's own fitted, directly-triggered reading is the
+                # strongest evidence it's been reached.
                 if self.sensor_manager.has_sensor(sensor) and self.sensor_manager.check_sensor(sensor):
                     return True
                 if _furthest_triggered_gate_sensor_index() >= GATE_SENSOR_ORDER.index(sensor):
@@ -949,15 +926,11 @@ class MmuController(MmuFilamentMovement):
             return fill
 
         def gate_presence_marker():
-            # Filament can be present at the gate even when the entry sensor
-            # itself hasn't triggered (not fitted, or fitted but not yet reached)
-            # -- gate_status is the one source of truth for that. Returns `arrow`
-            # (not `line`) like every other fill helper: whenever nothing further
-            # along the line shows real progress, this presence marker IS the
-            # leading edge of what's known, so the global tip-restoration pass
-            # should be free to promote it to a tip glyph -- same convention as
-            # everywhere else in thin style. It only stays a plain arrow-turned-
-            # line when something later in the string is the genuine last arrow.
+            # Filament can be present even when entry hasn't triggered (unfitted,
+            # or not yet reached) -- gate_status decides that. Returns `arrow`
+            # (not `line`) so the tip-restoration pass below can promote it when
+            # it's the furthest-along signal in the whole line; it only stays a
+            # plain line when something later is the genuine last arrow.
             if pos <= FILAMENT_POS_UNLOADED and _gate_empty():
                 return space
             return arrow
@@ -965,19 +938,15 @@ class MmuController(MmuFilamentMovement):
         def entry_marker():
             if self.sensor_manager.has_sensor(SENSOR_ENTRY_PREFIX):
                 return trig_sensor if self.sensor_manager.check_sensor(SENSOR_ENTRY_PREFIX) else empty_sensor
-            # NOT past(FILAMENT_POS_UNLOADED): past()'s `pos >= target_pos` can
-            # never be true for FILAMENT_POS_UNKNOWN, since it sits below every
-            # real target_pos rather than further along one -- that left a
-            # one-character gap right after gate_presence_marker() at UNKNOWN
-            # even with a non-empty gate. gate_presence_marker() has no such
-            # comparison (only the same empty-gate guard), so it's already
-            # correct here in every case, UNKNOWN included.
+            # NOT past(FILAMENT_POS_UNLOADED): its `pos >= target_pos` comparison
+            # can never be true for UNKNOWN (below every target, not further
+            # along one). gate_presence_marker() has no such comparison and is
+            # correct here in every case.
             return gate_presence_marker()
 
         def gate_sensor_marker(sensor):
-            # A fitted sensor's own reading is always shown -- there's no such
-            # thing as "stale" real data. Only an unfitted sensor falls back to
-            # inferring passage from a later, further-along real trigger.
+            # A fitted sensor's own reading is always shown; only an unfitted
+            # one falls back to inferring passage from a further-along trigger.
             if self.sensor_manager.has_sensor(sensor):
                 return trig_sensor if self.sensor_manager.check_sensor(sensor) else empty_sensor
             return arrow if _passed_gate_sensor(sensor) else space
@@ -985,10 +954,8 @@ class MmuController(MmuFilamentMovement):
         def gate_sensor_gap(sensor, width=2):
             if _passed_gate_sensor(sensor):
                 return arrow * width
-            # Split arrow/space applies whenever there's no positional info to
-            # go on (UNLOADED forward-parked, or UNKNOWN) -- HOMED_GATE is a
-            # crisp, discrete event (home + space, like every other
-            # homed_segment()), not a partial/ambiguous split.
+            # Split applies when there's no positional info (UNLOADED/UNKNOWN);
+            # HOMED_GATE is a crisp, discrete event, not a partial split.
             if pos in (FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN) and _reached_gate_sensor(sensor):
                 left = width - width // 2
                 right = width // 2
@@ -996,13 +963,10 @@ class MmuController(MmuFilamentMovement):
             return space * width
 
         def entry_exit_gap(width=2):
-            # entry is excluded from GATE_SENSOR_ORDER, so this checks its own
-            # reading directly: a token sliver (one tip char) only once entry has
-            # confirmed the tip got that far; otherwise gate_presence_marker() is
-            # the only "something's here" signal, until exit itself is reached.
-            # UNKNOWN is treated the same as UNLOADED here -- neither carries any
-            # positional information of its own, so real sensor evidence (exit
-            # reached, or entry's own reading) is all either state has to go on.
+            # entry isn't in GATE_SENSOR_ORDER, so this checks its own reading
+            # directly: a token sliver only once entry confirms the tip got that
+            # far; UNKNOWN is treated like UNLOADED since neither carries
+            # positional info of its own.
             if pos <= FILAMENT_POS_UNLOADED and _gate_empty():
                 return space * width
             if pos in (FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN) and not _reached_gate_sensor(SENSOR_EXIT_PREFIX):
@@ -1203,7 +1167,6 @@ class MmuController(MmuFilamentMovement):
         # is the distinct tip glyph these placeholders should render as
         visual = visual.replace(TIP_OVERRIDE, line if bold else arrow)
 
-        # Post process filament color
         if color and gate >= 0:
             if residual_filament_color:
                 rgb_hex = MmuColorUtils.color_to_rgb_hex(residual_filament_color)

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -758,6 +758,7 @@ class MmuController(MmuFilamentMovement):
         pos = self.filament_pos
         direction = self.filament_direction
         gate_homing_endstop = self.mmu_unit().p.gate_homing_endstop
+        gate_status = self.gate_status[gate] if gate >= 0 else GATE_UNKNOWN
 
         status = self.get_status(0)
         if status['filament_remaining']:
@@ -784,9 +785,18 @@ class MmuController(MmuFilamentMovement):
                 UI_ARROW_FILLED_RIGHT,
             )
 
+        # Placeholder that survives the "no tip beside home" pass below as a
+        # literal tip glyph even when a `home` exists elsewhere -- used where the
+        # leading edge is genuinely past a home point (encoder-homing overshoot;
+        # filament past the nozzle once LOADED).
+        TIP_OVERRIDE = "\x00"
+
         # Helper methods -------
 
         def past(target_pos):
+            # A genuinely empty gate has nothing to show as "already passed"
+            if pos <= FILAMENT_POS_UNLOADED and _gate_empty():
+                return space
             return arrow if pos >= target_pos else space
 
         def sensor_label(sensor, label=""):
@@ -814,17 +824,139 @@ class MmuController(MmuFilamentMovement):
                 return homed_segment(target_pos, sensor_label(sensor))
             return pad(target_pos, width)
 
-        def gate_segment():
-            # Forward-parked exit sensor: filament is UNLOADED but still sits at/past the
-            # gate sensor (positive gate_parking_distance), so render it as homed there
-            # rather than as not-yet-reached
-            if pos == FILAMENT_POS_UNLOADED and self.sensor_manager.check_sensor(gate_homing_endstop):
-                return home + sensor_label(gate_homing_endstop) + space
-            return optional_sensor(gate_homing_endstop, FILAMENT_POS_HOMED_GATE)
+        # Physical order of the gate-area endstops, gate-ward to extruder-ward --
+        # decides whether the tip has already passed a sensor once homed via a
+        # different, further-along endstop. Anything not in this tuple (shouldn't
+        # happen) is treated as furthest-along/already passed.
+        GATE_SENSOR_ORDER = (SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT, SENSOR_ENCODER, SENSOR_EXTRUDER_ENTRY)
+
+        def _furthest_triggered_gate_sensor_index():
+            index = -1
+            for i, s in enumerate(GATE_SENSOR_ORDER):
+                if self.sensor_manager.has_sensor(s) and self.sensor_manager.check_sensor(s):
+                    index = max(index, i)
+            return index
+
+        def _gate_empty():
+            # gate_status is persisted and can go stale (e.g. a failed home marks
+            # a gate GATE_EMPTY even when filament is still physically present) --
+            # a triggered entry or gate-area sensor always overrides it, same as
+            # gate_sensor_marker() never lets gate_status hide a real reading.
+            if gate_status != GATE_EMPTY:
+                return False
+            if self.sensor_manager.check_sensor(SENSOR_ENTRY_PREFIX) is True:
+                return False
+            return _furthest_triggered_gate_sensor_index() < 0
+
+        def _passed_gate_sensor(sensor):
+            if pos == FILAMENT_POS_UNLOADED:
+                # Forward-parked: a triggered downstream sensor implies every
+                # upstream point was passed too, regardless of this sensor's own
+                # (possibly absent) reading -- avoids a false gap in the line.
+                # Strictly further-than, not as-far-as (see _reached_gate_sensor).
+                return _furthest_triggered_gate_sensor_index() > GATE_SENSOR_ORDER.index(sensor)
+            if pos > FILAMENT_POS_HOMED_GATE:
+                return True
+            if pos == FILAMENT_POS_HOMED_GATE:
+                try:
+                    return GATE_SENSOR_ORDER.index(gate_homing_endstop) > GATE_SENSOR_ORDER.index(sensor)
+                except ValueError:
+                    return True
+            return False
+
+        def _reached_gate_sensor(sensor):
+            # Like _passed_gate_sensor but >= rather than > -- "arrived, maybe not
+            # past yet". Decides whether a gap reads as "just arrived" vs "long
+            # since passed" (gate_sensor_gap).
+            if pos == FILAMENT_POS_UNLOADED:
+                return _furthest_triggered_gate_sensor_index() >= GATE_SENSOR_ORDER.index(sensor)
+            if pos > FILAMENT_POS_HOMED_GATE:
+                return True
+            if pos == FILAMENT_POS_HOMED_GATE:
+                try:
+                    return GATE_SENSOR_ORDER.index(gate_homing_endstop) >= GATE_SENSOR_ORDER.index(sensor)
+                except ValueError:
+                    return True
+            return False
+
+        def _homed_here(sensor):
+            return pos == FILAMENT_POS_HOMED_GATE and gate_homing_endstop == sensor
+
+        def _with_home(fill, sensor):
+            # Swap fill's last char for `home` when exactly homed at `sensor` now
+            if _homed_here(sensor) and fill:
+                return fill[:-1] + home
+            return fill
+
+        def gate_presence_marker():
+            # Filament can be present at the gate even when the entry sensor
+            # itself hasn't triggered (not fitted, or fitted but not yet reached)
+            # -- gate_status is the one source of truth for that, shown here as
+            # plain presence, never as a promotable tip.
+            if pos <= FILAMENT_POS_UNLOADED and _gate_empty():
+                return space
+            return line
+
+        def entry_marker():
+            if self.sensor_manager.has_sensor(SENSOR_ENTRY_PREFIX):
+                return trig_sensor if self.sensor_manager.check_sensor(SENSOR_ENTRY_PREFIX) else empty_sensor
+            return past(FILAMENT_POS_UNLOADED)
+
+        def gate_sensor_marker(sensor):
+            # A fitted sensor's own reading is always shown -- there's no such
+            # thing as "stale" real data. Only an unfitted sensor falls back to
+            # inferring passage from a later, further-along real trigger.
+            if self.sensor_manager.has_sensor(sensor):
+                return trig_sensor if self.sensor_manager.check_sensor(sensor) else empty_sensor
+            return arrow if _passed_gate_sensor(sensor) else space
+
+        def gate_sensor_gap(sensor, width=2):
+            if _passed_gate_sensor(sensor):
+                return arrow * width
+            # Split arrow/space only applies to the UNLOADED forward-parked
+            # ambiguity -- HOMED_GATE is a crisp, discrete event (home + space,
+            # like every other homed_segment()), not a partial/ambiguous split.
+            if pos == FILAMENT_POS_UNLOADED and _reached_gate_sensor(sensor):
+                left = width - width // 2
+                right = width // 2
+                return arrow * left + space * right
+            return space * width
+
+        def entry_exit_gap(width=2):
+            # entry is excluded from GATE_SENSOR_ORDER, so this checks its own
+            # reading directly: a token sliver (one tip char) only once entry has
+            # confirmed the tip got that far; otherwise gate_presence_marker() is
+            # the only "something's here" signal, until exit itself is reached.
+            if pos <= FILAMENT_POS_UNLOADED and _gate_empty():
+                return space * width
+            if pos == FILAMENT_POS_UNLOADED and not _reached_gate_sensor(SENSOR_EXIT_PREFIX):
+                if self.sensor_manager.check_sensor(SENSOR_ENTRY_PREFIX) is not True:
+                    return space * width
+                left = width - width // 2
+                right = width // 2
+                return arrow * left + space * right
+            return arrow * width
+
+        def gate_area_segment():
+            # presence, entry, then [exit marker, gap] and [shared_exit marker,
+            # gap] -- both shown independently, each its own real reading, since a
+            # unit can fit both even though only one is the active
+            # gate_homing_endstop. 2-char gaps (funded by shrinking bowden fill
+            # elsewhere) keep exit/shared_exit/encoder visually distinct. The gap
+            # before the active gate_homing_endstop shows `home` when homed.
+            return (
+                gate_presence_marker()
+                + entry_marker()
+                + _with_home(entry_exit_gap(), SENSOR_EXIT_PREFIX)
+                + gate_sensor_marker(SENSOR_EXIT_PREFIX)
+                + _with_home(gate_sensor_gap(SENSOR_EXIT_PREFIX), SENSOR_SHARED_EXIT)
+                + gate_sensor_marker(SENSOR_SHARED_EXIT)
+                + _with_home(gate_sensor_gap(SENSOR_SHARED_EXIT), SENSOR_ENCODER)
+            )
 
         def nozzle_segment():
             if pos >= FILAMENT_POS_LOADED:
-                return arrow + home + "Nz" + arrow * 2
+                return arrow + home + "Nz" + TIP_OVERRIDE
             if residual_filament_color:
                 return residual_line + gate_mark + "Nz"
             return space + gate_mark + "Nz"
@@ -899,20 +1031,35 @@ class MmuController(MmuFilamentMovement):
             if gate_homing_endstop == SENSOR_ENCODER
             else FILAMENT_POS_IN_BOWDEN
         )
+        # Virtually-triggered the instant we're exactly homed via the encoder
+        # itself, even before pos reaches encoder_ref_pos (movement vs "this is
+        # the endstop we just homed on" are different thresholds)
+        encoder_char = (
+            UI_ENCODER_VIRTUAL_TRIGGER
+            if pos >= encoder_ref_pos or _homed_here(SENSOR_ENCODER)
+            else "e"
+        )
+
+        # The encoder is a movement-based virtual endstop with no physical
+        # trigger point, so homing against it always overshoots slightly --
+        # marked with TIP_OVERRIDE right after the encoder glyph.
+        encoder_overshoots = self.has_encoder() and _homed_here(SENSOR_ENCODER)
 
         parts = [
             tool_text,
-            past(FILAMENT_POS_UNLOADED) * 2,
 
-            gate_segment(),
+            gate_area_segment(),
 
             (
-                "En" + past(encoder_ref_pos) * 2
+                encoder_char
+                + (TIP_OVERRIDE if encoder_overshoots else past(encoder_ref_pos))
+                + past(encoder_ref_pos)
                 if self.has_encoder()
-                else past(encoder_ref_pos) * 4
+                else past(encoder_ref_pos) * 3
             ),
 
-            past(FILAMENT_POS_IN_BOWDEN) * bowden_half,
+            # 2 shorter than nominal -- reclaimed to fund gate_area_segment()'s wider gaps
+            past(FILAMENT_POS_IN_BOWDEN) * max(0, bowden_half - 2),
 
             (
                 buffer_segment()
@@ -920,7 +1067,8 @@ class MmuController(MmuFilamentMovement):
                 else pad(FILAMENT_POS_IN_BOWDEN, 7)
             ),
 
-            past(FILAMENT_POS_END_BOWDEN) * bowden_half,
+            # 2 shorter than nominal -- same reclaiming as above, plus 1 more to trim overall length
+            past(FILAMENT_POS_END_BOWDEN) * max(0, bowden_half - 2),
 
             optional_sensor(SENSOR_EXTRUDER_ENTRY, FILAMENT_POS_HOMED_ENTRY),
 
@@ -933,10 +1081,12 @@ class MmuController(MmuFilamentMovement):
             nozzle_segment(),
         ]
 
+        is_empty = pos == FILAMENT_POS_UNLOADED and _gate_empty()
+
         if pos == FILAMENT_POS_LOADED:
             parts.append(" {5}{4}LOADED{0}{6}")
         elif pos == FILAMENT_POS_UNLOADED:
-            parts.append(" {5}{4}UNLOADED{0}{6}")
+            parts.append(" {5}{4}%s{0}{6}" % ("EMPTY" if is_empty else "UNLOADED"))
         elif pos == FILAMENT_POS_UNKNOWN:
             parts.append(" {5}{4}UNKNOWN{0}{6}")
         elif direction == DIRECTION_LOAD:
@@ -944,12 +1094,14 @@ class MmuController(MmuFilamentMovement):
         elif direction == DIRECTION_UNLOAD:
             parts.append(" {5}{4}" + UI_ARROW_HOLLOW_LEFT * 3 + "{0}{6}")
 
-        encoder_str = (
-            " {1}(e:%.1fmm){0}" % self.get_encoder_distance(dwell=None)
-            if self.has_encoder() and self.mmu_unit().p.encoder_move_validation
-            else ""
-        )
-        parts.append(" {5}%.1fmm{6}%s" % (self.drive().get_filament_position(), encoder_str))
+        # A genuinely empty gate has no measurements to report
+        if not is_empty:
+            encoder_str = (
+                " {1}(e:%.1fmm){0}" % self.get_encoder_distance(dwell=None)
+                if self.has_encoder() and self.mmu_unit().p.encoder_move_validation
+                else ""
+            )
+            parts.append(" {5}%.1fmm{6}%s" % (self.drive().get_filament_position(), encoder_str))
 
         visual = "".join(parts)
 
@@ -958,8 +1110,16 @@ class MmuController(MmuFilamentMovement):
 
         visual = visual.replace(arrow, line)
 
-        if last_arrow != -1 and (last_home == -1 or not bold):
+        # Arrow-as-tip only applies "in transit" (no `home` present) -- a `home`
+        # marks an exact arrival, so any leftover arrow elsewhere shouldn't also
+        # compete for the tip. In bold, home and arrow are the same glyph, so
+        # this is equivalent to "never restore", matching bold's all-solid look.
+        if last_arrow != -1 and last_home == -1:
             visual = visual[:last_arrow] + arrow + visual[last_arrow + 1:]
+
+        # bold: arrow==home, folds into `line` like every bold tip; thin: arrow
+        # is the distinct tip glyph these placeholders should render as
+        visual = visual.replace(TIP_OVERRIDE, line if bold else arrow)
 
         # Post process filament color
         if color and gate >= 0:
@@ -967,13 +1127,13 @@ class MmuController(MmuFilamentMovement):
                 rgb_hex = MmuColorUtils.color_to_rgb_hex(residual_filament_color)
                 visual = _color_filament(visual, rgb_hex, residual_line)
             else:
-                # No special color treatment
                 visual = visual.replace(residual_line, line)
 
             rgb_hex = MmuColorUtils.color_to_rgb_hex(self.gate_color[gate], "FFFFFF")
             visual = _color_filament(visual, rgb_hex, line)
 
-            # Get rid of special residual filament character
+            # Must happen after gate_color coloring, else residual_filament_color's
+            # own markup above would be overwritten
             visual = visual.replace(residual_line, line)
 
         return visual

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -965,7 +965,14 @@ class MmuController(MmuFilamentMovement):
         def entry_marker():
             if self.sensor_manager.has_sensor(SENSOR_ENTRY_PREFIX):
                 return trig_sensor if self.sensor_manager.check_sensor(SENSOR_ENTRY_PREFIX) else empty_sensor
-            return past(FILAMENT_POS_UNLOADED)
+            # NOT past(FILAMENT_POS_UNLOADED): past()'s `pos >= target_pos` can
+            # never be true for FILAMENT_POS_UNKNOWN, since it sits below every
+            # real target_pos rather than further along one -- that left a
+            # one-character gap right after gate_presence_marker() at UNKNOWN
+            # even with a non-empty gate. gate_presence_marker() has no such
+            # comparison (only the same empty-gate guard), so it's already
+            # correct here in every case, UNKNOWN included.
+            return gate_presence_marker()
 
         def gate_sensor_marker(sensor):
             # A fitted sensor's own reading is always shown -- there's no such
@@ -1167,8 +1174,10 @@ class MmuController(MmuFilamentMovement):
         elif direction == DIRECTION_UNLOAD:
             parts.append(" {5}{4}" + UI_ARROW_HOLLOW_LEFT * 3 + "{0}{6}")
 
-        # A genuinely empty gate has no measurements to report
-        if not is_empty:
+        # A genuinely empty gate has no measurements to report -- neither does a
+        # genuinely unknown position, for the same reason: there's nothing
+        # meaningful to measure yet.
+        if not is_empty and pos != FILAMENT_POS_UNKNOWN:
             encoder_str = (
                 " {1}(e:%.1fmm){0}" % self.get_encoder_distance(dwell=None)
                 if self.has_encoder() and self.mmu_unit().p.encoder_move_validation

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -830,11 +830,18 @@ class MmuController(MmuFilamentMovement):
         # happen) is treated as furthest-along/already passed.
         GATE_SENSOR_ORDER = (SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT, SENSOR_ENCODER, SENSOR_EXTRUDER_ENTRY)
 
-        # shared_exit/encoder/extruder are shared across a unit's gates (and the
-        # encoder is a movement latch, not a presence sensor) -- a trigger there
-        # says nothing about THIS gate specifically, so the UNLOADED forward-park
-        # inference below may only draw on the one genuinely per-gate sensor.
-        PER_GATE_SENSORS = (SENSOR_EXIT_PREFIX,)
+        # encoder/extruder are shared across a unit's gates (and the encoder is a
+        # movement latch, not a presence sensor) -- a trigger there says nothing
+        # about THIS gate specifically. shared_exit is ALSO shared hardware, but
+        # unlike those two it's a real-time switch: get_filament_position_string()
+        # only ever renders the currently selected/engaged gate, so its reading
+        # right now genuinely reflects that gate's own progress (this is a
+        # different question from _gate_empty()'s "is this gate empty", which
+        # deliberately still excludes it -- a stale reading left over from
+        # whichever gate was selected before this one is a real risk for an
+        # at-rest presence check, not for inferring how far THIS gate's tip has
+        # travelled once its own entry/exit already confirm it's moved at all).
+        PER_GATE_SENSORS = (SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT)
 
         def _furthest_triggered_gate_sensor_index():
             index = -1
@@ -866,10 +873,13 @@ class MmuController(MmuFilamentMovement):
             # a gate GATE_EMPTY even when filament is still physically present) --
             # a triggered entry or exit sensor always overrides it, same as
             # gate_sensor_marker() never lets gate_status hide a real reading.
-            # Deliberately only entry/exit, NOT _furthest_triggered_gate_sensor_index()
-            # -- shared_exit/encoder/extruder_entry are shared across a unit's gates
-            # (see gate-endstop-invariants), so a reading there says nothing about
-            # whether THIS gate specifically is empty.
+            # Deliberately its own entry/exit-only check, NOT
+            # _furthest_triggered_gate_sensor_index() (which now also allows
+            # shared_exit, for a different purpose -- see PER_GATE_SENSORS above):
+            # a stale shared_exit reading left over from whichever gate was
+            # selected before this one is a real risk for an at-rest presence
+            # check specifically, so this question stays limited to sensors that
+            # can only ever mean THIS gate.
             if gate_status != GATE_EMPTY:
                 return False
             if self.sensor_manager.check_sensor(SENSOR_ENTRY_PREFIX) is True:
@@ -879,13 +889,19 @@ class MmuController(MmuFilamentMovement):
             return True
 
         def _passed_gate_sensor(sensor):
-            if pos == FILAMENT_POS_UNLOADED:
+            # UNKNOWN shares UNLOADED's total absence of positional information --
+            # real sensor evidence is all there is either way -- but NOT the
+            # parked-forward assumption below: that's a parking-specific
+            # convention, meaningless before a position has even been determined.
+            if pos in (FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN):
                 # Forward-parked: a triggered downstream sensor implies every
                 # upstream point was passed too, regardless of this sensor's own
                 # (possibly absent) reading -- avoids a false gap in the line.
                 # Strictly further-than, not as-far-as (see _reached_gate_sensor).
                 if _furthest_triggered_gate_sensor_index() > GATE_SENSOR_ORDER.index(sensor):
                     return True
+                if pos != FILAMENT_POS_UNLOADED:
+                    return False
                 # No real trigger anywhere -- fall back to the parked-forward
                 # assumption, capped at the nearest fitted sensor/entry evidence
                 # (see _parked_forward_cap()), never past a real "clear" reading.
@@ -903,7 +919,7 @@ class MmuController(MmuFilamentMovement):
             # Like _passed_gate_sensor but >= rather than > -- "arrived, maybe not
             # past yet". Decides whether a gap reads as "just arrived" vs "long
             # since passed" (gate_sensor_gap).
-            if pos == FILAMENT_POS_UNLOADED:
+            if pos in (FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN):
                 # `sensor`'s own fitted, directly-triggered reading is the
                 # strongest possible evidence it's been reached -- checked before
                 # any inference from a different sensor.
@@ -911,6 +927,8 @@ class MmuController(MmuFilamentMovement):
                     return True
                 if _furthest_triggered_gate_sensor_index() >= GATE_SENSOR_ORDER.index(sensor):
                     return True
+                if pos != FILAMENT_POS_UNLOADED:
+                    return False
                 return not _gate_empty() and _parked_forward_cap() >= GATE_SENSOR_ORDER.index(sensor)
             if pos > FILAMENT_POS_HOMED_GATE:
                 return True
@@ -960,10 +978,11 @@ class MmuController(MmuFilamentMovement):
         def gate_sensor_gap(sensor, width=2):
             if _passed_gate_sensor(sensor):
                 return arrow * width
-            # Split arrow/space only applies to the UNLOADED forward-parked
-            # ambiguity -- HOMED_GATE is a crisp, discrete event (home + space,
-            # like every other homed_segment()), not a partial/ambiguous split.
-            if pos == FILAMENT_POS_UNLOADED and _reached_gate_sensor(sensor):
+            # Split arrow/space applies whenever there's no positional info to
+            # go on (UNLOADED forward-parked, or UNKNOWN) -- HOMED_GATE is a
+            # crisp, discrete event (home + space, like every other
+            # homed_segment()), not a partial/ambiguous split.
+            if pos in (FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN) and _reached_gate_sensor(sensor):
                 left = width - width // 2
                 right = width // 2
                 return arrow * left + space * right
@@ -974,20 +993,17 @@ class MmuController(MmuFilamentMovement):
             # reading directly: a token sliver (one tip char) only once entry has
             # confirmed the tip got that far; otherwise gate_presence_marker() is
             # the only "something's here" signal, until exit itself is reached.
+            # UNKNOWN is treated the same as UNLOADED here -- neither carries any
+            # positional information of its own, so real sensor evidence (exit
+            # reached, or entry's own reading) is all either state has to go on.
             if pos <= FILAMENT_POS_UNLOADED and _gate_empty():
                 return space * width
-            if pos == FILAMENT_POS_UNLOADED and not _reached_gate_sensor(SENSOR_EXIT_PREFIX):
+            if pos in (FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN) and not _reached_gate_sensor(SENSOR_EXIT_PREFIX):
                 if self.sensor_manager.check_sensor(SENSOR_ENTRY_PREFIX) is not True:
                     return space * width
                 left = width - width // 2
                 right = width // 2
                 return arrow * left + space * right
-            # Strictly below UNLOADED (i.e. FILAMENT_POS_UNKNOWN) has no evidence
-            # of any progress at all -- pos == UNLOADED falls through here too
-            # (the branch above only returns early when NOT yet reached), and
-            # that "reached" case legitimately wants the arrow fill below.
-            if pos < FILAMENT_POS_UNLOADED:
-                return space * width
             return arrow * width
 
         def gate_area_segment():

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -843,6 +843,24 @@ class MmuController(MmuFilamentMovement):
                     index = max(index, GATE_SENSOR_ORDER.index(s))
             return index
 
+        def _parked_forward_cap():
+            # At UNLOADED, absent any real trigger, parking convention assumes
+            # filament sits as far forward as possible -- but only up to the
+            # nearest point real evidence could contradict. A fitted, confirmed-
+            # clear entry sensor is the strongest such evidence (nothing has
+            # passed entry at all, full stop -- matches the entry_exit_gap()
+            # token-sliver rule). Otherwise the cap is one short of whichever
+            # GATE_SENSOR_ORDER sensor is fitted nearest the gate: everything
+            # strictly before it is unfitted (no evidence either way) so the
+            # assumption may cover it, but the fitted sensor itself keeps its own
+            # real reading (via gate_sensor_marker()), never overridden here.
+            if self.sensor_manager.check_sensor(SENSOR_ENTRY_PREFIX) is False:
+                return -1
+            for i, s in enumerate(GATE_SENSOR_ORDER):
+                if self.sensor_manager.has_sensor(s):
+                    return i - 1
+            return len(GATE_SENSOR_ORDER) - 1
+
         def _gate_empty():
             # gate_status is persisted and can go stale (e.g. a failed home marks
             # a gate GATE_EMPTY even when filament is still physically present) --
@@ -866,7 +884,12 @@ class MmuController(MmuFilamentMovement):
                 # upstream point was passed too, regardless of this sensor's own
                 # (possibly absent) reading -- avoids a false gap in the line.
                 # Strictly further-than, not as-far-as (see _reached_gate_sensor).
-                return _furthest_triggered_gate_sensor_index() > GATE_SENSOR_ORDER.index(sensor)
+                if _furthest_triggered_gate_sensor_index() > GATE_SENSOR_ORDER.index(sensor):
+                    return True
+                # No real trigger anywhere -- fall back to the parked-forward
+                # assumption, capped at the nearest fitted sensor/entry evidence
+                # (see _parked_forward_cap()), never past a real "clear" reading.
+                return not _gate_empty() and _parked_forward_cap() >= GATE_SENSOR_ORDER.index(sensor)
             if pos > FILAMENT_POS_HOMED_GATE:
                 return True
             if pos == FILAMENT_POS_HOMED_GATE:
@@ -881,7 +904,14 @@ class MmuController(MmuFilamentMovement):
             # past yet". Decides whether a gap reads as "just arrived" vs "long
             # since passed" (gate_sensor_gap).
             if pos == FILAMENT_POS_UNLOADED:
-                return _furthest_triggered_gate_sensor_index() >= GATE_SENSOR_ORDER.index(sensor)
+                # `sensor`'s own fitted, directly-triggered reading is the
+                # strongest possible evidence it's been reached -- checked before
+                # any inference from a different sensor.
+                if self.sensor_manager.has_sensor(sensor) and self.sensor_manager.check_sensor(sensor):
+                    return True
+                if _furthest_triggered_gate_sensor_index() >= GATE_SENSOR_ORDER.index(sensor):
+                    return True
+                return not _gate_empty() and _parked_forward_cap() >= GATE_SENSOR_ORDER.index(sensor)
             if pos > FILAMENT_POS_HOMED_GATE:
                 return True
             if pos == FILAMENT_POS_HOMED_GATE:

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -830,23 +830,35 @@ class MmuController(MmuFilamentMovement):
         # happen) is treated as furthest-along/already passed.
         GATE_SENSOR_ORDER = (SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT, SENSOR_ENCODER, SENSOR_EXTRUDER_ENTRY)
 
+        # shared_exit/encoder/extruder are shared across a unit's gates (and the
+        # encoder is a movement latch, not a presence sensor) -- a trigger there
+        # says nothing about THIS gate specifically, so the UNLOADED forward-park
+        # inference below may only draw on the one genuinely per-gate sensor.
+        PER_GATE_SENSORS = (SENSOR_EXIT_PREFIX,)
+
         def _furthest_triggered_gate_sensor_index():
             index = -1
-            for i, s in enumerate(GATE_SENSOR_ORDER):
+            for s in PER_GATE_SENSORS:
                 if self.sensor_manager.has_sensor(s) and self.sensor_manager.check_sensor(s):
-                    index = max(index, i)
+                    index = max(index, GATE_SENSOR_ORDER.index(s))
             return index
 
         def _gate_empty():
             # gate_status is persisted and can go stale (e.g. a failed home marks
             # a gate GATE_EMPTY even when filament is still physically present) --
-            # a triggered entry or gate-area sensor always overrides it, same as
+            # a triggered entry or exit sensor always overrides it, same as
             # gate_sensor_marker() never lets gate_status hide a real reading.
+            # Deliberately only entry/exit, NOT _furthest_triggered_gate_sensor_index()
+            # -- shared_exit/encoder/extruder_entry are shared across a unit's gates
+            # (see gate-endstop-invariants), so a reading there says nothing about
+            # whether THIS gate specifically is empty.
             if gate_status != GATE_EMPTY:
                 return False
             if self.sensor_manager.check_sensor(SENSOR_ENTRY_PREFIX) is True:
                 return False
-            return _furthest_triggered_gate_sensor_index() < 0
+            if self.sensor_manager.check_sensor(SENSOR_EXIT_PREFIX) is True:
+                return False
+            return True
 
         def _passed_gate_sensor(sensor):
             if pos == FILAMENT_POS_UNLOADED:

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -1093,7 +1093,11 @@ class MmuController(MmuFilamentMovement):
             nozzle_segment(),
         ]
 
-        is_empty = pos == FILAMENT_POS_UNLOADED and _gate_empty()
+        # Unlike the fill/marker helpers above, the EMPTY/UNLOADED text itself is
+        # never second-guessed by a sensor -- gate_status is what the user (or
+        # gate-map logic) declared, and that word should be trustworthy on its
+        # own even while a sensor's real reading still draws filament above it.
+        is_empty = pos == FILAMENT_POS_UNLOADED and gate_status == GATE_EMPTY
 
         if pos == FILAMENT_POS_LOADED:
             parts.append(" {5}{4}LOADED{0}{6}")

--- a/test/README.md
+++ b/test/README.md
@@ -640,16 +640,49 @@ reactor fixes that in theory but breaks `MMU_PRELOAD` in practice (every gate en
 
 ---
 
+## 1b. The filament-display sweep
+
+```
+make filament_display
+make filament_display ARGS='-k UNKNOWN'
+```
+
+Renders `get_filament_position_string()` (the `[T0] ■◉■■◉■┈┈┈...` status line) across
+every sensor/position/`gate_homing_endstop` combination — thousands of them, in
+milliseconds — so a change to that method can be eyeballed everywhere at once instead
+of one console prompt at a time. `filament_display.py` wraps a plain-data
+`FilamentDisplayState` in a duck-typed stand-in for `self` and calls the *real*
+`MmuController.get_filament_position_string` directly, so there's no copy of its logic
+to keep in sync — only the stand-in's attribute names need updating if that method ever
+touches something new on `self`.
+
+Not part of `make test`: this repo's discovery pattern is `*`, not unittest's default
+`test*.py`, so a `test_*.py`-style name alone wouldn't keep this out — `make test` would
+sweep it in and print its whole render matrix as test output. Instead
+`filament_display_review.py` defines a `load_tests(loader, tests, pattern)` hook, which
+unittest's loader always consults in place of collecting `TestCase` subclasses; it
+returns an empty suite unless `HH_FILAMENT_DISPLAY_REVIEW` is set, which only the
+`filament_display` Makefile target does. It's a manual/visual review aid (most of it
+renders combinations for a human to read, not asserts against them), not a correctness
+suite that should gate CI — run it on demand when touching the status line.
+
+`make UT='filament_display_review.py' test` won't work for this reason (same empty
+suite, no env var set) — `make filament_display` is the only entry point.
+
+---
+
 ## 2. What is where
 
 ```
 test/
-  test_mmu_*.py     the tests themselves — this is what you read and write
-  select.py         the file picker `make test` opens (§1)
-  console.py        the interactive console (§1a)
-  hh/               the harness: the fake Klipper and fake Moonraker
-  hh/klippy_root/   41 stand-in modules that pretend to be Klipper's own code
-  installer/        legacy installer tests, currently skipped (see §6)
+  test_mmu_*.py             the tests themselves — this is what you read and write
+  select.py                 the file picker `make test` opens (§1)
+  console.py                the interactive console (§1a)
+  filament_display.py       duck-typed adapter for get_filament_position_string() (§1b)
+  filament_display_review.py  the bulk sweep, run via `make filament_display` (§1b)
+  hh/                       the harness: the fake Klipper and fake Moonraker
+  hh/klippy_root/           41 stand-in modules that pretend to be Klipper's own code
+  installer/                legacy installer tests, currently skipped (see §6)
 ```
 
 The test files, grouped by what they're about:

--- a/test/filament_display.py
+++ b/test/filament_display.py
@@ -1,0 +1,206 @@
+# Happy Hare MMU Software
+#
+# Calls the REAL MmuController.get_filament_position_string()
+# (extras/mmu/mmu_controller.py) against a duck-typed stand-in for `self`,
+# so the filament-position status line can be exercised in bulk -- every
+# sensor/position/gate_homing_endstop combination in milliseconds, no
+# reactor or greenlets -- without maintaining a hand-ported copy of the
+# method's logic. Used by filament_display_review.py (`make filament_display`
+# -- not part of `make test`, see that file for why).
+#
+# get_filament_position_string() is a plain instance method (no
+# isinstance/super/decorator tricks), so any object exposing the same
+# attribute/method names it touches can stand in for `self`. FilamentDisplayState
+# below is that stand-in; _RealMmuController adapts it to the real names.
+#
+# Importing extras.mmu.mmu_controller at all still requires the fake klippy
+# tree (test/hh) -- mmu_filament_movement.py does `import mcu` and
+# `from ..homing import HomingMove`, real Klipper modules -- so this module
+# depends on test/hh purely to make that import succeed. No printer is
+# booted; test.hh.install() only symlinks a fake klippy/ layout onto
+# sys.path once, then the real MmuController class is used exactly as
+# extras/mmu itself would use it.
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import os, sys
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+if __package__ in (None, ''):                       # allow `python test/filament_display.py`
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from test.hh import install as _install_fake_klippy  # noqa: E402
+_install_fake_klippy()
+
+from extras.mmu.mmu_controller import MmuController  # noqa: E402
+from extras.mmu.mmu_constants import (                # noqa: E402
+    FILAMENT_POS_UNKNOWN, FILAMENT_POS_UNLOADED, FILAMENT_POS_HOMED_GATE, FILAMENT_POS_START_BOWDEN,
+    FILAMENT_POS_IN_BOWDEN, FILAMENT_POS_END_BOWDEN, FILAMENT_POS_HOMED_ENTRY, FILAMENT_POS_HOMED_EXTRUDER,
+    FILAMENT_POS_EXTRUDER_ENTRY, FILAMENT_POS_HOMED_TS, FILAMENT_POS_IN_EXTRUDER, FILAMENT_POS_LOADED,
+    DIRECTION_UNKNOWN, SENSOR_ENCODER, GATE_ENDSTOPS, GATE_AVAILABLE,
+)
+
+# All the FILAMENT_POS_* values, in position order, for combination generators
+FILAMENT_POSITIONS = [
+    FILAMENT_POS_UNKNOWN, FILAMENT_POS_UNLOADED, FILAMENT_POS_HOMED_GATE, FILAMENT_POS_START_BOWDEN,
+    FILAMENT_POS_IN_BOWDEN, FILAMENT_POS_END_BOWDEN, FILAMENT_POS_HOMED_ENTRY, FILAMENT_POS_HOMED_EXTRUDER,
+    FILAMENT_POS_EXTRUDER_ENTRY, FILAMENT_POS_HOMED_TS, FILAMENT_POS_IN_EXTRUDER, FILAMENT_POS_LOADED,
+]
+
+# Gate homing endstop choices (mirrors GATE HOMING param spec choices in
+# extras/mmu/unit/mmu_unit_parameters.py). gate_preload_endstop additionally
+# allows '' meaning "inherit gate_homing_endstop".
+GATE_HOMING_ENDSTOPS = list(GATE_ENDSTOPS)
+GATE_PRELOAD_ENDSTOPS = list(GATE_ENDSTOPS) + ['']
+
+
+@dataclass
+class FilamentDisplayState:
+    """
+    Plain-data stand-in for everything get_filament_position_string() reads
+    off `self` (MmuController), passed through _RealMmuController. Sensors
+    are modelled as a single dict rather than separate check_sensor()/
+    has_sensor() calls into a live MmuSensorManager: a sensor absent from
+    the dict (or mapped to None) is "not present", any bool value is
+    "present, triggered=value".
+    """
+    # Console formatting flags (console_show_bold_filament / console_show_filament_color)
+    bold: bool = False
+    color: bool = False
+
+    # Selection / position / direction
+    tool: int = 0
+    gate: int = 0
+    pos: int = FILAMENT_POS_UNLOADED
+    direction: int = DIRECTION_UNKNOWN
+
+    # Per-unit gate endstop config
+    gate_homing_endstop: str = SENSOR_ENCODER
+    gate_preload_endstop: str = ''  # NOTE: not currently read by get_filament_position_string()
+
+    # Whether this gate has a spool in it at all (GATE_EMPTY/GATE_AVAILABLE/
+    # GATE_UNKNOWN, mmu_constants.py) -- tracked per-gate, independent of pos
+    gate_status: int = GATE_AVAILABLE
+
+    sensors: Dict[str, Optional[bool]] = field(default_factory=dict)
+
+    # Encoder / buffer / sync-feedback
+    has_encoder: bool = False
+    encoder_move_validation: bool = False
+    encoder_distance: float = 0.0
+    has_buffer: bool = False
+    sync_feedback_state: str = "unavailable"
+    sync_feedback_bias_modelled: Optional[float] = None
+
+    # Residual filament (hotend) / gate spool color
+    filament_remaining: float = 0.0
+    filament_remaining_color: str = ""
+    gate_color: str = ""
+
+    # Drive (stepper) position, mm
+    filament_position: float = 0.0
+
+    def check_sensor(self, name):
+        return self.sensors.get(name)
+
+    def has_sensor(self, name):
+        return self.sensors.get(name) is not None
+
+
+class _ConstantIndex:
+    """`self.gate_status[gate]` / `self.gate_color[gate]` only ever need one
+    gate's value here, regardless of the index the real method indexes with."""
+    def __init__(self, value):
+        self._value = value
+
+    def __getitem__(self, index):
+        return self._value
+
+
+class _RealMmuController:
+    """Duck-typed `self` for MmuController.get_filament_position_string(),
+    backed by a FilamentDisplayState -- exposes exactly the attribute/method
+    names that method touches, nothing more."""
+
+    def __init__(self, state):
+        self._state = state
+        self.p = _ConsoleParams(state)
+        self.tool_selected = state.tool
+        self.gate_selected = state.gate
+        self.filament_pos = state.pos
+        self.filament_direction = state.direction
+        self.gate_status = _ConstantIndex(state.gate_status)
+        self.gate_color = _ConstantIndex(state.gate_color)
+        self.sensor_manager = _SensorManagerShim(state)
+
+    def mmu_unit(self):
+        return _MmuUnitShim(self._state)
+
+    def get_status(self, flags):
+        return {
+            'filament_remaining': self._state.filament_remaining,
+            'filament_remaining_color': self._state.filament_remaining_color,
+            'sync_feedback_state': self._state.sync_feedback_state,
+            'sync_feedback_bias_modelled': self._state.sync_feedback_bias_modelled,
+        }
+
+    def has_encoder(self):
+        return self._state.has_encoder
+
+    def get_encoder_distance(self, dwell=None):
+        return self._state.encoder_distance
+
+    def drive(self):
+        return _DriveShim(self._state)
+
+
+class _ConsoleParams:
+    def __init__(self, state):
+        self.console_show_bold_filament = state.bold
+        self.console_show_filament_color = state.color
+
+
+class _MmuUnitShim:
+    def __init__(self, state):
+        self._state = state
+        self.p = _UnitParams(state)
+
+    def has_buffer(self):
+        return self._state.has_buffer
+
+
+class _UnitParams:
+    def __init__(self, state):
+        self.gate_homing_endstop = state.gate_homing_endstop
+        self.encoder_move_validation = state.encoder_move_validation
+
+
+class _SensorManagerShim:
+    def __init__(self, state):
+        self._state = state
+
+    def check_sensor(self, name):
+        return self._state.check_sensor(name)
+
+    def has_sensor(self, name):
+        return self._state.has_sensor(name)
+
+
+class _DriveShim:
+    def __init__(self, state):
+        self._state = state
+
+    def get_filament_position(self):
+        return self._state.filament_position
+
+
+def get_filament_position_string(state):
+    return MmuController.get_filament_position_string(_RealMmuController(state))
+
+
+def strip_color_markup(visual):
+    """Strip the {0}..{6} / {{RRGGBB}} / {{}} tokens that MmuLogger._color_message()
+    (extras/mmu/mmu_logger.py) would otherwise resolve, leaving the plain glyphs."""
+    import re
+    return re.sub(r'\{\{[0-9A-Fa-f]*\}\}|\{[0-9]\}', '', visual)

--- a/test/filament_display_review.py
+++ b/test/filament_display_review.py
@@ -1,0 +1,824 @@
+# Happy Hare MMU Software
+#
+# Bulk sensor/position/gate_homing_endstop sweep for
+# MmuController.get_filament_position_string() (extras/mmu/mmu_controller.py),
+# via filament_display.py's duck-typed adapter -- the real method runs every
+# time, nothing here is a copy of its logic.
+#
+# This repo's discovery pattern is '*', so `make test` would otherwise sweep this
+# in and print its whole render matrix as test output; the load_tests() hook near
+# the bottom keeps it out except via the dedicated target below. It's a manual/
+# visual review aid, not an assertion-heavy correctness suite -- most methods just
+# render every combination in a matrix and print it so a human can eyeball the
+# result. Run it on demand instead:
+#
+#   make filament_display
+#   make filament_display ARGS='-k UNKNOWN'
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import os, sys, unittest
+import itertools
+
+if __package__ in (None, ''):                       # allow `python test/filament_display_review.py`
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from test.filament_display import (                 # noqa: E402
+    FilamentDisplayState, get_filament_position_string, strip_color_markup,
+    FILAMENT_POSITIONS, GATE_HOMING_ENDSTOPS, GATE_PRELOAD_ENDSTOPS,
+)
+from extras.mmu.mmu_constants import (
+    FILAMENT_POS_UNKNOWN, FILAMENT_POS_UNLOADED, FILAMENT_POS_HOMED_GATE, FILAMENT_POS_START_BOWDEN,
+    FILAMENT_POS_IN_BOWDEN, FILAMENT_POS_END_BOWDEN, FILAMENT_POS_HOMED_ENTRY, FILAMENT_POS_HOMED_EXTRUDER,
+    FILAMENT_POS_EXTRUDER_ENTRY, FILAMENT_POS_HOMED_TS, FILAMENT_POS_IN_EXTRUDER, FILAMENT_POS_LOADED,
+    DIRECTION_LOAD, DIRECTION_UNLOAD, DIRECTION_UNKNOWN, TOOL_GATE_BYPASS,
+    SENSOR_ENCODER, SENSOR_EXTRUDER_ENTRY, SENSOR_TOOLHEAD, SENSOR_TENSION, SENSOR_COMPRESSION,
+    SENSOR_PROPORTIONAL, SENSOR_ENTRY_PREFIX, SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT,
+    GATE_EMPTY, GATE_AVAILABLE, UI_SENSOR_TRIGGERED, UI_SENSOR_EMPTY,
+)
+
+POS_NAMES = {
+    FILAMENT_POS_UNKNOWN:         "UNKNOWN",
+    FILAMENT_POS_UNLOADED:        "UNLOADED",
+    FILAMENT_POS_HOMED_GATE:      "HOMED_GATE",
+    FILAMENT_POS_START_BOWDEN:    "START_BOWDEN",
+    FILAMENT_POS_IN_BOWDEN:       "IN_BOWDEN",
+    FILAMENT_POS_END_BOWDEN:      "END_BOWDEN",
+    FILAMENT_POS_HOMED_ENTRY:     "HOMED_ENTRY",
+    FILAMENT_POS_HOMED_EXTRUDER:  "HOMED_EXTRUDER",
+    FILAMENT_POS_EXTRUDER_ENTRY:  "EXTRUDER_ENTRY",
+    FILAMENT_POS_HOMED_TS:        "HOMED_TS",
+    FILAMENT_POS_IN_EXTRUDER:     "IN_EXTRUDER",
+    FILAMENT_POS_LOADED:          "LOADED",
+}
+
+# Named sensor availability/state profiles applied on top of whatever gate
+# endstop sensor a given combination needs (see build_sensors()).
+# None = sensor not fitted, True/False = fitted and triggered/clear.
+SENSOR_PROFILES = {
+    "no_optional_sensors":     {SENSOR_EXTRUDER_ENTRY: None,  SENSOR_TOOLHEAD: None},
+    "optional_sensors_clear":  {SENSOR_EXTRUDER_ENTRY: False, SENSOR_TOOLHEAD: False},
+    "optional_sensors_triggered": {SENSOR_EXTRUDER_ENTRY: True, SENSOR_TOOLHEAD: True},
+}
+
+
+def build_sensors(gate_homing_endstop, profile, gate_triggered=True, entry=None, exit_sensor=None, shared_exit=None):
+    """
+    Compose a sensors dict for FilamentDisplayState: start from a named
+    SENSOR_PROFILES entry, then fit (or not) the sensor backing the current
+    gate_homing_endstop. SENSOR_ENCODER is a movement-based fake endstop with
+    no physical runout sensor, so it never gets a sensors-dict entry.
+
+    entry/exit_sensor/shared_exit (None = not fitted, True/False = fitted and
+    triggered/clear) let a caller independently fit the gate-area sensors that
+    gate_area_segment() now renders, on top of/overriding whatever
+    gate_homing_endstop already implied.
+    """
+    sensors = dict(SENSOR_PROFILES[profile])
+    if gate_homing_endstop != SENSOR_ENCODER:
+        sensors[gate_homing_endstop] = gate_triggered
+    if entry is not None:
+        sensors[SENSOR_ENTRY_PREFIX] = entry
+    if exit_sensor is not None:
+        sensors[SENSOR_EXIT_PREFIX] = exit_sensor
+    if shared_exit is not None:
+        sensors[SENSOR_SHARED_EXIT] = shared_exit
+    return sensors
+
+
+# console_show_bold_filament: "thin" uses the light line/arrow/home glyphs
+# (UI_LINE_LIGHT / UI_ARROW_FILLED_RIGHT / UI_HOME_LIGHT), "thick" uses the
+# bold solid-square set (UI_SOLID_SQUARE / UI_HOME_BOLD). Every batch below
+# repeats once per style so both render styles can be eyeballed side by side.
+BOLD_STYLES = (("thin", False), ("thick", True))
+
+
+def style_header(style_name, is_bold):
+    print(f"\n=== {style_name} filament line (bold={is_bold}) ===")
+
+
+# Fixed label column width used everywhere below so every printed status line
+# lines up, regardless of which test method produced it. unittest's own
+# verbose "test_name (...) ... " progress text has no trailing newline, so
+# each test method must print() a leading blank line before its first
+# render() call -- otherwise that first line gets shifted right, out of
+# alignment with the rest. Must be >= the longest label actually produced
+# below (currently "[shared_exit fitted, triggered, START_BOWDEN]" at 45
+# chars) -- widen this if a longer label gets added rather than shortening
+# the label, so the column keeps a little breathing room either side.
+LABEL_WIDTH = 48
+
+
+def render(label, state, verbose=True):
+    visual = strip_color_markup(get_filament_position_string(state))
+    if verbose:
+        print(f"{label:<{LABEL_WIDTH}} {visual}")
+    return visual
+
+
+SYNC_FEEDBACK_STATES = ["unavailable", "disabled", "inactive", "compressed", "tension", "neutral"]
+
+
+def render_buffer_batch(is_bold):
+    """Sync-feedback-buffer displays: tension/compression combos x sync_feedback_state,
+    plus the proportional-sensor numeric-bias variant of the neutral state."""
+    for sf_state in SYNC_FEEDBACK_STATES:
+        for c_sensor, t_sensor in ((False, False), (True, False), (False, True)):
+            sensors = build_sensors(SENSOR_ENCODER, "no_optional_sensors")
+            sensors[SENSOR_COMPRESSION] = c_sensor
+            sensors[SENSOR_TENSION] = t_sensor
+            state = FilamentDisplayState(
+                pos=FILAMENT_POS_IN_BOWDEN,
+                bold=is_bold,
+                gate_homing_endstop=SENSOR_ENCODER,
+                sensors=sensors,
+                has_encoder=True,
+                encoder_move_validation=True,
+                encoder_distance=1234.5,
+                has_buffer=True,
+                sync_feedback_state=sf_state,
+                filament_position=1234.5,
+            )
+            render(f"[sf={sf_state} C={c_sensor} T={t_sensor}]", state)
+
+    # Proportional sensor takes over the neutral-state slot with a numeric bias
+    sensors = build_sensors(SENSOR_ENCODER, "no_optional_sensors")
+    sensors[SENSOR_PROPORTIONAL] = True
+    for bias in (-1.0, -0.3, 0.0, 0.3, 1.0):
+        state = FilamentDisplayState(
+            pos=FILAMENT_POS_IN_BOWDEN,
+            bold=is_bold,
+            gate_homing_endstop=SENSOR_ENCODER,
+            sensors=sensors,
+            has_encoder=True,
+            encoder_move_validation=True,
+            encoder_distance=1234.5,
+            has_buffer=True,
+            sync_feedback_state="neutral",
+            sync_feedback_bias_modelled=bias,
+            filament_position=1234.5,
+        )
+        render(f"[sf=neutral proportional bias={bias:+.1f}]", state)
+
+
+# Physical order of the 4 gate-area endstop choices, gate-ward to
+# extruder-ward -- mirrors GATE_SENSOR_ORDER in filament_display.py, and is
+# used the same way: whether a sensor's location has been passed once we've
+# reached FILAMENT_POS_HOMED_GATE via a *different*, further-along endstop.
+GATE_SENSOR_ORDER = (SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT, SENSOR_ENCODER, SENSOR_EXTRUDER_ENTRY)
+
+# Sensors relevant to depth-of-parking at FILAMENT_POS_UNLOADED, in physical
+# (gate-ward-most-first) order
+PARKING_ORDER = (SENSOR_ENTRY_PREFIX, SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT)
+SENSOR_SHORT_NAME = {
+    SENSOR_ENTRY_PREFIX: "entry",
+    SENSOR_EXIT_PREFIX: "exit",
+    SENSOR_SHARED_EXIT: "shared_exit",
+    SENSOR_EXTRUDER_ENTRY: "extruder",
+    SENSOR_TOOLHEAD: "toolhead",
+}
+
+# All 5 real, independently-fittable gate-area sensors (encoder isn't a
+# "sensors dict" entry -- it has no physical trigger, see
+# UI_ENCODER_VIRTUAL_TRIGGER in filament_display.py -- its presence is the
+# has_encoder hardware flag instead)
+ALL_FITTED = frozenset((SENSOR_ENTRY_PREFIX, SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT, SENSOR_EXTRUDER_ENTRY))
+
+SENSOR_COMBO_NAMES = ("entry", "exit", "shared_exit", "encoder", "extruder", "toolhead")
+SENSOR_COMBO_TO_CONSTANT = {
+    "entry": SENSOR_ENTRY_PREFIX,
+    "exit": SENSOR_EXIT_PREFIX,
+    "shared_exit": SENSOR_SHARED_EXIT,
+    "extruder": SENSOR_EXTRUDER_ENTRY,
+    "toolhead": SENSOR_TOOLHEAD,
+}
+
+# Every combination of the 6 sensors, none fitted through all fitted (2**6 = 64),
+# grouped by size then in SENSOR_COMBO_NAMES order within each size
+SENSOR_COMBOS = tuple(
+    itertools.chain.from_iterable(
+        itertools.combinations(SENSOR_COMBO_NAMES, r) for r in range(len(SENSOR_COMBO_NAMES) + 1)
+    )
+)
+
+
+def _combo_config(combo):
+    """
+    For a given fitted-sensor combo (a tuple of names from SENSOR_COMBO_NAMES):
+    has_encoder is simply whether "encoder" is in the combo; the real,
+    independently-checkable sensors (entry/exit/shared_exit/extruder/toolhead)
+    map straight to their FilamentDisplayState.sensors keys.
+    """
+    has_encoder = "encoder" in combo
+    fitted = frozenset(SENSOR_COMBO_TO_CONSTANT[name] for name in combo if name in SENSOR_COMBO_TO_CONSTANT)
+    return has_encoder, fitted
+
+
+# The 4 gate_homing_endstop choices (mirrors GATE_ENDSTOPS in filament_display.py)
+GATE_ENDSTOP_NAME_TO_CONSTANT = {
+    "exit": SENSOR_EXIT_PREFIX,
+    "shared_exit": SENSOR_SHARED_EXIT,
+    "encoder": SENSOR_ENCODER,
+    "extruder": SENSOR_EXTRUDER_ENTRY,
+}
+
+
+def _valid_gate_endstops(combo):
+    """
+    gate_homing_endstop can only be set to something that physically exists
+    on the machine -- you can't home against a switch you don't have. So the
+    only valid choices for a given combo are whichever of exit/shared_exit/
+    encoder/extruder are actually in it (not crossed with every choice
+    regardless of fitment, and not "entry", which was never a valid
+    gate_homing_endstop choice in the first place -- see GATE_ENDSTOPS in
+    filament_display.py). A combo with none of the four (e.g. () or
+    ("entry",)) has no valid gate_homing_endstop at all -- gate homing simply
+    isn't possible on that machine -- so it contributes no rows.
+    """
+    return [(name, GATE_ENDSTOP_NAME_TO_CONSTANT[name]) for name in combo if name in GATE_ENDSTOP_NAME_TO_CONSTANT]
+
+
+def _gate_sensor_triggered(sensor, pos, gate_endstop):
+    """Has the tip reached/passed sensor's location, given the active gate_homing_endstop?
+    (FILAMENT_POS_UNLOADED is handled by _parking_subrows instead, not here.)"""
+    if pos > FILAMENT_POS_HOMED_GATE:
+        return True
+    if pos == FILAMENT_POS_HOMED_GATE:
+        return GATE_SENSOR_ORDER.index(gate_endstop) >= GATE_SENSOR_ORDER.index(sensor)
+    return False
+
+
+def _derive_sensors(pos, gate_endstop, fitted):
+    """
+    Only ever emits a state for a sensor in `fitted` (True/False) -- a sensor
+    left out of `fitted` is entirely absent (None via FilamentDisplayState's
+    own has_sensor()), never independently toggled. For every fitted sensor,
+    the trigger state is derived from `pos` (and `gate_endstop` for exit/
+    shared_exit) so each row is a physically real machine state, not an
+    arbitrary/impossible combination.
+    """
+    sensors = {}
+    if SENSOR_ENTRY_PREFIX in fitted:
+        sensors[SENSOR_ENTRY_PREFIX] = pos > FILAMENT_POS_UNLOADED
+    if SENSOR_EXIT_PREFIX in fitted:
+        sensors[SENSOR_EXIT_PREFIX] = _gate_sensor_triggered(SENSOR_EXIT_PREFIX, pos, gate_endstop)
+    if SENSOR_SHARED_EXIT in fitted:
+        sensors[SENSOR_SHARED_EXIT] = _gate_sensor_triggered(SENSOR_SHARED_EXIT, pos, gate_endstop)
+    if SENSOR_EXTRUDER_ENTRY in fitted:
+        threshold = FILAMENT_POS_HOMED_GATE if gate_endstop == SENSOR_EXTRUDER_ENTRY else FILAMENT_POS_HOMED_ENTRY
+        sensors[SENSOR_EXTRUDER_ENTRY] = pos >= threshold
+    if SENSOR_TOOLHEAD in fitted:
+        sensors[SENSOR_TOOLHEAD] = pos >= FILAMENT_POS_HOMED_TS
+    return sensors
+
+
+def _position_walk(gate_endstop):
+    """
+    (label, pos) pairs to render after the UNLOADED parking sub-rows, in order.
+
+    Special case: gate_endstop == SENSOR_EXTRUDER_ENTRY homes the gate using
+    the very same physical sensor that later (independently) confirms the
+    extruder entry, so reaching FILAMENT_POS_HOMED_GATE via this endstop
+    means the tip is already all the way at the extruder, not merely
+    "somewhere past the gate". Rather than hand-crafting a "gate homed but
+    really at the extruder" state, the "HOMED_GATE" row here renders at
+    FILAMENT_POS_HOMED_EXTRUDER instead -- exactly the HOMED_EXTRUDER row's
+    own rendering, just reused under the HOMED_GATE label -- and the
+    normally-intervening START_BOWDEN/IN_BOWDEN/END_BOWDEN/HOMED_ENTRY rows
+    are skipped, since rendering them afterwards would walk backwards from
+    where "HOMED_GATE" just landed.
+    """
+    if gate_endstop == SENSOR_EXTRUDER_ENTRY:
+        return [
+            ("HOMED_GATE", FILAMENT_POS_HOMED_EXTRUDER),
+            ("EXTRUDER_ENTRY", FILAMENT_POS_EXTRUDER_ENTRY),
+            ("HOMED_TS", FILAMENT_POS_HOMED_TS),
+            ("IN_EXTRUDER", FILAMENT_POS_IN_EXTRUDER),
+            ("LOADED", FILAMENT_POS_LOADED),
+        ]
+    return [
+        (POS_NAMES[pos], pos)
+        for pos in FILAMENT_POSITIONS
+        if pos not in (FILAMENT_POS_UNKNOWN, FILAMENT_POS_UNLOADED)
+    ]
+
+
+def _parking_subrows(fitted):
+    """
+    Depth-of-parking sub-states at FILAMENT_POS_UNLOADED: a forward-parked
+    filament triggers every gate-ward sensor up to however far forward it
+    sits and none past that point, so this enumerates "how far forward" --
+    not an independent per-sensor toggle (which would emit physically
+    impossible combinations, e.g. shared_exit triggered but exit clear).
+
+    "No sensor triggered" is genuinely ambiguous between two different
+    gate_status readings, both rendered here: a genuinely empty gate
+    (GATE_EMPTY) and filament present but parked before even the first
+    relevant sensor (GATE_AVAILABLE) -- a sensor reading alone (e.g. entry
+    clear) can't tell those apart, but gate_status is Happy Hare's actual,
+    separately-tracked answer to that question. The sensors keep reporting
+    their own real state regardless of which one it is (entry stays clear at
+    every later depth too, until "past entry"). A combo fitting none of
+    entry/exit/shared_exit still gets this same pair of rows ("empty" /
+    "parked"), just with no sensor evidence to show either way.
+
+    Any OTHER fitted sensor (extruder_entry, toolhead) is downstream of the
+    gate entirely -- at FILAMENT_POS_UNLOADED it's definitely, not just
+    presumably, clear -- so every row here marks it False rather than leaving
+    it out of the sensors dict (which would read as "not fitted" and fall
+    back to the ambiguous ellipsis fill instead of its own real ◯ glyph).
+    """
+    relevant = [s for s in PARKING_ORDER if s in fitted]
+    downstream_clear = {s: False for s in fitted if s not in PARKING_ORDER}
+    all_clear = {**{s: False for s in relevant}, **downstream_clear}
+    before_label = f"before {SENSOR_SHORT_NAME[relevant[0]]}" if relevant else "parked"
+    rows = [("empty", all_clear, GATE_EMPTY), (before_label, all_clear, GATE_AVAILABLE)]
+    for depth in range(1, len(relevant) + 1):
+        sensors = {**{s: (i < depth) for i, s in enumerate(relevant)}, **downstream_clear}
+        rows.append((f"past {SENSOR_SHORT_NAME[relevant[depth - 1]]}", sensors, GATE_AVAILABLE))
+    return rows
+
+
+# Column offsets of entry/exit/shared_exit's marker glyph within the fixed-
+# width gate_area_segment() prefix -- stable because every combo in this
+# sweep renders with the same tool="[T0] " and has_buffer=False, so the
+# segment widths leading up to each marker never vary (see
+# gate_area_segment() in filament_display.py: presence(1)+entry(1)+gap(2)+
+# exit(1)+gap(2)+shared_exit(1)+gap(2), 10 chars total).
+_TOOL_TEXT_LEN = len("[T0] ")
+_GATE_AREA_MARKER_OFFSET = {
+    SENSOR_ENTRY_PREFIX: _TOOL_TEXT_LEN + 1,
+    SENSOR_EXIT_PREFIX: _TOOL_TEXT_LEN + 4,
+    SENSOR_SHARED_EXIT: _TOOL_TEXT_LEN + 7,
+}
+
+
+def _assert_sensor_markers(test_case, visual, sensors, label):
+    """
+    For every sensor with a real (non-None) reading in `sensors`, assert its
+    marker glyph (◉/◯) actually appears at its known column in `visual`,
+    instead of relying on a human to spot a missing/wrong marker by eye.
+    extruder/toolhead sit downstream of variable-width bowden/buffer fill, so
+    their column is anchored relative to the literal "Ex"/"Nz" text instead of
+    a fixed offset from the start (see optional_sensor()/homed_segment() and
+    nozzle_segment() in filament_display.py: 3-char sensor block, marker in
+    the middle, immediately before each label).
+    """
+    for sensor, triggered in sensors.items():
+        if triggered is None:
+            continue
+        if sensor in _GATE_AREA_MARKER_OFFSET:
+            index = _GATE_AREA_MARKER_OFFSET[sensor]
+        elif sensor == SENSOR_EXTRUDER_ENTRY:
+            index = visual.index("Ex") - 3
+        elif sensor == SENSOR_TOOLHEAD:
+            index = visual.index("Nz") - 5
+        else:
+            continue
+        expected = UI_SENSOR_TRIGGERED if triggered else UI_SENSOR_EMPTY
+        test_case.assertEqual(
+            visual[index], expected,
+            f"{label}: {SENSOR_SHORT_NAME[sensor]} marker wrong at column {index} in {visual!r}"
+        )
+
+
+class TestFilamentDisplayVisualReview(unittest.TestCase):
+    """
+    Curated, ordered walkthrough for manual visual review (as opposed to the
+    brute-force cartesian dumps in the other test classes below): for each
+    line style (thin then thick), all 64 combinations of which of {entry,
+    exit, shared_exit, encoder, extruder, toolhead} are fitted (SENSOR_COMBOS
+    -- the full powerset, none through all six), crossed ONLY with the
+    gate_homing_endstop choices that combo can actually have (_valid_gate_endstops
+    -- you can't home against a switch that doesn't exist, so "exit" is only
+    ever the active endstop in combos that fit it, etc; a combo fitting none
+    of exit/shared_exit/encoder/extruder can't home its gate at all and is
+    skipped). Within a group, only the fitted sensors' triggered state and
+    filament_position vary, and the former is *derived from* the latter (see
+    _derive_sensors) so every row is a physically real machine state,
+    walking UNKNOWN first, then every filament_position in order with
+    UNLOADED expanded into its depth-of-parking sub-rows.
+    """
+
+    def _render_combo(self, combo, gate_endstop, is_bold):
+        has_encoder, fitted = _combo_config(combo)
+
+        # UNKNOWN first (before boot/recovery has determined a position at
+        # all) -- _derive_sensors naturally reads every fitted sensor as
+        # clear here since every one of its `pos >=/>` thresholds is above
+        # FILAMENT_POS_UNKNOWN, which is itself a physically real state
+        # rather than a special case.
+        unknown_sensors = _derive_sensors(FILAMENT_POS_UNKNOWN, gate_endstop, fitted)
+        state = FilamentDisplayState(
+            tool=0, gate=0, pos=FILAMENT_POS_UNKNOWN, bold=is_bold, has_encoder=has_encoder,
+            gate_homing_endstop=gate_endstop, sensors=unknown_sensors,
+            encoder_move_validation=has_encoder, encoder_distance=1234.5,
+            filament_position=1234.5,
+        )
+        visual = render("[UNKNOWN]", state)
+        _assert_sensor_markers(self, visual, unknown_sensors, "UNKNOWN")
+
+        # Same position, opposite extreme: every fitted sensor reads
+        # triggered despite the position genuinely being unknown -- a
+        # physically odd but not impossible combination (e.g. stale/noisy
+        # sensor state on a freshly connected MCU, before anything has
+        # actually been homed), and a real stress case for any fill logic
+        # that assumes "no known position" implies "no possible progress".
+        unknown_all_triggered = {s: True for s in fitted}
+        state = FilamentDisplayState(
+            tool=0, gate=0, pos=FILAMENT_POS_UNKNOWN, bold=is_bold, has_encoder=has_encoder,
+            gate_homing_endstop=gate_endstop, sensors=unknown_all_triggered,
+            encoder_move_validation=has_encoder, encoder_distance=1234.5,
+            filament_position=1234.5,
+        )
+        visual = render("[UNKNOWN, all triggered]", state)
+        _assert_sensor_markers(self, visual, unknown_all_triggered, "UNKNOWN, all triggered")
+
+        # Fabricated, distinctly-not-zero mm values -- 0.0 reads as "nothing
+        # happened yet" and, more importantly, silently hid the "(e:...)"
+        # encoder-distance suffix (needs encoder_move_validation=True too,
+        # which a bare has_encoder=True doesn't imply).
+        for sub_label, sensors, gate_status in _parking_subrows(fitted):
+            state = FilamentDisplayState(
+                tool=0, gate=0, pos=FILAMENT_POS_UNLOADED, bold=is_bold, has_encoder=has_encoder,
+                gate_homing_endstop=gate_endstop, sensors=sensors, gate_status=gate_status,
+                encoder_move_validation=has_encoder, encoder_distance=1234.5,
+                filament_position=1234.5,
+            )
+            visual = render(f"[{sub_label}]", state)
+            _assert_sensor_markers(self, visual, sensors, sub_label)
+
+        for label, pos in _position_walk(gate_endstop):
+            sensors = _derive_sensors(pos, gate_endstop, fitted)
+            state = FilamentDisplayState(
+                tool=0, gate=0, pos=pos, bold=is_bold, has_encoder=has_encoder,
+                gate_homing_endstop=gate_endstop, sensors=sensors,
+                encoder_move_validation=has_encoder, encoder_distance=1234.5,
+                filament_position=1234.5,
+            )
+            visual = render(f"[{label}]", state)
+            _assert_sensor_markers(self, visual, sensors, label)
+
+    def test_visual_review(self):
+        print()
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+
+            print("\n--- sync-feedback buffer ---")
+            render_buffer_batch(is_bold)
+
+            for n, combo in enumerate(SENSOR_COMBOS, start=1):
+                combo_desc = ", ".join(combo) if combo else "None"
+                valid_endstops = _valid_gate_endstops(combo)
+                if not valid_endstops:
+                    print(f"\n--- {n}) {combo_desc} / no valid gate_homing_endstop -- skipped ---")
+                    continue
+                for endstop_label, gate_endstop in valid_endstops:
+                    print(f"\n--- {n}) {combo_desc} / gate_endstop={endstop_label} ---")
+                    self._render_combo(combo, gate_endstop, is_bold)
+
+
+class TestFilamentDisplayAllSensorsAlwaysFalse(unittest.TestCase):
+    """
+    All 5 real, independently-fittable sensors (entry/exit/shared_exit/
+    extruder/toolhead) fitted, but forced to read False at every single
+    filament_position -- regardless of how far the tip has actually
+    travelled, unlike _derive_sensors' physically-consistent derivation used
+    by TestFilamentDisplayVisualReview. This is a broken/miscalibrated-sensor
+    scenario: it exercises the "sensor fitted but never triggers" fallback
+    glyph (empty_sensor, not trig_sensor) at positions where a working sensor
+    would normally read triggered, and confirms the pos-driven "already
+    passed" line fill (past()/_passed_gate_sensor()) doesn't secretly depend
+    on a sensor ever having reported True.
+    """
+
+    ALWAYS_FALSE_SENSORS = {
+        SENSOR_ENTRY_PREFIX: False,
+        SENSOR_EXIT_PREFIX: False,
+        SENSOR_SHARED_EXIT: False,
+        SENSOR_EXTRUDER_ENTRY: False,
+        SENSOR_TOOLHEAD: False,
+    }
+
+    def test_all_sensors_always_false(self):
+        print()
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+            for pos in FILAMENT_POSITIONS:
+                state = FilamentDisplayState(
+                    tool=0, gate=0, pos=pos, bold=is_bold, has_encoder=True,
+                    gate_homing_endstop=SENSOR_ENCODER, sensors=dict(self.ALWAYS_FALSE_SENSORS),
+                    gate_status=GATE_AVAILABLE,
+                    encoder_move_validation=True, encoder_distance=1234.5,
+                    filament_position=1234.5,
+                )
+                visual = render(f"[{POS_NAMES[pos]}]", state)
+                self.assertTrue(visual)
+
+
+class TestFilamentDisplayLoadUnloadDirection(unittest.TestCase):
+    """Mid-move states (pos not LOADED/UNLOADED/UNKNOWN) show a direction arrow instead."""
+
+    def test_direction_arrows(self):
+        print()
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+            for direction, label in ((DIRECTION_LOAD, "LOAD"), (DIRECTION_UNLOAD, "UNLOAD")):
+                state = FilamentDisplayState(
+                    pos=FILAMENT_POS_IN_BOWDEN,
+                    bold=is_bold,
+                    direction=direction,
+                    gate_homing_endstop=SENSOR_ENCODER,
+                    sensors=build_sensors(SENSOR_ENCODER, "optional_sensors_clear"),
+                    has_encoder=True,
+                    encoder_move_validation=True,
+                    encoder_distance=1234.5,
+                    filament_position=1234.5,
+                )
+                visual = render(f"[dir={label}]", state)
+                self.assertTrue(visual)
+
+
+class TestFilamentDisplayGatePreloadEndstop(unittest.TestCase):
+    """
+    gate_preload_endstop is read into FilamentDisplayState but the ported
+    render logic (like the original get_filament_position_string) never
+    consults it -- this test documents that today, so it turns red the
+    moment display work in this file starts factoring preload endstop into
+    the render, which is a useful nudge to update this test alongside it.
+    """
+
+    def test_preload_endstop_currently_has_no_effect(self):
+        print()
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+            renders = set()
+            for gate_preload_endstop in GATE_PRELOAD_ENDSTOPS:
+                state = FilamentDisplayState(
+                    pos=FILAMENT_POS_HOMED_GATE,
+                    bold=is_bold,
+                    gate_homing_endstop=GATE_HOMING_ENDSTOPS[0],
+                    gate_preload_endstop=gate_preload_endstop,
+                    sensors=build_sensors(GATE_HOMING_ENDSTOPS[0], "optional_sensors_clear"),
+                    has_encoder=True,
+                    encoder_move_validation=True,
+                    encoder_distance=1234.5,
+                    filament_position=1234.5,
+                )
+                visual = render(f"[preload={gate_preload_endstop or '(inherit)'}]", state)
+                renders.add(visual)
+
+            self.assertEqual(len(renders), 1, "gate_preload_endstop changed the render - update this test")
+
+
+class TestFilamentDisplayGateArea(unittest.TestCase):
+    """
+    gate_area_segment() -- the 10-char block right after the tool tag that
+    shows a leading gate_presence_marker() char, then the entry sensor plus
+    BOTH exit and shared_exit sensors independently (a unit can have both
+    fitted even though only one is the active gate_homing_endstop). Same
+    total rendered width either way: an unfitted sensor falls back to plain
+    past()-style arrow/space filler instead of a marker glyph. The exit/
+    shared_exit gaps are 2 chars each (not 1) so the three markers (exit,
+    shared_exit, encoder) read as visually distinct beats; funded by
+    shrinking encoder ("En" -> "e") by 1 and the bowden fill on both sides of
+    the sync-feedback buffer by 1-2 chars. Exit's and shared_exit's markers
+    always show their own real reading independently, never collapsed to
+    plain fill just because the other has also been reached -- a fitted
+    sensor's real data is never stale, no matter which one is the active
+    gate_homing_endstop. At FILAMENT_POS_UNLOADED specifically (forward-parked,
+    no discrete "homed" event), the entry-to-exit gap (entry_exit_gap()) shows
+    a token one-char tip -- not the gate_presence_marker()'s plain presence
+    indication, and not a full arrow run -- only once entry itself has
+    actually confirmed the tip got that far; the exit/shared_exit gaps
+    (gate_sensor_gap()) show the same split pattern once THEIR sensor has been
+    reached but not yet passed. The char right before whichever sensor is the
+    active gate_homing_endstop becomes `home` exactly when homed there (see
+    _with_home), and no OTHER char anywhere in
+    the whole rendered string is left eligible to also become the
+    leading-edge tip at that point: the final global pass in
+    get_filament_position_string() only restores an arrow-as-tip when no
+    `home` glyph appears anywhere, so once we're exactly homed, `home` alone
+    marks "arrived here" -- matching homed_segment()'s "no tip when exactly
+    at target" convention used everywhere else in this file (HOMED_ENTRY,
+    HOMED_EXTRUDER, HOMED_TS included). In "thick" style the home-char swap
+    is invisible either way since home and arrow share the same glyph
+    (UI_HOME_BOLD) by original design.
+    """
+
+    def _prefix(self, state):
+        # gate_area_segment() output is always the 10 chars right after tool_text
+        visual = strip_color_markup(get_filament_position_string(state))
+        tool_text_len = len(f"[T{state.tool}] ") if state.tool >= 0 else len("[T?] ")
+        return visual[tool_text_len:tool_text_len + 10]
+
+    def test_pinned_examples(self):
+        """
+        Pins the exact 10-char sequences from the design proposal so a future
+        display tweak can't silently drift this back out of shape. Entry
+        sensor fitted+triggered throughout (leading '◉', preceded by the
+        gate_presence_marker() line char); gate_homing_endstop only matters
+        once pos==HOMED_GATE (decides which of exit/shared_exit/encoder
+        counts as "already passed").
+
+        Thin-style expected prefixes were captured from a real run rather than
+        hand-derived: which single arrow in the whole string stays as the
+        "leading edge" glyph (instead of collapsing to a plain line char) is
+        decided by scanning the *entire* rendered string for the last arrow,
+        not just this 10-char prefix, so it isn't obvious by inspection alone.
+        """
+        print()
+        cases = [
+            ("exit not activated, UNLOADED",
+             dict(pos=FILAMENT_POS_UNLOADED, gate_homing_endstop=SENSOR_EXIT_PREFIX,
+                  sensors={SENSOR_ENTRY_PREFIX: True, SENSOR_EXIT_PREFIX: False, SENSOR_SHARED_EXIT: False}),
+             "━◉▶┈◯┈┈◯┈┈", "■◉■┈◯┈┈◯┈┈"),  # no evidence exit's location was reached -- only a token sliver assumed
+            ("exit set, UNLOADED (fwd-parked)",
+             dict(pos=FILAMENT_POS_UNLOADED, gate_homing_endstop=SENSOR_EXIT_PREFIX,
+                  sensors={SENSOR_ENTRY_PREFIX: True, SENSOR_EXIT_PREFIX: True, SENSOR_SHARED_EXIT: False}),
+             "━◉━━◉▶┈◯┈┈", "■◉■■◉■┈◯┈┈"),  # exit's own outgoing gap splits (just arrived, not passed beyond)
+            ("exit set, homed@exit",
+             dict(pos=FILAMENT_POS_HOMED_GATE, gate_homing_endstop=SENSOR_EXIT_PREFIX,
+                  sensors={SENSOR_ENTRY_PREFIX: True, SENSOR_EXIT_PREFIX: True, SENSOR_SHARED_EXIT: False}),
+             "━◉━┫◉┈┈◯┈┈", "■◉■■◉┈┈◯┈┈"),  # home char before exit's own marker, no stray tip nearby
+                                            # (bold: home glyph == arrow glyph anyway)
+            ("exit set, homed@shared_exit",
+             dict(pos=FILAMENT_POS_HOMED_GATE, gate_homing_endstop=SENSOR_SHARED_EXIT,
+                  sensors={SENSOR_ENTRY_PREFIX: True, SENSOR_EXIT_PREFIX: True, SENSOR_SHARED_EXIT: True}),
+             "━◉━━◉━┫◉┈┈", "■◉■■◉■■◉┈┈"),  # exit's own real reading still shows even though shared_exit
+                                            # is the active endstop; home char before shared_exit's marker
+            ("exit set, homed@encoder",
+             dict(pos=FILAMENT_POS_HOMED_GATE, gate_homing_endstop=SENSOR_ENCODER,
+                  sensors={SENSOR_ENTRY_PREFIX: True, SENSOR_EXIT_PREFIX: True, SENSOR_SHARED_EXIT: True}),
+             "━◉━━◉━━◉━┫", "■◉■■◉■■◉■■"),  # exit's and shared_exit's own real readings both show;
+                                            # home char right before "e"/ê
+            ("start of bowden (encoder)",
+             dict(pos=FILAMENT_POS_START_BOWDEN, gate_homing_endstop=SENSOR_ENCODER,
+                  sensors={SENSOR_ENTRY_PREFIX: True, SENSOR_EXIT_PREFIX: True, SENSOR_SHARED_EXIT: True}),
+             "━◉━━◉━━◉━━", "■◉■■◉■■◉■■"),  # thick prefix unchanged; "e"+bowden arrows differ after it
+        ]
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+            for label, kwargs, thin_prefix, thick_prefix in cases:
+                expected_prefix = thick_prefix if is_bold else thin_prefix
+                state = FilamentDisplayState(tool=0, gate=0, bold=is_bold, has_encoder=True,
+                                              encoder_move_validation=True, encoder_distance=1234.5,
+                                              filament_position=1234.5, **kwargs)
+                visual = render(f"[{label}]", state)
+                self.assertEqual(self._prefix(state), expected_prefix, f"{label}: prefix drifted from pinned design")
+                self.assertTrue(visual)
+
+    def test_entry_sensor_optional(self):
+        """No entry sensor fitted -> P1 falls back to the plain past(UNLOADED) arrow (old behaviour)."""
+        print()
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+            for entry in (None, False, True):
+                state = FilamentDisplayState(
+                    tool=0, gate=0, pos=FILAMENT_POS_HOMED_GATE, bold=is_bold, has_encoder=True,
+                    gate_homing_endstop=SENSOR_EXIT_PREFIX,
+                    sensors=build_sensors(SENSOR_EXIT_PREFIX, "no_optional_sensors", entry=entry,
+                                          exit_sensor=True, shared_exit=False),
+                    encoder_move_validation=True, encoder_distance=1234.5,
+                    filament_position=1234.5,
+                )
+                label = f"[entry={'not fitted' if entry is None else entry}]"
+                visual = render(label, state)
+                self.assertEqual(len(self._prefix(state)), 10)
+
+    def test_exit_and_shared_exit_independent_fitment(self):
+        """All four fitted/not-fitted combinations of exit x shared_exit, same total width throughout."""
+        print()
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+            lengths = set()
+            for exit_fitted in (None, False, True):
+                for shared_fitted in (None, False, True):
+                    state = FilamentDisplayState(
+                        tool=0, gate=0, pos=FILAMENT_POS_HOMED_GATE, bold=is_bold, has_encoder=True,
+                        gate_homing_endstop=SENSOR_EXIT_PREFIX,
+                        sensors=build_sensors(SENSOR_EXIT_PREFIX, "no_optional_sensors",
+                                              entry=True, exit_sensor=exit_fitted, shared_exit=shared_fitted),
+                        encoder_move_validation=True, encoder_distance=1234.5,
+                        filament_position=1234.5,
+                    )
+                    label = f"[exit={exit_fitted} shared_exit={shared_fitted}]"
+                    visual = render(label, state)
+                    lengths.add(len(visual))
+            self.assertEqual(len(lengths), 1, "fitted vs not-fitted changed the total rendered width")
+
+    def test_total_length_unchanged_from_original_design(self):
+        """
+        Locks in the length-neutral trade (gate area +4 overall, 'En'->'e' -1,
+        2 fewer pre-buffer bowden chars, 1 fewer post-buffer bowden char ==
+        net 0) against the length of the original design's equivalent render,
+        so future edits here don't creep the total width back up. Length
+        doesn't depend on bold (thin/thick only swap glyphs, not segment
+        character counts), so both styles pin the same expected length.
+
+        Three further, deliberate changes on top of that: at FILAMENT_POS_LOADED,
+        nozzle_segment() now only shows a single tip char past "Nz" (-1);
+        gate_area_segment() gained a leading gate_presence_marker() char (+1);
+        and the post-buffer bowden fill was shrunk by 1 more char (-1), so the
+        pinned length here is 76 - 1 + 1 - 1 = 75.
+        """
+        print()
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+            state = FilamentDisplayState(
+                tool=0, gate=0, pos=FILAMENT_POS_LOADED, bold=is_bold,
+                gate_homing_endstop=SENSOR_EXIT_PREFIX,
+                sensors={SENSOR_EXIT_PREFIX: True, SENSOR_EXTRUDER_ENTRY: True, SENSOR_TOOLHEAD: False,
+                         SENSOR_COMPRESSION: False, SENSOR_TENSION: False},
+                has_encoder=True, encoder_move_validation=True, encoder_distance=817.5,
+                has_buffer=True, sync_feedback_state="neutral",
+                filament_position=814.6,
+            )
+            visual = render("[length-neutral check]", state)
+            self.assertEqual(len(visual), 75)  # 76 (pre-gate-area-redesign) - 1 (nozzle tip)
+                                                # + 1 (presence marker) - 1 (bowden fill shrink)
+
+
+class TestFilamentDisplayBufferAndSyncFeedback(unittest.TestCase):
+    """Tension/compression/proportional sensor combinations feed the buffer_segment() bracket."""
+
+    def test_buffer_matrix(self):
+        print()
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+            render_buffer_batch(is_bold)
+
+
+class TestFilamentDisplayToolAndGateEdgeCases(unittest.TestCase):
+
+    def test_bypass_tool(self):
+        print()
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+            state = FilamentDisplayState(
+                tool=TOOL_GATE_BYPASS,
+                gate=-1,
+                pos=FILAMENT_POS_LOADED,
+                bold=is_bold,
+                gate_homing_endstop=SENSOR_ENCODER,
+                sensors=build_sensors(SENSOR_ENCODER, "optional_sensors_triggered"),
+                has_encoder=True,
+                encoder_move_validation=True,
+                encoder_distance=1234.5,
+                filament_position=1234.5,
+            )
+            visual = render("[BYPASS tool, LOADED]", state)
+            self.assertIn("[BYPASS]", visual)
+
+    def test_unknown_tool(self):
+        print()
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+            state = FilamentDisplayState(
+                tool=-1,
+                gate=-1,
+                pos=FILAMENT_POS_UNKNOWN,
+                bold=is_bold,
+                gate_homing_endstop=SENSOR_ENCODER,
+                sensors=build_sensors(SENSOR_ENCODER, "no_optional_sensors"),
+            )
+            visual = render("[T? tool, UNKNOWN pos]", state)
+            self.assertIn("[T?]", visual)
+
+    def test_gate_color(self):
+        print()
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+            state = FilamentDisplayState(
+                tool=0,
+                gate=0,
+                pos=FILAMENT_POS_LOADED,
+                bold=is_bold,
+                gate_homing_endstop=SENSOR_ENCODER,
+                sensors=build_sensors(SENSOR_ENCODER, "optional_sensors_triggered"),
+                has_encoder=True,
+                encoder_move_validation=True,
+                encoder_distance=817.5,  # matches the original design-proposal sample string
+                color=True,
+                gate_color="#FF0000",
+                filament_position=814.6,
+            )
+            # color=True path exercises _color_filament(); strip_color_markup() should
+            # remove the resulting {{RRGGBB}}...{{}} tokens same as the plain case
+            visual = render("[gate_color=#FF0000]", state)
+            self.assertNotIn("{{", visual)
+
+
+def load_tests(loader, tests, pattern):
+    # unittest's discover() (and any other loadTestsFromModule call) checks for
+    # this hook and uses its return value instead of collecting TestCase
+    # subclasses -- so `make test`'s pattern='*' sweep gets nothing from this
+    # module. HH_FILAMENT_DISPLAY_REVIEW is set only by the `filament_display`
+    # Makefile target, so the classes below still run there.
+    if os.environ.get('HH_FILAMENT_DISPLAY_REVIEW'):
+        return tests
+    return unittest.TestSuite()
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/test_mmu_selector.py
+++ b/test/test_mmu_selector.py
@@ -715,13 +715,16 @@ class TestMultiUnitSelectors(SelectorTestCase):
         self.assertEqual(self.hh.errors, [])
         self.assertEqual(self.hh.mmu.filament_pos, FILAMENT_POS_UNLOADED)
 
-        # The status line should show the exit sensor as reached/triggered, not
-        # not-yet-reached, and the trailing state text should read UNLOADED
-        # rather than the misleading EMPTY a stale gate_status would otherwise
-        # produce for a gate that a fitted sensor confirms is not empty.
+        # gate_status is left GATE_EMPTY by this path (filament_detected excludes
+        # a forward-parked, non-active-endstop exit sensor - see the docstring
+        # above), so the trailing state text correctly reads EMPTY: that text is
+        # always gate_status's word, never second-guessed by a sensor. The exit
+        # sensor's own trigger is still drawn in the fill regardless, so the two
+        # facts - "gate_map says empty" and "something is physically detected" -
+        # are both visible at once rather than one hiding the other.
         visual = self.hh.mmu.get_filament_position_string()
         self.assertIn('◉■■◉', visual)  # entry triggered, gap fully filled, exit triggered
-        self.assertIn('UNLOADED', visual)
+        self.assertIn('EMPTY', visual)
 
 
 class TestPersistedPositionRestore(unittest.TestCase):

--- a/test/test_mmu_selector.py
+++ b/test/test_mmu_selector.py
@@ -715,11 +715,12 @@ class TestMultiUnitSelectors(SelectorTestCase):
         self.assertEqual(self.hh.errors, [])
         self.assertEqual(self.hh.mmu.filament_pos, FILAMENT_POS_UNLOADED)
 
-        # The status line should show the gate as homed (3 blocks then the triggered
-        # marker), not as not-yet-reached, and the trailing state text should read
-        # UNLOADED rather than nothing at all.
+        # The status line should show the exit sensor as reached/triggered, not
+        # not-yet-reached, and the trailing state text should read UNLOADED
+        # rather than the misleading EMPTY a stale gate_status would otherwise
+        # produce for a gate that a fitted sensor confirms is not empty.
         visual = self.hh.mmu.get_filament_position_string()
-        self.assertIn('■■■◉', visual)  # UI_SOLID_SQUARE x3 then UI_SENSOR_TRIGGERED
+        self.assertIn('◉■■◉', visual)  # entry triggered, gap fully filled, exit triggered
         self.assertIn('UNLOADED', visual)
 
 


### PR DESCRIPTION
## Summary
- Adds a leading gate-presence marker to the status line, and always shows a fitted sensor's real reading instead of hiding/collapsing it based on the currently active `gate_homing_endstop`
- Adds encoder-homing-overshoot handling and a one-character-shorter tip once filament is past the nozzle (`LOADED`)
- Distinguishes `EMPTY` from `UNLOADED` text: **`gate_status` alone is authoritative for that word** — if the gate map says a gate is empty, the line says `EMPTY`, always. Sensors never override the text.
- Sensors *do* still drive the drawn fill/markers independently of that text. That inference draws on `mmu_entry`/`mmu_exit`/`mmu_shared_exit` — `encoder` and `extruder` stay excluded (movement latch and toolhead-shared, respectively). `shared_exit` is shared hardware too, but unlike those two it's a real-time switch, and this display only ever renders the currently selected/engaged gate, so its reading right now is real evidence about that gate specifically.
- Fixes a phantom-fill bug in `entry_exit_gap()` at `FILAMENT_POS_UNKNOWN` — its fallback assumed "not empty and not exactly UNLOADED-unreached" meant the tip had definitely arrived, which broke for `UNKNOWN` (numerically below `UNLOADED`, not further along it).
- Fixes `gate_presence_marker()` always rendering a flat line glyph in thin style, even when it's genuinely the furthest-along signal in the whole line — it now returns `arrow` like every other fill helper, so it can be promoted to the arrowhead tip.
- Fixes the UNLOADED forward-park fill in the gate-area segment: (1) a sensor's own fitted, directly-triggered reading wasn't checked before falling back to inference from a different sensor, so a triggered `shared_exit` still rendered a blank gap right after its own marker instead of the usual one-character "just reached" extension; (2) when nothing has triggered at all, the fill from the gate up to the first fitted sensor stayed blank even though `gate_status` confirms a spool is present — it now assumes filament sits as far forward as possible, capped at the nearest fitted sensor and at zero when a fitted entry sensor reads clear. Not tied to `gate_homing_endstop`.
- Extends the above UNLOADED fixes to `FILAMENT_POS_UNKNOWN` too — it carries exactly as little positional information, so real sensor evidence fills its gaps the same way (e.g. all gate-area sensors triggered at UNKNOWN fills right up to the last one, with the tip past it). The "nothing triggered yet, assume parked forward" convention stays UNLOADED-only, since it's parking-specific and meaningless before a position has even been determined.
- Fixes a break in the fill exactly one character after the presence marker at `UNKNOWN`: `entry_marker()`'s unfitted-sensor fallback used a `pos >= target_pos` positional comparison that can never be true for `UNKNOWN` (it sits below every real position rather than further along one), leaving a gap even with real sensor evidence right next to it. Now reuses `gate_presence_marker()`'s logic, which has no such comparison and was already correct.
- Suppresses the trailing mm measurement at `FILAMENT_POS_UNKNOWN`, matching the existing `EMPTY` suppression — nothing meaningful to measure at either.

- Code-review pass: removed an inert unused parameter (`sensor_label()`'s `label=""`, never passed non-default), trimmed comments that had drifted into narrating fix history rather than stating the current invariant, and fixed a doc-parity gap between the two copies. No behavior change.

- Moves the ad-hoc sensor-combination sweep this whole review used (previously an untracked `units/` scratch script) into `test/`, so it's checked in instead of lost, without pulling it into `make test`'s default run:
  - `test/filament_display.py` — duck-typed adapter that calls the real `MmuController.get_filament_position_string()` directly instead of a hand-ported copy, so there's no second implementation left to drift out of sync with `mmu_controller.py`.
  - `test/filament_display_review.py` — the sweep itself (12 test classes: visual review, all-sensors-false, load/unload direction, gate-preload-endstop, gate-area fill, buffer/sync-feedback, tool/gate edge cases). Kept out of `make test` via a `load_tests()` hook gated on `HH_FILAMENT_DISPLAY_REVIEW` — this repo's discovery pattern is `*`, so a non-`test_*.py` filename alone isn't enough to exclude it.
  - `make filament_display` — dedicated target that sets the env var, mirroring `console`'s shape (`make filament_display ARGS='-k UNKNOWN'` to filter).

## Test plan
- [x] `make UT='test_mmu_selector.py' ALL=1 test` — 52/52 pass
- [x] `make ALL=1 test` — full suite, 1071 tests, `OK (skipped=1, expected failures=4)` (the known-clean baseline, unaffected by the new files)
- [x] `make filament_display` — 12/12 pass
- [x] Confirmed no phantom entries in `test/select.py`'s interactive picker and no impact on `loader.errors` from the new files
- [x] Manually verified in `make console` (`ercf_vvd` profile): `MMU_GATE_MAP GATE=9 AVAILABLE=0` then selecting gate 9 renders `EMPTY` in the text while still drawing the gate's genuinely-triggered `mmu_entry_9`/`mmu_exit_9` sensors in the fill; a gate on the encoder-only unit (unit0, no per-gate entry/exit) marked `AVAILABLE=0` renders all-dashes with `EMPTY` and no phantom fill from the shared encoder
- [x] Verified the `18)`/`23)`/`41)` combos across both `gate_endstop` sibling groups: gate-area fill/extension is consistent regardless of active endstop; `[UNKNOWN, all triggered]` fills continuously up to the last activated sensor with no measurement shown; plain `[UNKNOWN]` and a combo with a fitted, clear entry sensor stay unaffected (no regressions on the token-sliver rule or the encoder-contamination fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

