### PR TITLE
Require targeted gate map resets

### DIFF
--- a/config/base/mmu.cfg
+++ b/config/base/mmu.cfg
@@ -408,7 +408,7 @@ load_sequence_macro       : _MMU_LOAD_SEQUENCE		# VERY ADVANCED: Optionally call
 # These are the values that the various "RESET" commands will reset too rather than the built-in defaults. The length
 # of the lists must match the number of gates on your MMU.
 #
-# e.g. MMU_GATE_MAP RESET=1              - will use all the 'default_gate_XXX' values
+# e.g. MMU_GATE_MAP RESET=1 GATES=4,5    - will use the 'default_gate_XXX' values for gates 4 and 5
 #      MMU_TTG_MAP RESET=1               - will use the 'default_ttg_map'
 #      MMU_ENDLESS_SPOOL_GROUPS RESET=1  - will use the 'default_endless_spool_groups'
 #

--- a/extras/mmu/commands/mmu_gate_map.py
+++ b/extras/mmu/commands/mmu_gate_map.py
@@ -29,9 +29,9 @@ class MmuGateMapCommand(BaseCommand):
     HELP_PARAMS = (
         f"{CMD}: {HELP_BRIEF}\n"
         + "QUIET        = 1 To minimize console reporting\n"
-        + "RESET        = 1 To reset filament attributes to configured defaults\n"
-        + "GATES        = g,g,g comma separated list of gates (don't mix with GATE)\n"
-        + "GATE         = g Specify a single gate (don't mix with GATES)\n"
+        + "RESET        = 1 To reset specified GATE/GATES filament attributes to configured defaults\n"
+        + "GATES        = g,g,g comma separated list of gates; required with RESET unless GATE is used\n"
+        + "GATE         = g Specify a single gate; required with RESET unless GATES is used\n"
         + "BYPASS       = 1 Set filament attributes for the bypass\n"
         + "NEXT_SPOOLID = id Specify the spoolman id of the next filament loaded - automatically assigned (0 to cancel)\n"
         + "NAME         = # Filament name\n"
@@ -52,7 +52,7 @@ class MmuGateMapCommand(BaseCommand):
         + f"{CMD} NEXT_SPOOLID=45                ...Automatically mark the next spool preloaded or loaded with spoolman id 45\n"
         + f"{CMD} GATE=0 SPEED=50                ...Set load/unload speed of gate 0 to 50% - great for TPU!\n"
         + f"{CMD} GATE=0 RFID=E2003412           ...Record the RFID tag read for the spool loaded in gate 0\n"
-        + f"{CMD} RESET=1                        ...Reset filament attributes (optionally to defaults configured in mmu.cfg file)\n"
+        + f"{CMD} RESET=1 GATES=4,5              ...Reset gates 4 and 5 to defaults configured in mmu.cfg\n"
     )
 
     def __init__(self, mmu):
@@ -92,8 +92,8 @@ class MmuGateMapCommand(BaseCommand):
             mmu.log_debug("Exception whilst parsing gate map in MMU_GATE_MAP: %s" % str(e))
             return
 
-        if reset:
-            mmu.gate_maps.reset_gate_map()
+        if reset and gates == "!" and gate < 0:
+            raise gcmd.error("RESET=1 requires GATE or GATES")
 
         if next_spool_id is not None:
             # Completion of an in-flight shared NFC lookup (or a manual assignment/cancel).
@@ -168,6 +168,27 @@ class MmuGateMapCommand(BaseCommand):
 
         changed_gate_ids = []
 
+        gatelist = []
+        if gates != "!":
+            try:
+                for gate_str in gates.split(','):
+                    gate_idx = int(gate_str)
+                    if not 0 <= gate_idx < mmu.num_gates:
+                        if reset:
+                            raise ValueError
+                        continue
+                    gatelist.append(gate_idx)
+            except ValueError:
+                raise gcmd.error("Invalid GATES parameter: %s" % gates)
+        elif gate >= 0:
+            gatelist.append(gate)
+
+        if reset:
+            mmu.gate_maps.reset_gate_map(gatelist)
+            if not quiet:
+                mmu.log_always(mmu.gate_maps.gate_map_to_string(), color=True)
+            return
+
         if gate_map: # --------- BATCH UPDATE from spoolman or UI --------
             try:
                 mmu.log_debug("Received gate map update (replace: %s)" % replace)
