### PR TITLE
Add interactive FlowGuard telemetry plotting target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifeq ($(CHECK_OUTPUT_SYNC),)
   # 'console' and 'test' must stay in this list: --output-sync buffers a recipe's output
   # until it finishes, which for an interactive prompt means no prompt at all. 'test' opens
   # the file picker in test/select.py
-  ifeq ($(strip $(filter menuconfig uninstall variables gen_kconfig fix_links console test shots,$(MAKECMDGOALS))),)
+  ifeq ($(strip $(filter menuconfig uninstall variables gen_kconfig fix_links console test shots plot-sync,$(MAKECMDGOALS))),)
     ifneq ($(wildcard $(KCONFIG_CONFIG)),)
       # Check whether $KCONFIG_CONFIG is outdated. if so menuconfig will be triggered and output-sync should stay disabled
       ifeq ($(shell $(MAKE) CHECK_OUTPUT_SYNC=y -q $(KCONFIG_CONFIG) >/dev/null 2>&1 && echo y),y)
@@ -73,9 +73,10 @@ export PYTHONPATH:=$(SRC)/installer/lib/kconfiglib:$(PYTHONPATH)
 VENV       ?= $(SRC)/venv
 VENV_PY    := $(VENV)/bin/python
 VENV_STAMP := $(VENV)/.hh-test-requirements
-# Separate stamp: test/requirements.txt and installer/requirements.txt are installed
-# independently into the same venv, and neither should trigger the other
+# Separate stamps: test, installer and utility requirements are installed
+# independently into the same venv, and none should trigger the others
 INSTALLER_STAMP := $(VENV)/.hh-installer-requirements
+UTILS_STAMP     := $(VENV)/.hh-utils-requirements
 
 # Interpreter used to create the venv, falling back where plain `python` isn't a name
 BOOTSTRAP_PY := $(if $(shell command -v $(PY) 2>/dev/null),$(PY),python3)
@@ -175,7 +176,7 @@ restart_klipper = 0
 .SECONDEXPANSION:
 .DEFAULT_GOAL := build
 .PRECIOUS: $(KCONFIG_CONFIG) $(KCONFIG_CONFIG)_%
-.PHONY: menuconfig install uninstall check_version diff test console filament_display shots venv installer_venv clean_venv build clean variables python_deps fix_links gen_kconfig kconfig_needs_update olddefconfig verify_pickle
+.PHONY: menuconfig install uninstall check_version diff test console filament_display plot-sync shots venv installer_venv clean_venv build clean variables python_deps fix_links gen_kconfig kconfig_needs_update olddefconfig verify_pickle
 .SECONDARY: \
 	$(call backup_name,$(KLIPPER_CONFIG_HOME)/mmu) \
 	$(call backup_name,$(KLIPPER_CONFIG_HOME)/$(MOONRAKER_CONFIG_FILE)) \
@@ -610,6 +611,18 @@ filament_display: $(test_prereqs)
 	$(Q)$(using_klippy_env)
 	$(Q)HH_FILAMENT_DISPLAY_REVIEW=1 PYTHONPATH="$(SRC)/installer/lib/kconfiglib:$(PYTHONPATH)" \
 		$(TEST_PY) -m unittest test.filament_display_review -v $(ARGS)
+
+# Plot a real FlowGuard telemetry log. With several sync_<gate>.jsonl files the
+# wrapper presents an interactive picker; LOG= skips it. PLOT_LOG_DIR defaults to
+# the logs directory beside Klipper's configured config directory, then to the
+# conventional Moonraker path when this checkout has not been configured.
+PLOT_LOG_DIR ?= $(if $(strip $(KLIPPER_CONFIG_HOME)),$(patsubst %/,%,$(dir $(KLIPPER_CONFIG_HOME)))/logs,$(HOME)/printer_data/logs)
+PLOT_OUT     ?= sync_feedback_plot.png
+
+plot-sync: $(UTILS_STAMP)
+	$(Q)MPLCONFIGDIR="$(VENV)/.matplotlib" PYTHON="$(VENV_PY)" $(SRC)/utils/plot_sync_feedback.sh \
+		$(if $(strip $(LOG)),--log "$(LOG)") \
+		--log-dir "$(PLOT_LOG_DIR)" --out "$(PLOT_OUT)" -- $(ARGS)
 
 variables:
 	@echo "========================="

