### PR TITLE
Model sync-feedback buffer travel

### DIFF
--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1596,9 +1596,9 @@ class MmuFilamentMovement:
                     f"(measured {measured:.1f}mm)"
                 )
 
-                self.set_filament_pos_state(FILAMENT_POS_HOMED_ENTRY)
-
                 if u.p.extruder_homing_endstop == SENSOR_EXTRUDER_ENTRY:
+                    self.set_filament_pos_state(FILAMENT_POS_HOMED_ENTRY)
+
                     # Close the fixed gap from the entry sensor to the extruder gear.
                     actual, _, measured, _ = self.move_filament(
                         "Aligning filament to extruder gear",

--- a/test/README.md
+++ b/test/README.md
@@ -212,8 +212,8 @@ Tool change requested: T1
 ------------------------------------------------------------------------
 T1   gate 1    LOADED IN NOZZLE           868.0mm  Idle
   print=initialized  SYNCED  t=+2.51s  realtime=100%
-  mmu_entry_1=1  mmu_exit_1=1  filament_compression=1  filament_tension=1  ...
-            nfc pre ent exit/gate shex enc comp/extr nozl
+  mmu_entry_1=1  mmu_exit_1=1  filament_compression=0  filament_tension=0  ...
+            nfc pre ent exit/gate shex enc extr comp nozl
    gate 0    ..  ..  ..     ..     ..   ..     ..     ..     -100.0
   *gate 1    ##  ##  ##     ##     ##   ##     ##     ##     +768.0
 ------------------------------------------------------------------------
@@ -787,6 +787,14 @@ sensor never releases.
 The encoder is not a switch: it reports *motion*, so what matters is how much of a move
 happened while filament covered the wheel. That is `fil.travel_over()`, and the harness
 turns it into real pulses so Happy Hare's own counter callback does the accumulating.
+
+A tension-sprung, two-switch sync-feedback buffer also has travel. It starts squeezed with
+tension triggered. Reaching the extruder opens tension, but passing the nominal coordinate
+during an ordinary Bowden move does not prove contact and cannot build compression. A
+`filament_compression` homing move establishes contact; another 70% of the configured
+`buffer_maxrange` then triggers compression. Gear-only and extruder-only moves change that
+stored travel in opposite directions, so a paced console load visibly passes through tension,
+neutral and compression.
 
 **The fake Moonraker** provides a working in-memory Spoolman — not a mock. When Happy Hare
 auto-creates a spool, a spool really is created, and the next scan of that tag really

--- a/test/filament_display.py
+++ b/test/filament_display.py
@@ -78,6 +78,7 @@ class FilamentDisplayState:
     # Per-unit gate endstop config
     gate_homing_endstop: str = SENSOR_ENCODER
     gate_preload_endstop: str = ''  # NOTE: not currently read by get_filament_position_string()
+    extruder_homing_endstop: str = 'none'  # NOTE: not currently read by get_filament_position_string()
 
     # Whether this gate has a spool in it at all (GATE_EMPTY/GATE_AVAILABLE/
     # GATE_UNKNOWN, mmu_constants.py) -- tracked per-gate, independent of pos
@@ -173,6 +174,7 @@ class _MmuUnitShim:
 class _UnitParams:
     def __init__(self, state):
         self.gate_homing_endstop = state.gate_homing_endstop
+        self.extruder_homing_endstop = state.extruder_homing_endstop
         self.encoder_move_validation = state.encoder_move_validation
 
 

--- a/test/filament_display_review.py
+++ b/test/filament_display_review.py
@@ -34,6 +34,7 @@ from extras.mmu.mmu_constants import (
     DIRECTION_LOAD, DIRECTION_UNLOAD, DIRECTION_UNKNOWN, TOOL_GATE_BYPASS,
     SENSOR_ENCODER, SENSOR_EXTRUDER_ENTRY, SENSOR_TOOLHEAD, SENSOR_TENSION, SENSOR_COMPRESSION,
     SENSOR_PROPORTIONAL, SENSOR_ENTRY_PREFIX, SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT,
+    SENSOR_GEAR_TOUCH, SENSOR_EXTRUDER_NONE,
     GATE_EMPTY, GATE_AVAILABLE, UI_SENSOR_TRIGGERED, UI_SENSOR_EMPTY,
 )
 
@@ -291,6 +292,7 @@ def _position_walk(gate_endstop):
     if gate_endstop == SENSOR_EXTRUDER_ENTRY:
         return [
             ("HOMED_GATE", FILAMENT_POS_HOMED_EXTRUDER),
+            ("HOMED_EXTRUDER", FILAMENT_POS_HOMED_EXTRUDER),
             ("EXTRUDER_ENTRY", FILAMENT_POS_EXTRUDER_ENTRY),
             ("HOMED_TS", FILAMENT_POS_HOMED_TS),
             ("IN_EXTRUDER", FILAMENT_POS_IN_EXTRUDER),
@@ -448,6 +450,7 @@ class TestFilamentDisplayVisualReview(unittest.TestCase):
             visual = render(f"[{sub_label}]", state)
             _assert_sensor_markers(self, visual, sensors, sub_label)
 
+        position_visuals = {}
         for label, pos in _position_walk(gate_endstop):
             sensors = _derive_sensors(pos, gate_endstop, fitted)
             state = FilamentDisplayState(
@@ -457,7 +460,15 @@ class TestFilamentDisplayVisualReview(unittest.TestCase):
                 filament_position=1234.5,
             )
             visual = render(f"[{label}]", state)
+            position_visuals[label] = visual
             _assert_sensor_markers(self, visual, sensors, label)
+
+        if gate_endstop == SENSOR_EXTRUDER_ENTRY:
+            self.assertEqual(
+                position_visuals["HOMED_GATE"],
+                position_visuals["HOMED_EXTRUDER"],
+                "gate homing on the extruder sensor should render at HOMED_EXTRUDER",
+            )
 
     def test_visual_review(self):
         print()
@@ -476,6 +487,69 @@ class TestFilamentDisplayVisualReview(unittest.TestCase):
                 for endstop_label, gate_endstop in valid_endstops:
                     print(f"\n--- {n}) {combo_desc} / gate_endstop={endstop_label} ---")
                     self._render_combo(combo, gate_endstop, is_bold)
+
+
+class TestFilamentDisplayExtruderHomingEndstops(unittest.TestCase):
+    """Focused extruder-area matrix with every displayable sensor fitted."""
+
+    POSITIONS = (
+        FILAMENT_POS_END_BOWDEN,
+        FILAMENT_POS_HOMED_ENTRY,
+        FILAMENT_POS_HOMED_EXTRUDER,
+        FILAMENT_POS_EXTRUDER_ENTRY,
+    )
+    ENDSTOPS = (
+        ("filament_compression", SENSOR_COMPRESSION),
+        ("extruder", SENSOR_EXTRUDER_ENTRY),
+        ("encoder", SENSOR_ENCODER),
+        ("mmu_gear_touch", SENSOR_GEAR_TOUCH),
+        ("none", SENSOR_EXTRUDER_NONE),
+    )
+    FITTED = frozenset((
+        SENSOR_ENTRY_PREFIX,
+        SENSOR_EXIT_PREFIX,
+        SENSOR_SHARED_EXIT,
+        SENSOR_EXTRUDER_ENTRY,
+        SENSOR_TOOLHEAD,
+    ))
+
+    def test_extruder_homing_endstop_matrix(self):
+        print()
+        for style_name, is_bold in BOLD_STYLES:
+            style_header(style_name, is_bold)
+            for endstop_label, extruder_endstop in self.ENDSTOPS:
+                print(
+                    "\n--- all sensors / gate_endstop=exit / "
+                    f"extruder_homing_endstop={endstop_label} ---"
+                )
+                for pos in self.POSITIONS:
+                    sensors = _derive_sensors(pos, SENSOR_EXIT_PREFIX, self.FITTED)
+                    compression_homed = (
+                        extruder_endstop == SENSOR_COMPRESSION
+                        and pos >= FILAMENT_POS_HOMED_ENTRY
+                    )
+                    sensors[SENSOR_COMPRESSION] = compression_homed
+                    sensors[SENSOR_TENSION] = False
+                    state = FilamentDisplayState(
+                        tool=0,
+                        gate=0,
+                        pos=pos,
+                        bold=is_bold,
+                        gate_homing_endstop=SENSOR_EXIT_PREFIX,
+                        extruder_homing_endstop=extruder_endstop,
+                        sensors=sensors,
+                        has_encoder=True,
+                        encoder_move_validation=True,
+                        encoder_distance=1234.5,
+                        has_buffer=True,
+                        sync_feedback_state=(
+                            "compressed" if compression_homed else "neutral"
+                        ),
+                        filament_position=1234.5,
+                    )
+                    visual = render(f"[{POS_NAMES[pos]}]", state)
+                    _assert_sensor_markers(self, visual, sensors, POS_NAMES[pos])
+                    self.assertTrue(visual)
 
 
 class TestFilamentDisplayAllSensorsAlwaysFalse(unittest.TestCase):

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -396,18 +396,36 @@ class Session:
         The 1-D filament path model for this machine, created on first use and
         published as printer.harness_filament so the fake HomingMove can find it.
 
-        Sensors it does not own are left alone: the buffer spring sensors are held at
-        their configured resting state by apply_initial_sensor_states, and a filament
-        model that also drove them would fight it.
+        Sensors it does not own are left alone. Unsupported buffer types remain at the
+        state established by apply_initial_sensor_states; a tension-sprung two-switch
+        buffer is explicitly claimed by the filament model so its state can change.
         """
         existing = getattr(self.printer, 'harness_filament', None)
         if existing is not None and layout is None:
             return existing
 
         from .filament import FilamentPath
+        from extras.mmu.mmu_constants import (
+            DRIVE_UNSYNCED, DRIVE_EXTRUDER_ONLY,
+        )
+
+        def drive_mode(gate):
+            mode = self.mmu.drive(gate).get_sync_mode()
+            if mode == DRIVE_UNSYNCED:
+                return 'gear'
+            if mode == DRIVE_EXTRUDER_ONLY:
+                return 'extruder'
+            return 'synced'
+
         model = FilamentPath(self.mmu.num_gates, layout=layout)
+        model.configure_buffers(
+            self.mmu.mmu_machine.units,
+            selected_gate=lambda: self.mmu.gate_selected,
+            drive_mode=drive_mode,
+        )
         owned = [name for name in self.sensors()
-                 if name not in getattr(self, '_spring_at_rest', set())
+                 if (name not in getattr(self, '_spring_at_rest', set())
+                     or model.models_sensor(name))
                  and model.position(name) is not None]
         # Which gates each unit owns, so a unit-qualified sensor is not answered from another
         # unit's filament - see FilamentPath.gates_visible_to.

--- a/test/hh/filament.py
+++ b/test/hh/filament.py
@@ -92,14 +92,9 @@ DEFAULT_LAYOUT = {
     # set MMU_HAS_SENSOR_EXTRUDER; none did before ercf_vvd.
     'extruder': 700.0,
     'toolhead': 740.0,
-    # The buffer's COMPRESSION sensor is what a load homes to when
-    # extruder_homing_endstop is filament_compression (BoxTurtle's default): the MMU
-    # pushes filament until it meets the stationary extruder gears and the buffer
-    # compresses. Modelling it at the extruder entry is what lets a full load complete.
-    #
-    # Its partner filament_tension is deliberately NOT here. Tension is about the spring
-    # being pulled taut by the extruder, not about how far the tip has travelled, so it
-    # stays owned by the resting-state logic in bootstrap.apply_initial_sensor_states.
+    # Fallback for machines without the dynamically modelled, tension-sprung switch
+    # buffer. configure_buffers() moves this landmark forward by 70% of buffer_maxrange
+    # for the common two-switch design.
     'filament_compression': 700.0,
 }
 
@@ -112,6 +107,11 @@ TIP_PRESENTED = -180.0          # offered to the MMU, not yet past the entry swi
 DEFAULT_TAG_OFFSET = 0.0
 # Half-width of the NFC read zone: a tag is detectable within +/- this of the reader.
 DEFAULT_TAG_WINDOW = 15.0
+
+# A switch-style buffer normally reaches its compression switch before the physical
+# end stop. There is no more precise geometry in mmu_hardware.cfg, so keep the model's
+# deliberately approximate switch point in one named place.
+BUFFER_COMPRESSION_FRACTION = 0.7
 
 
 class Tag:
@@ -152,11 +152,65 @@ class FilamentPath:
         # the Session to turn filament travel into encoder pulses; a switch cannot
         # express that, because an encoder reports MOTION rather than presence.
         self.observers = []
+        # Unit-qualified switch-buffer geometry, populated from the real MmuBuffer
+        # objects by Session.filament(). Only tension-sprung, two-switch buffers are
+        # modelled dynamically; other buffer types retain their configured resting state.
+        self.buffers = {}
+        self._selected_gate = None
+        self._drive_mode = None
+
+    def configure_buffers(self, units, selected_gate=None, drive_mode=None):
+        """Import the physical buffer travel configured for each MMU unit."""
+        self._selected_gate = selected_gate
+        self._drive_mode = drive_mode
+        for unit in units:
+            buffer = getattr(unit, 'buffer', None)
+            if (buffer is None
+                    or getattr(buffer, 'buffer_spring_state', 'none') != 'tension'
+                    or getattr(buffer, 'compression_sensor', None) is None
+                    or getattr(buffer, 'tension_sensor', None) is None):
+                continue
+            maxrange = float(getattr(buffer, 'buffer_maxrange', 0.))
+            if maxrange <= 0.:
+                continue
+            prefix = getattr(buffer, 'name', unit.name)
+            if prefix in self.buffers:
+                continue
+            gates = tuple(
+                gate
+                for connected in getattr(buffer, 'connected_units', (unit,))
+                for gate in range(connected.first_gate,
+                                  connected.first_gate + connected.num_gates)
+            )
+            entry = self.layout['extruder_entry']
+            self.buffers[prefix] = {
+                'gates': gates,
+                'entry': entry,
+                'compression': entry + maxrange * BUFFER_COMPRESSION_FRACTION,
+                'compression_travel': maxrange * BUFFER_COMPRESSION_FRACTION,
+                'maxrange': maxrange,
+                'travel': {gate: 0. for gate in gates},
+                'contact': {gate: False for gate in gates},
+            }
+
+        # The console's path legend reads the unqualified layout. A shared path can
+        # only draw one landmark, so use the first configured buffer as its representative.
+        if self.buffers:
+            first = next(iter(self.buffers.values()))
+            self.layout['filament_compression'] = first['compression']
+        return self
 
     # -- setup -------------------------------------------------------------
     def place(self, gate, position, sync=True):
         """Put a gate's filament tip at an absolute path position."""
         self.tip[gate] = float(position)
+        for geometry in self.buffers.values():
+            if gate in geometry['travel']:
+                # Absolute placement says where the filament is along the path, not
+                # whether it is pushing against the extruder. Only a compression-home
+                # establishes that contact and stores subsequent relative motion.
+                geometry['travel'][gate] = 0.
+                geometry['contact'][gate] = False
         if sync:
             self.sync(gate)
         return self
@@ -203,6 +257,13 @@ class FilamentPath:
     # -- queries -----------------------------------------------------------
     def position(self, name):
         """Path position of a logical sensor name, accepting qualified names."""
+        geometry = self._buffer_geometry(name)
+        if geometry is not None:
+            bare = name.split(':')[-1]
+            if bare == 'filament_tension':
+                return geometry['entry']
+            if bare == 'filament_compression':
+                return geometry['compression']
         bare = name.split(':')[-1]
         # Strip a trailing per-gate index: mmu_exit_2 -> mmu_exit
         if bare in self.layout:
@@ -211,6 +272,44 @@ class FilamentPath:
         if head in self.layout:
             return self.layout[head]
         return None
+
+    def models_sensor(self, name):
+        """Whether a registered sensor is owned by the dynamic buffer model."""
+        return (name.split(':')[-1] in ('filament_tension', 'filament_compression')
+                and self._buffer_geometry(name) is not None)
+
+    def _buffer_geometry(self, name):
+        bare = name.split(':')[-1]
+        if bare not in ('filament_tension', 'filament_compression'):
+            return None
+        if ':' in name:
+            return self.buffers.get(name.split(':')[0])
+        if len(self.buffers) == 1:
+            return next(iter(self.buffers.values()))
+        return None
+
+    def _buffer_gate(self, geometry, gate=None):
+        gates = geometry['gates']
+        if gate is not None and gate in gates:
+            return gate
+        if self._selected_gate is not None:
+            selected = self._selected_gate()
+            if selected in gates:
+                return selected
+        # At startup no gate need be selected. Prefer a non-empty lane if one exists;
+        # otherwise the resting spring state is the same whichever lane represents it.
+        return max(gates, key=lambda g: self.tip[g])
+
+    def _buffer_triggered(self, name, gate=None):
+        geometry = self._buffer_geometry(name)
+        if geometry is None:
+            return None
+        gate = self._buffer_gate(geometry, gate)
+        tip = self.tip[gate]
+        travel = geometry['travel'][gate]
+        if name.split(':')[-1] == 'filament_tension':
+            return tip < geometry['entry'] and travel <= 0.
+        return travel + 1e-9 >= geometry['compression_travel']
 
     def gate_of(self, name):
         """Gate index encoded in a per-gate sensor name, or None."""
@@ -247,6 +346,8 @@ class FilamentPath:
 
     def triggered(self, name, gate=None):
         """Would this sensor read triggered right now?"""
+        if self.models_sensor(name):
+            return self._buffer_triggered(name, gate)
         position = self.position(name)
         if position is None:
             return None
@@ -290,6 +391,11 @@ class FilamentPath:
         direction = 1.0 if delta > 0 else -1.0
         best = None
         for name in names:
+            if self.models_sensor(name):
+                travel = self._buffer_trip_distance(gate, delta, name, sought)
+                if travel is not None and (best is None or travel < best[1]):
+                    best = (name, travel)
+                continue
             position = self.position(name)
             if position is None:
                 continue
@@ -313,6 +419,45 @@ class FilamentPath:
             if travel <= abs(delta) and (best is None or travel < best[1]):
                 best = (name, travel)
         return best
+
+    def _buffer_trip_distance(self, gate, delta, name, sought):
+        """Distance to a switch transition in a tension-sprung buffer."""
+        current = self._buffer_triggered(name, gate)
+        if current == bool(sought):
+            return 0.
+        geometry = self._buffer_geometry(name)
+        start = self.tip[gate]
+        forward = delta > 0.
+        bare = name.split(':')[-1]
+        epsilon = 1e-6
+        if bare == 'filament_tension':
+            if forward and not sought:
+                travel = geometry['entry'] - start
+            elif not forward and sought:
+                travel = start - geometry['entry'] + epsilon
+            else:
+                return None
+        else:
+            buffer_travel = geometry['travel'][gate]
+            mode = self._drive_mode(gate) if self._drive_mode is not None else 'gear'
+            if mode == 'gear':
+                if forward and sought:
+                    travel = max(0., geometry['entry'] - start) + (
+                        geometry['compression_travel'] - buffer_travel)
+                elif not forward and not sought:
+                    travel = buffer_travel - geometry['compression_travel'] + epsilon
+                else:
+                    return None
+            elif mode == 'extruder':
+                if forward and not sought:
+                    travel = buffer_travel - geometry['compression_travel'] + epsilon
+                elif not forward and sought:
+                    travel = geometry['compression_travel'] - buffer_travel
+                else:
+                    return None
+            else:
+                return None
+        return travel if 0. <= travel <= abs(delta) else None
 
     def nfc_trip_distance(self, gate, delta):
         """Distance until this gate's tag enters the reader window, or None."""
@@ -357,6 +502,7 @@ class FilamentPath:
         if not delta:
             return self.tip[gate]
         start_tip, start_tail = self.tip[gate], self.tail[gate]
+        self._advance_buffer(gate, delta, start_tip, reason)
         self.tip[gate] += delta
         self.tail[gate] += delta        # filament moves as one piece
         self.history.append((gate, delta, reason))
@@ -366,6 +512,36 @@ class FilamentPath:
         for observe in self.observers:
             observe(gate, delta, start_tip, start_tail)
         return self.tip[gate]
+
+    def _advance_buffer(self, gate, delta, start_tip, reason):
+        """Store relative gear/extruder travel in a tension-sprung buffer."""
+        for geometry in self.buffers.values():
+            if gate not in geometry['travel']:
+                continue
+            mode = self._drive_mode(gate) if self._drive_mode is not None else 'gear'
+            travel = geometry['travel'][gate]
+            contact = geometry['contact'][gate]
+            compression_home = ('homing' in reason
+                                and 'filament_compression' in reason)
+            if mode == 'gear':
+                if delta > 0.:
+                    # Passing the nominal entry coordinate on an ordinary Bowden move
+                    # is not proof of contact: calibration and flex can overshoot it.
+                    # A compression homing move is the explicit collision with the
+                    # extruder; after that, relative gear feed expands the buffer.
+                    if contact or compression_home:
+                        travel += max(
+                            0., start_tip + delta - max(start_tip, geometry['entry']))
+                        contact = start_tip + delta >= geometry['entry']
+                elif contact:
+                    travel += delta
+            elif mode == 'extruder' and contact:
+                travel -= delta
+            # Equal gear/extruder motion transports filament without changing the buffer.
+            geometry['travel'][gate] = min(geometry['maxrange'], max(0., travel))
+            if start_tip + delta < geometry['entry'] and geometry['travel'][gate] <= 0.:
+                contact = False
+            geometry['contact'][gate] = contact
 
     # -- pushing state into Happy Hare -------------------------------------
     def sync(self, gate=None):

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -1687,7 +1687,10 @@ class TestConsoleScript(unittest.TestCase):
         # Put this gate through every fitted sensor; other gates remain merely parked.
         hh.place_filament(0, position=800.)
         affected = [name for name in console.fil.sensor_names()
-                    if console.fil.gate_of(name) in (None, 0)]
+                    if console.fil.gate_of(name) in (None, 0)
+                    # Buffer switches report stored slack/tension, not filament
+                    # presence, and are intentionally not all true at once.
+                    and not console.fil.models_sensor(name)]
         self.assertTrue(affected, 'profile has no modelled sensors for gate 0')
         self.assertTrue(all(hh.sensor(name).present for name in affected),
                         'precondition: filament did not cover every sensor')
@@ -2120,6 +2123,49 @@ class TestTheDefaultProfile(unittest.TestCase):
         self.assertGreater(len(seen), 50, 'a whole load produced only a handful of updates')
         self.assertGreater(len(set(seen)), 50, 'the filament did not move between updates')
         self.assertEqual(seen, sorted(seen), 'a load should only ever feed filament forwards')
+
+    def test_gate9_compression_rises_only_during_extruder_home(self):
+        """ViViD's buffer must stay uncompressed throughout its Bowden move."""
+        from extras.mmu.mmu_constants import (
+            FILAMENT_POS_HOMED_ENTRY,
+            FILAMENT_POS_HOMED_EXTRUDER,
+            FILAMENT_POS_LOADED,
+        )
+        console = self.console
+        hh = console.hh
+        hh.set_pacing(1.)
+        compression = hh.sensor('unit1:filament_compression')
+        previous = [compression.present]
+        rising_reasons = []
+        filament_states = []
+
+        def observe(gate, delta, start_tip, start_tail):
+            if gate != 9:
+                return
+            present = compression.present
+            if present and not previous[0]:
+                rising_reasons.append(console.fil.history[-1][2])
+            previous[0] = present
+
+        console.fil.observers.append(observe)
+        hh.run_gcode('MMU_SELECT GATE=9')
+        original_set_state = hh.mmu.set_filament_pos_state
+
+        def record_state(state, silent=False):
+            filament_states.append(state)
+            return original_set_state(state, silent=silent)
+
+        hh.mmu.set_filament_pos_state = record_state
+        self.addCleanup(setattr, hh.mmu, 'set_filament_pos_state', original_set_state)
+        hh.run_gcode('MMU_LOAD')
+
+        self.assertEqual(rising_reasons,
+                         ['homing -> unit1:filament_compression'])
+        self.assertNotIn(FILAMENT_POS_HOMED_ENTRY, filament_states,
+                         'compression homing must not masquerade as entry-sensor homing')
+        self.assertIn(FILAMENT_POS_HOMED_EXTRUDER, filament_states)
+        self.assertEqual(hh.mmu.filament_pos, FILAMENT_POS_LOADED)
+        self.assertEqual(hh.errors, [])
 
     def test_pacing_does_not_change_where_the_filament_ends_up(self):
         """Slicing a move must be exact - the totals cannot drift from the unpaced answer."""

--- a/test/test_mmu_motion.py
+++ b/test/test_mmu_motion.py
@@ -118,6 +118,38 @@ class TestModelItself(MotionTestCase):
         self.assertIsNone(self.fil.trip_distance(0, 50., ['mmu_exit_0']),
                           'a 50mm move cannot reach a sensor 100mm away')
 
+    def test_tension_sprung_buffer_uses_configured_travel(self):
+        """Only contact during extruder homing can build compression."""
+        buffer = self.hh.mmu.mmu_machine.units[0].buffer
+        entry = self.fil.layout['extruder_entry']
+        compression = entry + buffer.buffer_maxrange * 0.7
+
+        self.assertAlmostEqual(self.fil.position('filament_compression'), compression)
+
+        self.hh.place_filament(0, position=entry - 1.)
+        self.assertTrue(self.hh.sensor('filament_tension').present)
+        self.assertFalse(self.hh.sensor('filament_compression').present)
+
+        self.hh.place_filament(0, position=entry)
+        self.assertFalse(self.hh.sensor('filament_tension').present)
+        self.assertFalse(self.hh.sensor('filament_compression').present)
+
+        # A calibrated Bowden move can overshoot the nominal coordinate without
+        # proving that the filament has contacted the extruder. It must not squeeze
+        # the buffer merely because the model's absolute tip position passed entry.
+        self.fil.advance(0, buffer.buffer_maxrange, 'move')
+        self.assertFalse(self.hh.sensor('filament_tension').present)
+        self.assertFalse(self.hh.sensor('filament_compression').present)
+
+        trip = self.fil.trip_distance(
+            0, buffer.buffer_maxrange,
+            ['unit0:filament_compression'],
+        )
+        self.assertAlmostEqual(trip[1], buffer.buffer_maxrange * 0.7)
+        self.fil.advance(0, trip[1], 'homing -> unit0:filament_compression')
+        self.assertFalse(self.hh.sensor('filament_tension').present)
+        self.assertTrue(self.hh.sensor('filament_compression').present)
+
 
 class TestGateMapCommand(MotionTestCase):
 

--- a/test/test_mmu_toolchange.py
+++ b/test/test_mmu_toolchange.py
@@ -6,17 +6,19 @@
 #
 # WHAT MAKES A FULL LOAD POSSIBLE HERE
 #
-#  - filament_compression is modelled at the extruder entry. BoxTurtle's
+#  - filament_compression is modelled after the extruder entry. BoxTurtle's
 #    extruder_homing_endstop is filament_compression: the MMU pushes filament until it
-#    meets the stationary extruder gears and the buffer compresses. Without that sensor in
-#    the layout a load dies with "Failed to reach extruder 'filament_compression' endstop".
+#    meets the stationary extruder gears, then expands the buffer through 70% of its
+#    configured max range. Without that sensor in the layout a load dies with "Failed to
+#    reach extruder 'filament_compression' endstop".
 #  - the shipped config/macros/*.cfg are loaded verbatim. An unload refuses to run without
 #    _MMU_FORM_TIP ("Filament tip forming macro not found"). They are COPIED not rendered
 #    by the installer (Makefile:148), so the harness reads them raw.
 #  - the extruder is pre-heated. Otherwise HH auto-heats and reports it through log_error
 #    (mmu_controller.py:2456), which lands in the error sentinel.
 #
-# GEOMETRY. park -100, entry -50, gate 0, extruder entry / compression +700, nozzle +740.
+# GEOMETRY. park -100, entry -150, gate 0, extruder entry +700, BoxTurtle compression
+# +708.4 (70% of its 12mm max range), nozzle +740.
 # A loaded filament sits at +768 - past the nozzle by toolhead_extruder_to_nozzle.
 #
 #   ./venv/bin/python -m unittest test.test_mmu_toolchange
@@ -84,6 +86,32 @@ class TestLoad(ToolchangeTestCase):
                         'never homed to the gate')
         self.assertTrue(any('filament_compression' in r for r in reasons),
                         'never homed to the extruder compression sensor')