@@ -207,6 +228,10 @@ class MmuGateMapCommand(BaseCommand):
                         spool_id = self._safe_int(fil.get('spool_id', -1))
                         if (not from_spoolman or spool_id != -1):
                             # Update attributes but don't allow spoolman to accidently clear
+                            status = self._safe_int(fil.get('status', mmu.gate_status[gate_idx]))
+                            if status == GATE_EMPTY and mmu.gate_status[gate_idx] != GATE_EMPTY:
+                                mmu.gate_maps.clear_gate_attributes(gate_idx)
+                                ids_dict[gate_idx] = -1
                             mmu.gate_filament_name[gate_idx] = fil.get('name', '')
                             mmu.gate_material[gate_idx] = fil.get('material', '')
                             mmu.gate_vendor[gate_idx] = fil.get('vendor', '')
@@ -216,7 +241,7 @@ class MmuGateMapCommand(BaseCommand):
                                 mmu.p.default_extruder_temp
                             )
                             mmu.gate_speed_override[gate_idx] = self._safe_int(fil.get('speed_override', mmu.gate_speed_override[gate_idx]))
-                            mmu.gate_status[gate_idx] = self._safe_int(fil.get('status', mmu.gate_status[gate_idx])) # For UI manual fixing of availabilty
+                            mmu.gate_status[gate_idx] = status # For UI manual fixing of availability
 
                         # RFID is read locally from gate hardware; always allow it through regardless of spoolman origin
                         if not from_spoolman:
@@ -235,21 +260,7 @@ class MmuGateMapCommand(BaseCommand):
                 mmu.log_debug("Invalid MAP parameter: %s\nException: %s" % (gate_map, str(e)))
                 raise gcmd.error("Invalid MAP parameter. See mmu.log for details")
 
-        elif gates != "!" or gate >= 0:
-            gatelist = []
-            if gates != "!":
-                # List of gates
-                try:
-                    for gate_str in gates.split(','):
-                        gate_idx = int(gate_str)
-                        if 0 <= gate_idx < mmu.num_gates:
-                            gatelist.append(gate_idx)
-                except ValueError:
-                    raise gcmd.error("Invalid GATES parameter: %s" % gates)
-            else:
-                # Specifying one gate (filament)
-                gatelist.append(gate)
-
+        elif gatelist:
             ids_dict = {}
             for gate_idx in gatelist:
                 available = gcmd.get_int('AVAILABLE', mmu.gate_status[gate_idx], minval=-1, maxval=2)
@@ -259,8 +270,12 @@ class MmuGateMapCommand(BaseCommand):
                 color = gcmd.get('COLOR', None)
                 spool_id = gcmd.get_int('SPOOLID', None, minval=-1)
                 temperature = gcmd.get_int('TEMP', int(mmu.p.default_extruder_temp))
-                speed_override = gcmd.get_int('SPEED', mmu.gate_speed_override[gate_idx], minval=10, maxval=150)
+                speed_override = gcmd.get_int('SPEED', None, minval=10, maxval=150)
                 rfid = gcmd.get('RFID', None)
+
+                if available == GATE_EMPTY and mmu.gate_status[gate_idx] != GATE_EMPTY:
+                    mmu.gate_maps.clear_gate_attributes(gate_idx)
+                    ids_dict[gate_idx] = -1
 
                 # RFID is read locally from gate hardware and isn't owned by spoolman, so it's always settable
                 rfid = rfid if rfid is not None else mmu.gate_spool_rfid[gate_idx]
@@ -274,6 +289,7 @@ class MmuGateMapCommand(BaseCommand):
                     vendor = vendor if vendor is not None else mmu.gate_vendor[gate_idx]
                     color = (color if color is not None else mmu.gate_color[gate_idx]).lower()
                     temperature = temperature or mmu.gate_temperature[gate_idx]
+                    speed_override = speed_override if speed_override is not None else mmu.gate_speed_override[gate_idx]
                     color = MmuColorUtils.validate_color(color)
                     if color is None:
                         raise gcmd.error("Color specification must be in form 'rrggbb' or 'rrggbbaa' hexadecimal value (no '#') or valid color name or empty string")
@@ -299,7 +315,8 @@ class MmuGateMapCommand(BaseCommand):
                 else:
                     # Remote (spoolman) gate map, don't update local attributes that are set by spoolman
                     mmu.gate_status[gate_idx] = available
