### PR TITLE
Fix selected gate marker in MMU status

### DIFF
--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -1310,10 +1310,10 @@ class MmuController(MmuFilamentMovement):
                 if g == self.gate_selected:
                     if g == TOOL_GATE_BYPASS:
                         ext_swatch = bypass_ext_swatch
-                    elif self.filament_pos < FILAMENT_POS_START_BOWDEN:
-                        ext_swatch = UI_SEPARATOR
-                    else:
+                    elif self.gate_status[g] >= GATE_AVAILABLE:
                         ext_swatch = self._get_filament_char(g, show_swatch=True, symbol=UI_SOLID_TRIANGLE)
+                    else:
+                        ext_swatch = UI_SEPARATOR
                     select_strings.append(f"|\\{ext_swatch}/|")
                 else:
                     select_strings.append(selct_char * 4)

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -1904,6 +1904,19 @@ class TestTheDefaultProfile(unittest.TestCase):
         self.assertNotIn('X', selct, 'the selector reads as unhomed at bootup')
         self.assertNotIn('[T?]', joined, 'bootup rendered an unknown tool')
 
+    def test_selected_available_gate_has_a_filament_triangle(self):
+        """An available gate keeps its tip marker even while filament is parked at the gate."""
+        from extras.mmu.mmu_constants import GATE_AVAILABLE, UI_SOLID_TRIANGLE
+
+        mmu = self.console.hh.mmu
+        self.assertEqual(mmu.filament_pos, 0, 'precondition: filament is parked at the gate')
+        self.assertGreaterEqual(mmu.gate_status[mmu.gate_selected], GATE_AVAILABLE)
+        selct = next(
+            line for line in mmu._mmu_visual_to_string().split('\n')
+            if line.startswith('Selct:')
+        )
+        self.assertIn(UI_SOLID_TRIANGLE, selct)
+
     def test_the_homing_chatter_stays_out_of_the_banner(self):
         """
         Homing has to precede bootup, but "Homing MMU unit0... / Homed" is setup rather than


### PR DESCRIPTION
## Summary
- restore the solid triangle on the Selct row for a selected available gate
- derive the marker from gate availability instead of bowden progress
- add a regression test for available filament parked at the gate

## Testing
- ./venv/bin/python -m unittest test.test_mmu_console (182 tests)