+
+    def test_compression_home_includes_buffer_travel(self):
+        """Compression trips after the tip reaches the extruder plus 70% of maxrange."""
+        self.hh.mmu.select_gate(0)
+        self.hh.run_gcode('MMU_LOAD')
+        moves = [d for _g, d, reason in self.fil.history
+                 if 'homing -> unit0:filament_compression' in reason]
+        buffer = self.hh.mmu.mmu_machine.units[0].buffer
+        expected = self.fil.layout['extruder_entry'] + buffer.buffer_maxrange * 0.7
+        self.assertTrue(moves)
+        # Loading immediately reverse-homes off compression with the extruder; that
+        # second transition is only a microscopic release move.
+        self.assertAlmostEqual(max(moves), expected, places=3)
+
+    def test_paced_load_shows_all_three_buffer_states(self):
+        """The console pacer exposes tension, neutral and compression while loading."""
+        seen = set()
+        self.hh.set_pacing(1.)
+        self.hh.printer.harness_pace_observer = lambda: seen.add((
+            self.hh.sensor('filament_tension').present,
+            self.hh.sensor('filament_compression').present,
+        ))
+        self.addCleanup(setattr, self.hh.printer, 'harness_pace_observer', None)
+        self.hh.mmu.select_gate(0)
+        self.hh.run_gcode('MMU_LOAD')
+        self.assertTrue({(True, False), (False, False), (False, True)} <= seen)
 
     def test_bowden_distance_is_travelled(self):
         """Gate (0) to extruder (+700) really is covered, not skipped."""


### PR DESCRIPTION
## Summary

- model tension-sprung two-switch sync-feedback buffers using the configured `buffer_maxrange`
- expose tension, neutral, and compression transitions during paced console loads, with compression only building after extruder contact
- cover extruder-homing endstop display states and prevent compression homing from transiently reporting `HOMED_ENTRY`

## Testing

- `make ALL=1 test`
- 1104 tests passed (1 skipped, 4 expected failures)