-                    mmu.gate_speed_override[gate_idx] = speed_override
+                    if speed_override is not None:
+                        mmu.gate_speed_override[gate_idx] = speed_override
                     if any(x is not None for x in [material, vendor, color, spool_id, name]):
                         mmu.log_error("Spoolman mode is '%s': Can only set gate status and speed override locally\nUse MMU_SPOOLMAN or update spoolman directly" % SPOOLMAN_PULL)
                         break

--- a/extras/mmu/mmu_gate_maps.py
+++ b/extras/mmu/mmu_gate_maps.py
@@ -166,7 +166,7 @@ class MmuGateMaps:
         self.mmu.var_manager.set(VARS_MMU_GATE_STATUS, self.gate_status, write=True)
 
 
-    def persist_gate_map(self, spoolman_sync=False, gate_ids=None):
+    def persist_gate_map(self, spoolman_sync=False, gate_ids=None, changed_gate=None):
         self.mmu.var_manager.set(VARS_MMU_GATE_STATUS, self.gate_status)
         self.mmu.var_manager.set(VARS_MMU_GATE_FILAMENT_NAME, self.gate_filament_name)
         self.mmu.var_manager.set(VARS_MMU_GATE_MATERIAL, self.gate_material)
@@ -189,9 +189,11 @@ class MmuGateMaps:
             elif self.p.spoolman_support == SPOOLMAN_READONLY:
                 self.mmu._spoolman_update_filaments(gate_ids)
 
-        self.mmu.led_manager.gate_map_changed(None) # Force full LED update
-        self.mmu.mmu_macro_event(MACRO_EVENT_GATE_MAP_CHANGED, "GATE=-1")
-        self.mmu._moonraker_push_lane_data()
+        self.mmu.led_manager.gate_map_changed(changed_gate)
+        event_gate = -1 if changed_gate is None else changed_gate
+        self.mmu.mmu_macro_event(MACRO_EVENT_GATE_MAP_CHANGED, "GATE=%d" % event_gate)
+        lane_ids = None if changed_gate is None else [(changed_gate, self.gate_spool_id[changed_gate])]
+        self.mmu._moonraker_push_lane_data(lane_ids)
 
 
 # -----------------------------------------------------------------------------------------------------------
@@ -216,9 +218,11 @@ class MmuGateMaps:
 
     # Use mmu entry (and gear) sensors to "correct" gate status
     # Return updated gate_status adjusted by sensor readings
-    def validate_gate_status(self):
+    def validate_gate_status(self, gates=None):
         v_gate_status = list(self.gate_status) # Ensure that webhooks sees get_status() change
-        for gate, status in enumerate(v_gate_status):
+        gates = range(self.num_gates) if gates is None else gates
+        for gate in gates:
+            status = v_gate_status[gate]
             gear_detected = self.mmu.sensor_manager.check_gate_sensor(SENSOR_EXIT_PREFIX, gate)
             if gear_detected is True:
                 v_gate_status[gate] = GATE_AVAILABLE
@@ -228,6 +232,8 @@ class MmuGateMaps:
                     v_gate_status[gate] = GATE_UNKNOWN
                 elif pre_detected is False and status != GATE_EMPTY:
                     v_gate_status[gate] = GATE_EMPTY
+            if status != GATE_EMPTY and v_gate_status[gate] == GATE_EMPTY:
+                self.clear_gate_attributes(gate)
         self.gate_status = v_gate_status
 
 
@@ -289,52 +295,66 @@ class MmuGateMaps:
         if 0 <= gate < self.num_gates:
             if state != self.gate_status[gate]:
                 self.gate_status = list(self.gate_status) # Ensure that webhooks sees get_status() change
+                if state == GATE_EMPTY:
+                    self.clear_gate_attributes(gate)
                 self.gate_status[gate] = state
+                if state == GATE_EMPTY:
+                    self.update_gate_color_rgb()
+                    self.persist_gate_map(
+                        spoolman_sync=True,
+                        gate_ids=[(gate, -1)],
+                        changed_gate=gate
+                    )
+                    return
                 self.persist_gate_status()
                 self.mmu.led_manager.gate_map_changed(gate)
                 self.mmu.mmu_macro_event(MACRO_EVENT_GATE_MAP_CHANGED, "GATE=%d" % gate)
                 self.mmu._moonraker_push_lane_data([(gate, self.gate_spool_id[gate])])
 
 