--- a/utils/README.md
+++ b/utils/README.md
@@ -13,13 +13,19 @@ actual controller behavior, not a mock.
 ### Plot real telemetry: `plot_sync_feedback.sh`
 
 Plots a flowguard telemetry log recorded during a real print (written to
-`~/printer_data/logs/sync_?.jsonl` when flowguard telemetry logging is
+`~/printer_data/logs/sync_*.jsonl` when flowguard telemetry logging is
 enabled — see the commented-out line in `config/base/mmu_parameters.cfg`).
 
 ```bash
-./plot_sync_feedback.sh                    # auto-picks ~/printer_data/logs/sync_?.jsonl
+./plot_sync_feedback.sh                    # picks from ~/printer_data/logs/sync_*.jsonl
 ./plot_sync_feedback.sh /path/to/sync_1.jsonl
+make plot-sync                             # installs plotting deps and offers a gate picker
+make plot-sync LOG=/path/to/sync_1.jsonl   # skip the picker
 ```
+
+`make plot-sync` creates or reuses `./venv` and automatically installs the
+dependencies in `utils/requirements.txt`. Override discovery or output with
+`PLOT_LOG_DIR=/path/to/logs` and `PLOT_OUT=/path/to/graph.png`.
 
 ### Simulate: `sim_sync_feedback.sh`
 

--- a/utils/plot_sync_feedback.sh
+++ b/utils/plot_sync_feedback.sh
@@ -1,28 +1,141 @@
 #!/usr/bin/env bash
-# Simple wrapper to source klipper python env and run sync_feedback.py with the proper PYTHONPATH
+# Select and plot a FlowGuard sync_<gate>.jsonl telemetry log.
 
-# ----- Argument validation -----
-[ "$#" -gt 1 ] && {
-    echo "Usage: $0 [<sync_?.jsonl>]"
-    exit 1
+set -u
+
+usage() {
+    cat <<EOF
+Usage: $0 [<sync_<gate>.jsonl>] [options]
+
+Options:
+  --log FILE       Plot FILE without prompting
+  --log-dir DIR    Search DIR (default: ~/printer_data/logs)
+  --out FILE       Save the graph to FILE (default: sim_plot.png)
+  -h, --help       Show this help
+
+Additional options after -- are passed to sync_feedback_sim.py.
+EOF
 }
 
-log="${1:-`ls -1 ~/printer_data/logs/sync_?.jsonl 2>/dev/null`}"
+log=""
+log_dir="${LOG_DIR:-${HOME}/printer_data/logs}"
+out="${PLOT_OUT:-sim_plot.png}"
+plot_args=()
 
-if ! [ -e "$log" ]; then
-   echo $log Flowguard telemetry file doesn\'t exist
-   exit 1
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --log)
+            [ "$#" -ge 2 ] || { echo "--log requires a file" >&2; exit 2; }
+            log="$2"
+            shift 2
+            ;;
+        --log-dir)
+            [ "$#" -ge 2 ] || { echo "--log-dir requires a directory" >&2; exit 2; }
+            log_dir="$2"
+            shift 2
+            ;;
+        --out)
+            [ "$#" -ge 2 ] || { echo "--out requires a file" >&2; exit 2; }
+            out="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            plot_args+=("$@")
+            break
+            ;;
+        -*)
+            # The remaining arguments belong to sync_feedback_sim.py. Wrapper
+            # options therefore need to precede plotting options.
+            plot_args+=("$@")
+            break
+            ;;
+        *)
+            if [ -n "$log" ]; then
+                echo "Only one telemetry log may be specified" >&2
+                usage >&2
+                exit 2
+            fi
+            log="$1"
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$log" ]; then
+    shopt -s nullglob
+    logs=("$log_dir"/sync_*.jsonl)
+    shopt -u nullglob
+
+    # Ignore directories or other unusual matches.
+    files=()
+    for candidate in "${logs[@]}"; do
+        [ -f "$candidate" ] && files+=("$candidate")
+    done
+    logs=("${files[@]}")
+
+    if [ "${#logs[@]}" -eq 0 ]; then
+        echo "No FlowGuard telemetry logs found in '$log_dir'" >&2
+        exit 1
+    elif [ "${#logs[@]}" -eq 1 ]; then
+        log="${logs[0]}"
+    else
+        echo "Available FlowGuard telemetry logs:"
+        index=1
+        for candidate in "${logs[@]}"; do
+            name="${candidate##*/}"
+            gate="${name#sync_}"
+            gate="${gate%.jsonl}"
+            printf "  %d) Gate %s  %s\n" "$index" "$gate" "$candidate"
+            index=$((index + 1))
+        done
+
+        if [ ! -t 0 ]; then
+            echo "More than one log was found but input is not interactive; use LOG=<file>" >&2
+            exit 1
+        fi
+
+        while :; do
+            printf "Choose a log [1-%d]: " "${#logs[@]}"
+            IFS= read -r choice || exit 1
+            case "$choice" in
+                ''|*[!0-9]*) echo "Enter a number from 1 to ${#logs[@]}." ;;
+                *)
+                    if [ "$choice" -ge 1 ] && [ "$choice" -le "${#logs[@]}" ]; then
+                        log="${logs[$((choice - 1))]}"
+                        break
+                    fi
+                    echo "Enter a number from 1 to ${#logs[@]}."
+                    ;;
+            esac
+        done
+    fi
 fi
 
