### PR TITLE
Fix menuconfig macro string rendering

### DIFF
--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -97,7 +97,7 @@ description: Happy Hare optional configuration for print start/end checks
 gcode: # Leave empty
 
 # These variables control the behavior of the MMU_START_SETUP and MMU_START_LOAD_INITIAL_TOOL macros
-variable_user_pre_initialize_extension      : [[VAR_SOFTWARE_USER_PRE_INITIALIZE_EXTENSION]]	; Executed at start of MMU_START_SETUP. Commonly G28 to home
+variable_user_pre_initialize_extension      : [[VAR_SOFTWARE_USER_PRE_INITIALIZE_EXTENSION|klipper_string_literal]]	; Executed at start of MMU_START_SETUP. Commonly G28 to home
 variable_home_mmu                           : [[VAR_SOFTWARE_HOME_MMU]]	; True/False, Whether to home mmu before print starts
 variable_check_gates                        : [[VAR_SOFTWARE_CHECK_GATES]]	; True/False, Whether to check filament is loaded in all gates used
 variable_load_initial_tool                  : [[VAR_SOFTWARE_LOAD_INITIAL_TOOL]]	; True/False, Whether to automatically load initial tool
@@ -112,7 +112,7 @@ variable_load_initial_tool                  : [[VAR_SOFTWARE_LOAD_INITIAL_TOOL]]
 variable_automap_strategy                   : [[VAR_SOFTWARE_AUTOMAP_STRATEGY]]	; none|filament_name|material|color|closest_color|spool_id
 
 # These variables control the behavior of the MMU_END macro
-variable_user_print_end_extension           : [[VAR_SOFTWARE_USER_PRINT_END_EXTENSION]]	; Executed at start of MMU_END. Good place to move off print
+variable_user_print_end_extension           : [[VAR_SOFTWARE_USER_PRINT_END_EXTENSION|klipper_string_literal]]	; Executed at start of MMU_END. Good place to move off print
 variable_unload_tool                        : [[VAR_SOFTWARE_UNLOAD_TOOL]]	; True/False, Whether to unload the tool at the end of the print
 variable_reset_ttg                          : [[VAR_SOFTWARE_RESET_TTG]]	; True/False, Whether reset TTG map at end of print
 variable_dump_stats                         : [[VAR_SOFTWARE_DUMP_STATS]]	; True/False, Whether to display print stats at end of print
@@ -135,9 +135,9 @@ gcode: # Leave empty
 # You can extend functionality to all Happy Hare state change or event
 # macros by adding a command (or call to your gcode macro).
 # E.g for additional LED logic or consumption counters
-variable_user_action_changed_extension      : [[VAR_STATE_USER_ACTION_CHANGED_EXTENSION]]	; Executed after default logic with duplicate params
-variable_user_print_state_changed_extension : [[VAR_STATE_USER_PRINT_STATE_CHANGED_EXTENSION]]	; Executed after default logic with duplicate params
-variable_user_mmu_event_extension           : [[VAR_STATE_USER_MMU_EVENT_EXTENSION]]	; Executed after default logic with duplicate params
+variable_user_action_changed_extension      : [[VAR_STATE_USER_ACTION_CHANGED_EXTENSION|klipper_string_literal]]	; Executed after default logic with duplicate params
+variable_user_print_state_changed_extension : [[VAR_STATE_USER_PRINT_STATE_CHANGED_EXTENSION|klipper_string_literal]]	; Executed after default logic with duplicate params
+variable_user_mmu_event_extension           : [[VAR_STATE_USER_MMU_EVENT_EXTENSION|klipper_string_literal]]	; Executed after default logic with duplicate params
 
 # Maintenance warning limits (consumption counters)
 variable_servo_down_limit                   : [[VAR_STATE_SERVO_DOWN_LIMIT]]	; Set to -1 for no limit / disable warning
@@ -267,20 +267,20 @@ variable_unretract_speed                    : [[VAR_SEQUENCE_UNRETRACT_SPEED]]		
 #    YOUR_MOVE_MACRO X=<x_coord> Y=<y_coord> F=<speed>
 # when restoring the from parked postion the same macro is called but passed a RESTORE=1 parameter, along with co-ordinates to restore to
 #    YOUR_MOVE_MACRO RESTORE=1 X=<x_coord> Y=<y_coord> F=<speed>