-    def reset_gate_map(self):
-        self.mmu.log_debug("Resetting gate map")
-        self.gate_status = list(self.p.default_gate_status)
-        self.validate_gate_status()
-        self.gate_filament_name = list(self.p.default_gate_filament_name)
-        self.gate_material = list(self.p.default_gate_material)
-        self.gate_vendor = list(self.p.default_gate_vendor)
-        self.gate_color = list(self.p.default_gate_color)
-        self.gate_temperature = list(self.p.default_gate_temperature)
-        if self.p.spoolman_support in [SPOOLMAN_OFF, SPOOLMAN_PULL]:
-            self.gate_spool_id = [-1] * self.num_gates
-        else:
-            self.gate_spool_id = list(self.p.default_gate_spool_id)
-        self.gate_speed_override = list(self.p.default_gate_speed_override)
-        self.gate_spool_rfid = list(self.p.default_gate_spool_rfid)
+    def reset_gate_map(self, gates=None):
+        gates = list(range(self.num_gates)) if gates is None else list(gates)
+        self.mmu.log_debug("Resetting gate map for gates: %s" % gates)
+        self.renew_gate_map()
+        for gate in gates:
+            self.gate_status[gate] = self.p.default_gate_status[gate]
+        self.validate_gate_status(gates)
+        # Applying defaults after status validation deliberately allows configured
+        # metadata to be added back to a gate whose validated status is EMPTY.
+        for gate in gates:
+            for _, attr, default in self._gate_map_vars:
+                if attr == 'gate_status':
+                    continue
+                default_attr = getattr(self.p, "default_" + attr)
+                getattr(self, attr)[gate] = default_attr[gate] if default_attr else default
+            if self.p.spoolman_support in [SPOOLMAN_OFF, SPOOLMAN_PULL]:
+                self.gate_spool_id[gate] = -1
         self.update_gate_color_rgb()
-        self.persist_gate_map(spoolman_sync=True)
+        self.persist_gate_map(
+            spoolman_sync=True,
+            gate_ids=[(gate, self.gate_spool_id[gate]) for gate in gates]
+        )
+
+
+    def clear_gate_attributes(self, gate):
+        """Clear filament metadata when a gate transitions to EMPTY."""
+        for _, attr, default in self._gate_map_vars:
+            if attr != 'gate_status':
+                getattr(self, attr)[gate] = default
 
 
     def reset_gate(self, gate, status=GATE_EMPTY):
         """
-        Per-gate analog of reset_gate_map, used when filament is ejected: restore the
-        gate's filament attributes (name/material/vendor/color/temperature/speed) to
-        their configured defaults, but force availability to 'status' (the caller
-        knows ground truth - the spool is gone) and always clear the spool identity
-        (spool_id, rfid) regardless of defaults, since the physical spool has been
-        removed. Persists and syncs to spoolman ('push' mode unassigns the gate in
-        the spoolman db; 'readonly' has nothing to sync for a cleared spool_id).
+        Clear a gate when filament is ejected and force availability to ``status``.
+        Configured defaults are restored only by MMU_GATE_MAP RESET=1; an empty gate
+        must not retain metadata for the spool that was physically removed.
         """
         if not (0 <= gate < self.num_gates):
             return
         self.mmu.log_debug("Clearing gate map for gate %d" % gate)
         self.renew_gate_map() # Ensure webhooks sees get_status() change
-        for _, attr, default in self._gate_map_vars:
-            default_attr = getattr(self.p, "default_" + attr)
-            getattr(self, attr)[gate] = default_attr[gate] if default_attr else default
+        self.clear_gate_attributes(gate)
         self.gate_status[gate] = status
-        self.gate_spool_id[gate] = -1
-        self.gate_spool_rfid[gate] = ""
         self.update_gate_color_rgb()
         self.persist_gate_map(spoolman_sync=True, gate_ids=[(gate, -1)])
 

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -890,7 +890,10 @@ class Session:
         Goes through HH's own set_gate_filament_from_tag (mmu_gate_maps.py:352) rather than
         assigning the lists directly, so the colour is validated, gate_color_rgb is refreshed
         and the map is persisted exactly as a real tag read would leave it. That setter does
