### PR TITLE
Expose selector status on printer.mmu

### DIFF
--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -694,6 +694,9 @@ class MmuController(MmuFilamentMovement):
         # Adds sync_feedback status (this includes flowguard status)
         status.update(self.mmu_unit().sync_feedback.get_status(eventtime))
 
+        # Add selector status for the active unit
+        status['selector'] = self.selector().get_status(eventtime)
+
         # Add in active sensors
         status['sensors'] = self.sensor_manager.get_status(eventtime)
 

--- a/test/test_mmu_selector.py
+++ b/test/test_mmu_selector.py
@@ -136,6 +136,11 @@ class TestLinearSelector(SelectorTestCase):
         self.assertTrue(selector.is_homed)
         self.assertEqual(self.axis('unit0').carriage, self.axis('unit0').home_position())
 
+    def test_selector_status_is_published_under_mmu_selector(self):
+        selector = self.selector('unit0')
+
+        self.assertEqual(self.hh.mmu.get_status(0)['selector'], selector.get_status(0))
+
     def test_calibration_is_seeded_from_the_machines_own_cad_table(self):
         """
         Offsets come from HH's published quick method (cad_gate0_pos + i*cad_gate_width), so


### PR DESCRIPTION
## Summary
- publish the active selector status under `printer.mmu.selector`
- add an integration test for the nested selector status contract

## Testing
- `make test` (1105 tests passed; 1 skipped, 4 expected failures)