### PR TITLE
v4 installer: BME280 default to address 118

### DIFF
--- a/installer/Kconfig.environment_sensor
+++ b/installer/Kconfig.environment_sensor
@@ -145,10 +145,10 @@ if MMU_HAS_ENVIRONMENT_SENSOR && !CUSTOM_ENVIRONMENT_SENSOR_SETUP
 
       config PARAM_ENVIRONMENT_SENSOR_I2C_ADDRESS
         int "i2c address       "
-        default 119 if CHOICE_ENVIRONMENT_SENSOR_TYPE_BME280
+        default 118 if CHOICE_ENVIRONMENT_SENSOR_TYPE_BME280
         default 56
         help
-          i2c address of the environment sensor (default 56 [0x38] for AHT sensors, 119 [0x77] for BME280)
+          i2c address of the environment sensor (default 56 [0x38] for AHT sensors, 118 [0x76] for BME280)
 
       if CHOICE_ENVIRONMENT_SENSOR_I2C_HARDWARE
         choice CHOICE_ENVIRONMENT_SENSOR_I2C_BUS
@@ -297,10 +297,10 @@ if MMU_HAS_ENVIRONMENT_SENSOR && !CUSTOM_ENVIRONMENT_SENSOR_SETUP
             config PARAM_ENVIRONMENT_SENSOR_I2C_ADDRESS_$(i)
               int "Gate $(i) i2c address       "
 
-              default 119 if CHOICE_ENVIRONMENT_SENSOR_TYPE_BME280_$(i)
+              default 118 if CHOICE_ENVIRONMENT_SENSOR_TYPE_BME280_$(i)
               default 56
               help
-                i2c address of the sensor (default 56 [0x38] for AHT sensors, 119 [0x77] for BME280)
+                i2c address of the sensor (default 56 [0x38] for AHT sensors, 118 [0x76] for BME280)
 
             if CHOICE_ENVIRONMENT_SENSOR_I2C_SOFTWARE_$(i)
               config PIN_ENVIRONMENT_SENSOR_SCL_$(i)


### PR DESCRIPTION
Affordable BME280 sensor boards seem to all either pull down SDO or are clones that don't implement address changing. These boards all respond to `118` instead of `119` - This way should fit a much larger variety of BME280s by default.