-        NOT touch spool_id - a resolved Spoolman spool stays authoritative.
+        NOT touch spool_id - a resolved Spoolman spool stays authoritative. The same values
+        are installed as the harness's configured defaults so MMU_GATE_MAP RESET=1 can restore
+        the reproducible dummy filament map just as it could restore default_gate_XXX values
+        from a real mmu.cfg.
         """
         import random as _random
 
@@ -906,6 +909,11 @@ class Session:
                 'name': '%s %s' % (material, rng.choice(self.FILAMENT_GRADES)),
             }
             self.mmu.gate_maps.set_gate_filament_from_tag(gate, **attrs)
+            self.mmu.p.default_gate_vendor[gate] = attrs['vendor']
+            self.mmu.p.default_gate_material[gate] = attrs['material']
+            self.mmu.p.default_gate_color[gate] = attrs['color'].lower()
+            self.mmu.p.default_gate_temperature[gate] = attrs['temperature']
+            self.mmu.p.default_gate_filament_name[gate] = attrs['name']
             applied[gate] = attrs
         return applied
 
@@ -1069,9 +1077,10 @@ class Session:
         model = self.filament()
         for gate in range(self.mmu.num_gates):
             model.place(gate, tip_position)
+        seeded_status = GATE_AVAILABLE if status is None else status
         self.mmu.var_manager.set(VARS_MMU_GATE_STATUS,
-                                 [GATE_AVAILABLE if status is None else status]
-                                 * self.mmu.num_gates)
+                                 [seeded_status] * self.mmu.num_gates)
+        self.mmu.p.default_gate_status[:] = [seeded_status] * self.mmu.num_gates
         return self
 
     def seed_selection(self, gate, tool=None):

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -1699,6 +1699,23 @@ class TestConsoleScript(unittest.TestCase):
         self.assertTrue(all(not hh.sensor(name).present for name in affected),
                         'EMPTY left one or more gate-path sensors triggered')
 
+    def test_gate_map_reset_restores_the_primed_filament_defaults(self):
+        console = self._make_console(['--no-log', '--plain', '--header', 'off'])
+        hh = console.hh
+        maps = hh.mmu.gate_maps
+        attrs = ('gate_filament_name', 'gate_material', 'gate_vendor', 'gate_color',
+                 'gate_temperature', 'gate_speed_override', 'gate_spool_id',
+                 'gate_spool_rfid')
+        initial = {attr: getattr(maps, attr)[0] for attr in attrs}
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            console.run_command('MMU_GATE_MAP GATE=0 AVAILABLE=0 QUIET=1')
+            console.run_command('MMU_GATE_MAP GATE=0 RESET=1 QUIET=1')
+
+        self.assertEqual({attr: getattr(maps, attr)[0] for attr in attrs}, initial)
+        self.assertEqual(maps.gate_status[0], 0,
+                         'RESET must not recreate filament removed from the simulator')
+
     def test_gate_map_available_parks_filament_through_the_entry_sensor(self):
         console = self._make_console(['--no-preload', '--no-log', '--plain',
                                       '--header', 'off'])

--- a/test/test_mmu_motion.py
+++ b/test/test_mmu_motion.py
@@ -119,6 +119,70 @@ class TestModelItself(MotionTestCase):
                           'a 50mm move cannot reach a sensor 100mm away')
 
 
+class TestGateMapCommand(MotionTestCase):
+
+    def test_reset_requires_a_gate_target(self):
+        self.hh.run_gcode('MMU_GATE_MAP GATE=1 MATERIAL=PLA')
+        with self.assertRaisesRegex(Exception, 'requires GATE or GATES'):
+            self.hh.run_gcode('MMU_GATE_MAP RESET=1')
+        self.assertEqual(self.hh.mmu.gate_material[1], 'PLA')
+
+    def test_reset_only_restores_the_requested_gates(self):
+        mmu = self.hh.mmu
+        mmu.p.default_gate_material[0] = 'ABS'
+        mmu.p.default_gate_material[2] = 'PETG'
+        self.hh.run_gcode('MMU_GATE_MAP GATES=0,1,2 MATERIAL=PLA')
+
+        self.hh.run_gcode('MMU_GATE_MAP RESET=1 GATES=0,2')
+
+        self.assertEqual(mmu.gate_material[0], 'ABS')
+        self.assertEqual(mmu.gate_material[1], 'PLA')
+        self.assertEqual(mmu.gate_material[2], 'PETG')
+
+    def test_empty_transition_clears_all_gate_attributes(self):
+        mmu = self.hh.mmu
+        self.hh.run_gcode(
+            'MMU_GATE_MAP GATE=1 AVAILABLE=1 NAME=Basic MATERIAL=PLA '
+            'VENDOR=Maker COLOR=ff0000 TEMP=230 SPEED=50 SPOOLID=7 RFID=abc123'
+        )
+
+        self.hh.run_gcode('MMU_GATE_MAP GATE=1 AVAILABLE=0')
+
+        self.assertEqual(mmu.gate_filament_name[1], '')
+        self.assertEqual(mmu.gate_material[1], '')
+        self.assertEqual(mmu.gate_vendor[1], '')
+        self.assertEqual(mmu.gate_color[1], '')
+        self.assertEqual(mmu.gate_temperature[1], int(mmu.p.default_extruder_temp))
+        self.assertEqual(mmu.gate_speed_override[1], 100)
+        self.assertEqual(mmu.gate_spool_id[1], -1)
+        self.assertEqual(mmu.gate_spool_rfid[1], '')
+
+        # Clearing is transition-based: metadata may intentionally be added later
+        # without first changing the gate away from EMPTY.
+        self.hh.run_gcode('MMU_GATE_MAP GATE=1 MATERIAL=PETG RFID=newtag')
+        self.assertEqual(mmu.gate_material[1], 'PETG')
+        self.assertEqual(mmu.gate_spool_rfid[1], 'newtag')
+
+    def test_runtime_empty_transition_also_clears_attributes(self):
+        mmu = self.hh.mmu
+        self.hh.run_gcode(
+            'MMU_GATE_MAP GATE=2 AVAILABLE=1 NAME=Basic MATERIAL=PLA '
+            'SPOOLID=8 RFID=abc123'
+        )
+
+        mmu.gate_maps.set_gate_status(2, GATE_EMPTY)
+
+        self.assertEqual(mmu.gate_filament_name[2], '')
+        self.assertEqual(mmu.gate_material[2], '')
+        self.assertEqual(mmu.gate_spool_id[2], -1)
+        self.assertEqual(mmu.gate_spool_rfid[2], '')
+
+    def test_help_shows_targeted_reset_example(self):
+        at = len(self.hh.console)
+        self.hh.run_gcode('MMU_GATE_MAP HELP=1')
+        help_text = '\n'.join(self.hh.console[at:])
+        self.assertIn('RESET=1 GATES=4,5', help_text)
+
 class TestEveryDriveModeMovesFilament(MotionTestCase):
     """
     Happy Hare drives filament in four sync modes (mmu_constants.py:169-172), and a plain move
