### PR TITLE
Sync console sensors with explicit gate availability changes

### DIFF
--- a/test/console.py
+++ b/test/console.py
@@ -72,6 +72,11 @@ except Exception:                                   # pragma: no cover - Windows
 # precondition Happy Hare requires before a preload can start (test/README.md section 5).
 TIP_AT_GATE = -40.0
 DEFAULT_TEMP = 220
+# Gate availability values accepted by MMU_GATE_MAP. These stay local because importing
+# production `extras` before hh_session installs fake Klipper contaminates module resolution.
+GATE_EMPTY = 0
+GATE_AVAILABLE = 1
+GATE_AVAILABLE_FROM_BUFFER = 2
 
 
 ####################
@@ -770,6 +775,10 @@ class Console:
     def run_command(self, line):
         mark = len(self.sink)
         unhandled_mark = len(self.hh.gcode.unhandled)
+        gate_status_before = None
+        if (re.match(r'^\s*MMU_GATE_MAP(?:\s|$)', line, re.I)
+                and re.search(r'(?:^|\s)AVAILABLE\s*=', line, re.I)):
+            gate_status_before = list(self.hh.mmu.gate_maps.gate_status)
         # Stream Happy Hare's output as it happens rather than after the command returns.
         # Scoped to here, not global: _dispatch() is also the raw path for setup and for the
         # tests, and both need it silent.
@@ -782,6 +791,8 @@ class Console:
             # parameter would end the session.
             print(paint('!! %s' % exc, '1;31', self.color))
             self.failures += 1
+        if gate_status_before is not None:
+            self._sync_filament_to_gate_map(gate_status_before)
         # Settle whatever the command armed. Re-run unconditionally: a failed advance
         # skips its clock assignment, so this also repairs a mid-flight clock.
         try:
@@ -793,6 +804,22 @@ class Console:
         self.streaming = False
         self._warn_unhandled(line, unhandled_mark)
         self._warn_silent_macro(line, mark)
+
+    def _sync_filament_to_gate_map(self, before):
+        """Make explicit MMU_GATE_MAP availability changes physical in the simulator."""
+        after = self.hh.mmu.gate_maps.gate_status
+        with self.hh.quiet_sensors():
+            for gate, (old, new) in enumerate(zip(before, after)):
+                if old == new:
+                    continue
+                if new == GATE_EMPTY:
+                    self.fil.remove(gate)
+                elif new in (GATE_AVAILABLE, GATE_AVAILABLE_FROM_BUFFER):
+                    # An available gate has filament running back towards its source and
+                    # parked through the entry switch, ready for the MMU to pick up.
+                    self.fil.refill(gate, sync=False)
+                    self.fil.park(gate)
+                # GATE_UNKNOWN describes knowledge, not a physical state: preserve it.
 
     def _home_before_bootup(self):
         """

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -1681,6 +1681,76 @@ class TestConsoleScript(unittest.TestCase):
         self.assertIn('mmu_entry_1 disabled', out)
         self.assertIn('mmu_entry_1 enabled', out)
 
+    def test_gate_map_empty_removes_filament_from_the_gate_sensors(self):
+        console = self._make_console(['--no-log', '--plain', '--header', 'off'])
+        hh = console.hh
+        # Put this gate through every fitted sensor; other gates remain merely parked.
+        hh.place_filament(0, position=800.)
+        affected = [name for name in console.fil.sensor_names()
+                    if console.fil.gate_of(name) in (None, 0)]
+        self.assertTrue(affected, 'profile has no modelled sensors for gate 0')
+        self.assertTrue(all(hh.sensor(name).present for name in affected),
+                        'precondition: filament did not cover every sensor')
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            console.run_command('MMU_GATE_MAP GATE=0 AVAILABLE=0 QUIET=1')
+
+        self.assertEqual(hh.mmu.gate_maps.gate_status[0], 0)
+        self.assertTrue(all(not hh.sensor(name).present for name in affected),
+                        'EMPTY left one or more gate-path sensors triggered')
+
+    def test_gate_map_available_parks_filament_through_the_entry_sensor(self):
+        console = self._make_console(['--no-preload', '--no-log', '--plain',
+                                      '--header', 'off'])
+        hh = console.hh
+
+        for available in (1, 2):
+            with self.subTest(available=available):
+                # Force a real status transition for both availability values.
+                with contextlib.redirect_stdout(io.StringIO()):
+                    console.run_command('MMU_GATE_MAP GATE=0 AVAILABLE=0 QUIET=1')
+                    console.run_command(
+                        'MMU_GATE_MAP GATE=0 AVAILABLE=%d QUIET=1' % available)
+                self.assertEqual(hh.mmu.gate_maps.gate_status[0], available)
+                self.assertTrue(hh.sensor('mmu_entry_0').present)
+                self.assertFalse(hh.sensor('mmu_exit_0').present)
+
+    def test_gate_map_unknown_does_not_move_filament_or_change_sensors(self):
+        console = self._make_console(['--no-preload', '--no-log', '--plain',
+                                      '--header', 'off'])
+        hh = console.hh
+        hh.place_filament(0, position=20.)
+        before_tip = console.fil.tip[0]
+        before_sensors = {name: hh.sensor(name).present for name in hh.sensors()}
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            console.run_command('MMU_GATE_MAP GATE=0 AVAILABLE=-1 QUIET=1')
+
+        self.assertEqual(hh.mmu.gate_maps.gate_status[0], -1)
+        self.assertEqual(console.fil.tip[0], before_tip)
+        self.assertEqual({name: hh.sensor(name).present for name in hh.sensors()},
+                         before_sensors)
+
+    def test_bulk_gate_map_status_update_does_not_move_filament(self):
+        """Moonraker/UI MAP callbacks describe state; only AVAILABLE is a console action."""
+        console = self._make_console(['--no-preload', '--no-log', '--plain',
+                                      '--header', 'off'])
+        hh = console.hh
+        hh.place_filament(0, position=20.)
+        before_tip = console.fil.tip[0]
+        before_sensors = {name: hh.sensor(name).present for name in hh.sensors()}
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            console.run_command(
+                'MMU_GATE_MAP MAP="{0: {\'status\': 0, \'spool_id\': 5}}" '
+                'FROM_SPOOLMAN=1 QUIET=1')
+
+        self.assertEqual(hh.mmu.gate_maps.gate_status[0], 0,
+                         'precondition: bulk callback did not change map status')
+        self.assertEqual(console.fil.tip[0], before_tip)
+        self.assertEqual({name: hh.sensor(name).present for name in hh.sensors()},
+                         before_sensors)
+
     def test_a_disabled_sensor_reads_as_the_third_state(self):
         """Disabled is None, distinct from clear - the header must show it differently."""
         console = self._make_console(['--no-preload', '--no-log', '--plain', '--header', 'sensors'])


### PR DESCRIPTION
## Summary
- synchronize simulated filament and sensors after explicit MMU_GATE_MAP AVAILABLE changes
- clear the gate path for AVAILABLE=0 and park filament through the entry sensor for AVAILABLE=1 or 2
- preserve sensor state for AVAILABLE=-1
- exclude MAP-based Moonraker/Spoolman callbacks and metadata-only updates

## Testing
- ./venv/bin/python -m unittest test.test_mmu_console
- 180 tests passed