-variable_user_park_move_macro               : [[VAR_SEQUENCE_USER_PARK_MOVE_MACRO]]		; Executed instead of default 'G1 X Y move' to park position
+variable_user_park_move_macro               : [[VAR_SEQUENCE_USER_PARK_MOVE_MACRO|klipper_string_literal]]		; Executed instead of default 'G1 X Y move' to park position
 
 variable_auto_home                          : [[VAR_SEQUENCE_AUTO_HOME]]		; True = automatically home if necessary, False = disable
 variable_timelapse                          : [[VAR_SEQUENCE_TIMELAPSE]]		; True = take frame snapshot after load, False = disable
 
 # Instead of completely defining your own macros you can extend functionality
 # of default sequence macros by adding a command (or call to your gcode macro)
-variable_user_mmu_error_extension           : [[VAR_SEQUENCE_USER_MMU_ERROR_EXTENSION]]	; Executed after default logic when mmu error condition occurs
-variable_user_pre_unload_extension          : [[VAR_SEQUENCE_USER_PRE_UNLOAD_EXTENSION]]	; Executed after default logic
-variable_user_post_form_tip_extension       : [[VAR_SEQUENCE_USER_POST_FORM_TIP_EXTENSION]]	; Executed after default logic
-variable_user_post_unload_extension         : [[VAR_SEQUENCE_USER_POST_UNLOAD_EXTENSION]]	; Executed after default logic
-variable_user_pre_load_extension            : [[VAR_SEQUENCE_USER_PRE_LOAD_EXTENSION]]	; Executed after default logic
-variable_user_post_load_extension           : [[VAR_SEQUENCE_USER_POST_LOAD_EXTENSION]]	; Executed after default logic but before restoring toolhead position
-variable_user_post_preload_extension        : [[VAR_SEQUENCE_USER_POST_PRELOAD_EXTENSION]]	; Executed after successful preload
+variable_user_mmu_error_extension           : [[VAR_SEQUENCE_USER_MMU_ERROR_EXTENSION|klipper_string_literal]]	; Executed after default logic when mmu error condition occurs
+variable_user_pre_unload_extension          : [[VAR_SEQUENCE_USER_PRE_UNLOAD_EXTENSION|klipper_string_literal]]	; Executed after default logic
+variable_user_post_form_tip_extension       : [[VAR_SEQUENCE_USER_POST_FORM_TIP_EXTENSION|klipper_string_literal]]	; Executed after default logic
+variable_user_post_unload_extension         : [[VAR_SEQUENCE_USER_POST_UNLOAD_EXTENSION|klipper_string_literal]]	; Executed after default logic
+variable_user_pre_load_extension            : [[VAR_SEQUENCE_USER_PRE_LOAD_EXTENSION|klipper_string_literal]]	; Executed after default logic
+variable_user_post_load_extension           : [[VAR_SEQUENCE_USER_POST_LOAD_EXTENSION|klipper_string_literal]]	; Executed after default logic but before restoring toolhead position
+variable_user_post_preload_extension        : [[VAR_SEQUENCE_USER_POST_PRELOAD_EXTENSION|klipper_string_literal]]	; Executed after successful preload
 
 
 # CLIENT MACROS ---------------------------------------------------------------------------
@@ -304,9 +304,9 @@ variable_reset_ttg_on_cancel                : [[VAR_CLIENT_RESET_TTG_ON_CANCEL]]
 variable_unload_tool_on_cancel              : [[VAR_CLIENT_UNLOAD_TOOL_ON_CANCEL]]		; True/False, Whether to unload the tool on cancel
 
 # You can extend functionality by adding a command (or call to your gcode macro)
-variable_user_pause_extension               : [[VAR_CLIENT_USER_PAUSE_EXTENSION]]		; Executed after the klipper base pause
-variable_user_resume_extension              : [[VAR_CLIENT_USER_RESUME_EXTENSION]]		; Executed before the klipper base resume
-variable_user_cancel_extension              : [[VAR_CLIENT_USER_CANCEL_EXTENSION]]		; Executed before the klipper base cancel_print
+variable_user_pause_extension               : [[VAR_CLIENT_USER_PAUSE_EXTENSION|klipper_string_literal]]		; Executed after the klipper base pause
+variable_user_resume_extension              : [[VAR_CLIENT_USER_RESUME_EXTENSION|klipper_string_literal]]		; Executed before the klipper base resume
+variable_user_cancel_extension              : [[VAR_CLIENT_USER_CANCEL_EXTENSION|klipper_string_literal]]		; Executed before the klipper base cancel_print
 
 
 