@@ -417,11 +481,8 @@ class TestPreload(MotionTestCase):
 
     def test_a_failed_preload_keeps_an_assigned_spool_id(self):
         """
-        The spool_id is assigned by the entry-insert handler BEFORE the preload runs, so
-        what happens to it on failure matters. Nothing in the failure path clears it -
-        set_gate_status only touches gate_status, and only reset_gate (eject) and
-        reset_gate_map clear gate_spool_id. Pinned because the alternative would mean the
-        assignment had to be deferred until after the preload succeeded.
+        The pending spool is assigned while this gate is already EMPTY, so a failed
+        preload does not constitute a transition into EMPTY and must not clear it.
         """
         mmu = self.hh.mmu
         mmu.pending_spool_id = 7
@@ -431,8 +492,7 @@ class TestPreload(MotionTestCase):
         self.hh.place_filament(2, position=-100000.0)
         self.hh.run_gcode('MMU_PRELOAD GATE=2')
         self.assertEqual(mmu.gate_status[2], GATE_EMPTY)
-        self.assertEqual(mmu.gate_maps.gate_spool_id[2], 7,
-                         'a failed preload must not discard the assigned spool')
+        self.assertEqual(mmu.gate_maps.gate_spool_id[2], 7)
 
     def test_preload_leaves_other_gates_alone(self):
         self.hh.place_filament(0)


### PR DESCRIPTION
Summary:
- Require GATE or GATES when using MMU_GATE_MAP RESET=1.
- Reset only the selected gates to their configured defaults.
- Clear filament metadata and spool/RFID identity when a gate transitions to EMPTY.
- Seed the console simulator dummy filament map as default_gate_XXX values so targeted resets restore it.
- Update command help and configuration examples.

Testing:
- Full suite: 1086 tests passed, with 1 skipped and 4 expected failures.
- Post-rebase console and motion suites: 221 tests passed, with 1 expected failure.