-if [ -f ~/klippy-env/bin/activate ]; then
-    . ~/klippy-env/bin/activate
+if [ ! -f "$log" ]; then
+    echo "FlowGuard telemetry file '$log' does not exist" >&2
+    exit 1
 fi
 
-echo Processing ${log} Flowguard telemetry file
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+mmu_dir="${script_dir}/../extras/mmu"
+export PYTHONPATH="${mmu_dir}${PYTHONPATH:+:${PYTHONPATH}}"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MMU_DIR="${SCRIPT_DIR}/../extras/mmu"
-export PYTHONPATH="${MMU_DIR}:${PYTHONPATH}"
+# make plot-sync supplies the managed venv explicitly. Direct invocations reuse
+# that venv when present, then fall back to Klipper's environment or PATH.
+if [ -n "${PYTHON:-}" ]; then
+    python_bin="$PYTHON"
+elif [ -x "${script_dir}/../venv/bin/python" ]; then
+    python_bin="${script_dir}/../venv/bin/python"
+elif [ -x "${HOME}/klippy-env/bin/python" ]; then
+    python_bin="${HOME}/klippy-env/bin/python"
+else
+    python_bin="python"
+fi
 
-python "${SCRIPT_DIR}/sync_feedback_sim.py" --plot "$log"
-
+echo "Processing '$log' FlowGuard telemetry file"
+"$python_bin" "${script_dir}/sync_feedback_sim.py" --plot "$log" --out "$out" "${plot_args[@]}"

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,0 +1,6 @@
+# FlowGuard telemetry plotting dependencies. Deliberately separate from the
+# production installer and test harness: `make plot-sync` creates ./venv and
+# installs or refreshes these automatically via Makefile's generic stamp rule.
+
+matplotlib
+numpy


### PR DESCRIPTION
## Summary

- add `make plot-sync` with automatic NumPy and Matplotlib provisioning in the repository venv
- discover per-gate `sync_*.jsonl` telemetry and prompt when multiple logs are available
- support explicit log, log directory, output path, and graph argument overrides
- document the plotting workflow

## Verification

- `git diff --check`
- `bash -n utils/plot_sync_feedback.sh`
- automatic venv dependency installation
- interactive selection with gates 0 and 12, including invalid input handling
- generated a PNG from representative telemetry with `--show-ticks --x-mm signed`