### PR TITLE
Show filament color for unknown gates

### DIFF
--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -1251,7 +1251,7 @@ class MmuController(MmuFilamentMovement):
         elif gate_status == GATE_EMPTY:
             return "-" if show_letter or show_swatch else UI_SEPARATOR
 
-        return "?" if show_letter or show_swatch else UI_SEPARATOR
+        return "?" if show_letter or show_swatch else swatch
 
 
     def _mmu_visual_to_string(self):
@@ -1310,8 +1310,8 @@ class MmuController(MmuFilamentMovement):
                 if g == self.gate_selected:
                     if g == TOOL_GATE_BYPASS:
                         ext_swatch = bypass_ext_swatch
-                    elif self.gate_status[g] >= GATE_AVAILABLE:
-                        ext_swatch = self._get_filament_char(g, show_swatch=True, symbol=UI_SOLID_TRIANGLE)
+                    elif self.gate_status[g] != GATE_EMPTY:
+                        ext_swatch = self._get_filament_char(g, symbol=UI_SOLID_TRIANGLE)
                     else:
                         ext_swatch = UI_SEPARATOR
                     select_strings.append(f"|\\{ext_swatch}/|")

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -1917,6 +1917,26 @@ class TestTheDefaultProfile(unittest.TestCase):
         )
         self.assertIn(UI_SOLID_TRIANGLE, selct)
 
+    def test_unknown_gate_keeps_its_colored_swatch_and_selector_triangle(self):
+        """Unknown describes availability, so it must not hide known filament color."""
+        from extras.mmu.mmu_constants import GATE_UNKNOWN, UI_SOLID_SQUARE, UI_SOLID_TRIANGLE
+
+        mmu = self.console.hh.mmu
+        gate = mmu.gate_selected
+        mmu.gate_status[gate] = GATE_UNKNOWN
+        mmu.gate_color[gate] = 'ff0000'
+        square = '{{ff0000}}%s{{}}' % UI_SOLID_SQUARE
+        triangle = '{{ff0000}}%s{{}}' % UI_SOLID_TRIANGLE
+
+        visual = mmu._mmu_visual_to_string().split('\n')
+        avail = next(line for line in visual if line.startswith('Avail:'))
+        selct = next(line for line in visual if line.startswith('Selct:'))
+        self.assertIn('|%s?%s|' % (square, square), avail)
+        self.assertIn('|\\%s/|' % triangle, selct)
+
+        gate_row = mmu.gate_maps.gate_map_to_string().splitlines()[gate + 1]
+        self.assertIn('(%s?%s)' % (square, square), gate_row)
+
     def test_the_homing_chatter_stays_out_of_the_banner(self):
         """
         Homing has to precede bootup, but "Homing MMU unit0... / Homed" is setup rather than


### PR DESCRIPTION
## Summary
- render unknown gates as colored swatch, question mark, colored swatch in MMU_STATUS
- show the colored selector triangle for a selected unknown gate
- use the same colored unknown-gate rendering in MMU_GATE_MAP
- add regression coverage for both displays

## Testing
- ./venv/bin/python -m unittest test.test_mmu_console test.test_mmu_motion
- 223 tests passed, with 1 existing expected failure