@@ -441,7 +441,7 @@ variable_ramming_volume_standalone          : [[VAR_FORM_TIP_RAMMING_VOLUME_STAN
 # moves. Temperature will be restored after tip creation is complete
 variable_toolchange_temp                    : [[VAR_FORM_TIP_TOOLCHANGE_TEMP]]		; 0 = don't change temp, else temp to set
 variable_toolchange_fan_assist              : [[VAR_FORM_TIP_TOOLCHANGE_FAN_ASSIST]]		; Whether to use part cooling fan for quicker temp change
-variable_toolchange_fan_name                : [[VAR_FORM_TIP_TOOLCHANGE_FAN_NAME]]		; Define the part fan name if not default [fan] e.g "fan_generic fan0"
+variable_toolchange_fan_name                : [[VAR_FORM_TIP_TOOLCHANGE_FAN_NAME|klipper_string_literal]]		; Define the part fan name if not default [fan] e.g "fan_generic fan0"
 variable_toolchange_fan_speed               : [[VAR_FORM_TIP_TOOLCHANGE_FAN_SPEED]]		; Fan speed % if using fan_assist enabled
 
 # Step 2 - Nozzle Separation
@@ -860,7 +860,7 @@ variable_part_cooling_fan_blob_deposit      : [[VAR_BLOBIFIER_PART_COOLING_FAN_B
 # Define the part fan name if you are using a fan other than [fan]
 # Applies to [fan_generic] or other fan definitions
 # Example: if using auxiliary fan control in Orcaslicer, set to "fan_generic fan0"
-variable_fan_name                           : [[VAR_BLOBIFIER_FAN_NAME]]
+variable_fan_name                           : [[VAR_BLOBIFIER_FAN_NAME|klipper_string_literal]]
 
 # ========================================================================================
 # ==================== BUCKET ============================================================

--- a/installer/build.py
+++ b/installer/build.py
@@ -16,6 +16,8 @@ import argparse
 import re
 import os
 import copy
+import ast
+import json
 import logging
 import subprocess
 import pickle
@@ -477,8 +479,49 @@ def add_supplemental_params(builder, hhcfg, section):
             builder.copy_option(hhcfg, section, param)
 
 
+INVALID_KLIPPER_STRING_LITERAL = "<invalid klipper string literal>"
+
+
+def klipper_string_literal(value):
+    """Render arbitrary menuconfig text as a Klipper/Python string literal.
+
+    Kconfig strings are decoded before they reach Jinja, while Klipper expects
+    every gcode_macro variable to be a valid Python literal.  JSON string
+    encoding is also valid Python string syntax and safely handles quotes,
+    backslashes, control characters, and newlines.
+
+    Early menuconfig users worked around the missing encoding by entering the
+    surrounding quotes themselves.  Preserve those values by unwrapping a
+    complete quoted string literal before encoding it again.
+
+    This filter must never abort template rendering.  Kconfig supplies strings,
+    but if an unexpected internal value cannot be converted or encoded, emit an
+    intentionally invalid literal so Klipper reports the bad generated option.
+    """
+    try:
+        text = value if isinstance(value, str) else str(value)
+    except Exception:
+        logging.exception("Unable to convert value to a Klipper string literal")
+        return INVALID_KLIPPER_STRING_LITERAL
+
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
+        try:
+            legacy_value = ast.literal_eval(text)
+        except Exception:
+            pass
+        else:
+            if isinstance(legacy_value, str):
+                text = legacy_value
+
+    try:
+        return json.dumps(text, ensure_ascii=True)
+    except Exception:
+        logging.exception("Unable to encode value as a Klipper string literal")
+        return INVALID_KLIPPER_STRING_LITERAL
+
+
 def jinja_env():
-    return Environment(
+    env = Environment(
         loader=FileSystemLoader("."),
         block_start_string="[%",
         block_end_string="%]",
@@ -489,6 +532,8 @@ def jinja_env():
         trim_blocks=True,
         line_comment_prefix=";;",
     )
+    env.filters["klipper_string_literal"] = klipper_string_literal
+    return env
 
 
 def render_template(template_file, kcfg, extra_params):

--- a/installer/macro_vars/Kconfig.blobifier
+++ b/installer/macro_vars/Kconfig.blobifier
@@ -208,6 +208,7 @@ menu "Blobifier            (_BLOBIFIER)"
     default ""
     help
       Optional part fan name if using a fan other than [fan].
+      Enter the name without surrounding quotes.
 
   comment "_"
   comment "_Purge Length Tuning"

--- a/installer/macro_vars/Kconfig.client
+++ b/installer/macro_vars/Kconfig.client
@@ -32,17 +32,20 @@ menu "Client macros        (_MMU_CLIENT)"
     default ""
     help
       Executed after the Klipper base pause.
+      Enter G-code without surrounding quotes.
 
   config VAR_CLIENT_USER_RESUME_EXTENSION
     string "Resume extension macro"
     default ""
     help
       Executed before the Klipper base resume.
+      Enter G-code without surrounding quotes.
 
   config VAR_CLIENT_USER_CANCEL_EXTENSION
     string "Cancel extension macro"
     default ""
     help
       Executed before the Klipper base cancel_print.
+      Enter G-code without surrounding quotes.
 
 endmenu

--- a/installer/macro_vars/Kconfig.form_tip
+++ b/installer/macro_vars/Kconfig.form_tip
@@ -45,6 +45,7 @@ menu "Tip forming          (_MMU_FORM_TIP)"
     help
       Fan name if not using the default [fan].
       Example: fan_generic fan0
+      Enter the name without surrounding quotes.
 
   config VAR_FORM_TIP_TOOLCHANGE_FAN_SPEED
     int "Toolchange % fan speed     "

--- a/installer/macro_vars/Kconfig.sequence
+++ b/installer/macro_vars/Kconfig.sequence
@@ -182,42 +182,49 @@ menu "Sequence macros      (_MMU_SEQUENCE)"
     default ""
     help
       Executed after default logic when MMU error condition occurs.
+      Enter G-code without surrounding quotes.
 
   config VAR_SEQUENCE_USER_PRE_UNLOAD_EXTENSION
     string "Pre-unload extension macro   "
     default ""
     help
       Executed after default logic.
+      Enter G-code without surrounding quotes.
 
   config VAR_SEQUENCE_USER_POST_FORM_TIP_EXTENSION
     string "Post-form-tip extension macro"
     default ""
     help
       Executed after default logic.
+      Enter G-code without surrounding quotes.
 
   config VAR_SEQUENCE_USER_POST_UNLOAD_EXTENSION
     string "Post-unload extension macro  "
     default ""
     help
       Executed after default logic.
+      Enter G-code without surrounding quotes.
 
   config VAR_SEQUENCE_USER_PRE_LOAD_EXTENSION
     string "Pre-load extension macro     "
     default ""
     help
       Executed after default logic.
+      Enter G-code without surrounding quotes.
 
   config VAR_SEQUENCE_USER_POST_LOAD_EXTENSION
     string "Post-load extension macro    "
     default ""
     help
       Executed after default logic but before restoring toolhead position.
+      Enter G-code without surrounding quotes.
 
   config VAR_SEQUENCE_USER_POST_PRELOAD_EXTENSION
     string "Post-preload extension macro "
     default ""
     help
       Executed after successful filament preload
+      Enter G-code without surrounding quotes.
 
   comment "_"
   comment "_Misc"
@@ -253,6 +260,7 @@ menu "Sequence macros      (_MMU_SEQUENCE)"
       Advanced. User supplied macro that is executed instead of the default G1 XY
       move to park position.  Macro is called with X, Y, and F parameters. When
       restoring, it is also passed RESTORE=1.
+      Enter the macro name without surrounding quotes.
 
       This is useful when you want to control the movement path of the toolhead
       to avoid an area rather than accept the direct line

--- a/installer/macro_vars/Kconfig.software
+++ b/installer/macro_vars/Kconfig.software
@@ -13,6 +13,7 @@ menu "Print start/end      (_MMU_SOFTWARE)"
     help
       Macro executed at start of MMU_START_SETUP.
       Commonly G28 to home.
+      Enter G-code without surrounding quotes.
 
   config BOOL_SOFTWARE_HOME_MMU
     bool "Home MMU before print starts"
@@ -104,6 +105,7 @@ menu "Print start/end      (_MMU_SOFTWARE)"
     help
       Macro executed at start of MMU_END.
       Good place to move off print.
+      Enter G-code without surrounding quotes.
 
   config BOOL_SOFTWARE_UNLOAD_TOOL
     bool "Unload tool at end of print"

--- a/installer/macro_vars/Kconfig.state
+++ b/installer/macro_vars/Kconfig.state
@@ -11,6 +11,7 @@ menu "State change hooks   (_MMU_STATE)"
       Optional user macro that is executed after default logic when
       MMU action changes. Used to extend Happy Hare functionality.
       (passed same params as original macro)
+      Enter G-code without surrounding quotes.
 
   config VAR_STATE_USER_PRINT_STATE_CHANGED_EXTENSION
     string "Print state changed extension macro"
@@ -19,6 +20,7 @@ menu "State change hooks   (_MMU_STATE)"
       Optional user macro that is executed after default logic when
       MMU print state changes. Used to extend Happy Hare functionality.
       (passed same params as original macro)
+      Enter G-code without surrounding quotes.
 
   config VAR_STATE_USER_MMU_EVENT_EXTENSION
     string "MMU event extension macro          "
@@ -27,6 +29,7 @@ menu "State change hooks   (_MMU_STATE)"
       Optional user macro that is executed after default logic when
       MMU event occurs. Used to extend Happy Hare functionality.
       (passed same params as original macro)
+      Enter G-code without surrounding quotes.
 
   comment "_"
   comment "_Consumption counters"

--- a/test/hh/klippy_root/extras/gcode_macro.py
+++ b/test/hh/klippy_root/extras/gcode_macro.py
@@ -20,6 +20,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+import json
 import jinja2
 
 # One Environment and one compiled-template cache for the whole PROCESS, not per boot.
@@ -131,10 +132,13 @@ class GCodeMacro:
         import ast
         for option in config.get_prefix_options('variable_'):
             try:
-                self.variables[option[len('variable_'):]] = ast.literal_eval(
-                    config.get(option).strip())
-            except (SyntaxError, ValueError):
-                self.variables[option[len('variable_'):]] = config.get(option).strip()
+                literal = ast.literal_eval(config.get(option))
+                json.dumps(literal, separators=(',', ':'))
+                self.variables[option[len('variable_'):]] = literal
+            except (SyntaxError, TypeError, ValueError) as e:
+                raise config.error(
+                    "Option '%s' in section '%s' is not a valid literal: %s" % (
+                        option, config.get_name(), e))
         self.calls = []         # test assertion surface
         self.gcode.register_command(self.alias, self.cmd, desc=self.description)
 

--- a/test/test_mmu_config.py
+++ b/test/test_mmu_config.py
@@ -13,6 +13,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+import ast
 import os
 import re
 import tempfile
@@ -72,6 +73,17 @@ class TestBoxTurtleRender(unittest.TestCase):
                          'virtual_sdcard', 'display_status',
                          'gcode_macro _MMU_SEQUENCE_VARS'):
             self.assertIn(expected, secs)
+
+    def test_every_rendered_macro_variable_is_a_valid_klipper_literal(self):
+        """Real Klipper rejects the entire config if any variable is not a Python literal."""
+        parser = cfg.assemble(self.rendered, macros=False)
+        for section in parser.sections():
+            if not section.startswith('gcode_macro '):
+                continue
+            for option, value in parser.items(section):
+                if option.startswith('variable_'):
+                    with self.subTest(section=section, option=option, value=value):
+                        ast.literal_eval(value)
 
     def test_unit_topology_is_self_consistent(self):
         """
@@ -136,6 +148,74 @@ class TestBoxTurtleRender(unittest.TestCase):
         extruder = dict(parser.items('extruder'))
         self.assertEqual(extruder['step_pin'], 'mcu:PA1')          # from the stub
         self.assertIn('max_extrude_only_distance', extruder)       # from the template
+
+
+class TestMenuconfigMacroStrings(unittest.TestCase):
+
+    def _pre_unload_value(self, configured, profile_name):
+        profile = profiles.get('boxturtle').derive(
+            profile_name,
+            syms={'VAR_SEQUENCE_USER_PRE_UNLOAD_EXTENSION': configured})
+        rendered = cfg.render(profile)
+        parser = cfg.assemble(rendered, macros=False)
+        raw = dict(parser.items('gcode_macro _MMU_SEQUENCE_VARS'))[
+            'variable_user_pre_unload_extension']
+        return raw, ast.literal_eval(raw)
+
+    def test_plain_gcode_is_rendered_as_a_string_literal(self):
+        raw, value = self._pre_unload_value('MY_PRE_UNLOAD', 'macro_string_plain')
+        self.assertEqual(raw, '"MY_PRE_UNLOAD"')
+        self.assertEqual(value, 'MY_PRE_UNLOAD')
+
+    def test_empty_hook_is_an_empty_string_not_a_blank_value(self):
+        raw, value = self._pre_unload_value('', 'macro_string_empty')
+        self.assertEqual(raw, '""')
+        self.assertEqual(value, '')
+
+    def test_arbitrary_quotes_backslashes_and_newlines_survive_round_trip(self):
+        configured = 'RESPOND MSG="can\'t unload" PATH=C:\\tmp\\tool\\nM117 done'
+        raw, value = self._pre_unload_value(configured, 'macro_string_escaping')
+        self.assertEqual(value, configured.replace('\\n', '\n'))
+        self.assertIn('\\"', raw)
+        self.assertIn('\\\\tmp', raw)
+        self.assertIn('\\n', raw)
+
+    def test_malformed_quoted_input_does_not_abort_jinja_rendering(self):
+        configured = 'RESPOND MSG="unterminated'
+        raw, value = self._pre_unload_value(configured, 'macro_string_malformed_quote')
+        self.assertEqual(value, configured)
+        self.assertTrue(raw.startswith('"'))
+
+    def test_unexpected_internal_value_renders_invalid_sentinel_instead_of_raising(self):
+        cfg._prepare_imports()
+        from installer import build
+
+        class Unstringable:
+            def __str__(self):
+                raise RuntimeError('cannot stringify')
+
+        with self.assertLogs(level='ERROR'):
+            rendered = build.klipper_string_literal(Unstringable())
+        self.assertEqual(rendered, build.INVALID_KLIPPER_STRING_LITERAL)
+        with self.assertRaises((SyntaxError, ValueError)):
+            ast.literal_eval(rendered)
+
+    def test_existing_manually_quoted_workaround_is_not_double_quoted(self):
+        raw, value = self._pre_unload_value("'LEGACY_PRE_UNLOAD'",
+                                            'macro_string_legacy_quotes')
+        self.assertEqual(raw, '"LEGACY_PRE_UNLOAD"')
+        self.assertEqual(value, 'LEGACY_PRE_UNLOAD')
+
+    def test_optional_blobifier_fan_name_uses_the_same_encoding(self):
+        profile = profiles.get('boxturtle').derive(
+            'macro_string_blobifier',
+            syms={'MMU_HAS_BLOBIFIER': True,
+                  'VAR_BLOBIFIER_FAN_NAME': 'fan_generic fan0'})
+        rendered = cfg.render(profile)
+        parser = cfg.assemble(rendered, macros=False)
+        raw = dict(parser.items('gcode_macro _BLOBIFIER_VARS'))['variable_fan_name']
+        self.assertEqual(raw, '"fan_generic fan0"')
+        self.assertEqual(ast.literal_eval(raw), 'fan_generic fan0')
 
 
 # Deliberately TWO IDENTICAL BOXTURTLES rather than the real ercf_vvd profile. The point is


### PR DESCRIPTION
## Summary

- encode user-entered macro hooks and fan names as valid Klipper string literals
- keep Jinja rendering non-throwing for malformed input and preserve manually quoted workarounds
- make the fake Klipper parser enforce real Klipper literal rules
- add regression coverage for empty values, quotes, backslashes, newlines, malformed quotes, legacy quoting, and Blobifier

## Root cause

Kconfig decodes string values before Jinja rendering, but the macro-vars template inserted them verbatim. Klipper requires every variable_* value to be a Python literal, so plain menuconfig input and empty defaults produced invalid configuration.

## Testing

- make ALL=1 test: 1111 tests passed; skipped=1; expected failures=4
- test.test_mmu_config: 25 tests passed
- git diff --check