### PR TITLE
Keep MMU status fields stable during startup

### DIFF
--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -670,6 +670,7 @@ class MmuController(MmuFilamentMovement):
             'spoolman_support': self.p.spoolman_support,
             'bowden_progress': self._get_bowden_progress(), # Simple 0-100%. -1 if not performing bowden move
             'print_start_detection': self.p.print_start_detection, # For Klippain. Not really sure it is necessary
+            'encoder': None,
 
             # DEPRECATED but possibly still used in UI's or by users custom macros
             'espooler_active': self.espooler().get_operation(self.gate_selected)[0] if self.has_espooler() else ESPOOLER_NONE, # DEPRECATED
@@ -682,6 +683,10 @@ class MmuController(MmuFilamentMovement):
             'clog_detection_enabled': False,   # DEPRECATED
         }
 
+        # Keep these fields present from the first status query so Moonraker can
+        # establish stable subscriptions before MMU initialization completes.
+        status.update(self.mmu_unit().sync_feedback.get_status(eventtime))
+
         if not self._ready:
             return status
 
@@ -690,9 +695,6 @@ class MmuController(MmuFilamentMovement):
 
         # Adds extruder status (like filament remaining)
         status.update(self.mmu_unit().extruder_wrapper.get_status(eventtime))
-
-        # Adds sync_feedback status (this includes flowguard status)
-        status.update(self.mmu_unit().sync_feedback.get_status(eventtime))
 
         # Add selector status for the active unit
         status['selector'] = self.selector().get_status(eventtime)

--- a/extras/mmu/unit/mmu_sync_feedback.py
+++ b/extras/mmu/unit/mmu_sync_feedback.py
@@ -368,12 +368,21 @@ class MmuSyncFeedback:
 
 
     def get_status(self, eventtime=None):
+        status = {
+            'sync_feedback_state': None,
+            'sync_feedback_enabled': None,
+            'sync_feedback_bias_raw': None,
+            'sync_feedback_bias_modelled': None,
+            'sync_feedback_flow_rate': None,
+            'flowguard': None,
+            'tangle_prevention': None,
+        }
 
         # Buffer controlled sync feedback
         if self.mmu_unit.has_buffer() and self.ctrl:
             if self.mmu_unit.has_encoder():
                 self.flowguard_status['encoder_mode'] = self.p.flowguard_encoder_mode # Ok to mutate status
-            return {
+            status.update({
                 'sync_feedback_state': self.get_sync_feedback_string(),
                 'sync_feedback_enabled': self.is_enabled(),
                 'sync_feedback_bias_raw': round(self._get_sync_bias_raw(), 2),
@@ -387,19 +396,19 @@ class MmuSyncFeedback:
                     'threshold': self.p.tangle_prevention_threshold,
                     'release': self.p.tangle_prevention_release,
                 },
-            }
+            })
 
         # Encoder flowguard only
-        if self.mmu_unit.has_encoder():
-            return {
+        elif self.mmu_unit.has_encoder():
+            status.update({
                 'flowguard': {
                     'active': self.flowguard_active,
                     'enabled': self.p.flowguard_enabled,
                     'encoder_mode': self.p.flowguard_encoder_mode,
                 }
-            }
+            })
 
-        return {}
+        return status
 
 
     #

--- a/test/test_mmu_bootup.py
+++ b/test/test_mmu_bootup.py
@@ -99,6 +99,14 @@ class TestConfigLoad(unittest.TestCase):
         self.assertIsNotNone(getattr(unit, 'buffer', None), 'buffer missing')
         self.assertIsNotNone(getattr(unit, 'leds', None), 'leds missing')
 
+    def test_status_fields_exist_before_ready(self):
+        status = self.hh.mmu.get_status(self.hh.reactor.monotonic())
+        for key in ('encoder', 'sync_feedback_state', 'sync_feedback_enabled',
+                    'sync_feedback_bias_raw', 'sync_feedback_bias_modelled',
+                    'sync_feedback_flow_rate', 'flowguard', 'tangle_prevention'):
+            self.assertIn(key, status)
+            self.assertIsNone(status[key])
+
     def test_no_errors_during_config_load(self):
         self.assertEqual(self.hh.errors, [])
 
@@ -287,6 +295,12 @@ class TestReady(BootedSessionMixin, unittest.TestCase):
         status = self.hh.mmu.get_status(self.hh.reactor.monotonic())
         self.assertTrue(status['enabled'])
         self.assertEqual(status['num_gates'], 4)
+        self.assertIsNone(status['encoder'])
+        for key in ('sync_feedback_state', 'sync_feedback_enabled',
+                    'sync_feedback_bias_raw', 'sync_feedback_bias_modelled',
+                    'sync_feedback_flow_rate', 'flowguard', 'tangle_prevention'):
+            self.assertIn(key, status)
+            self.assertIsNotNone(status[key])
 
 
 class TestReadySaveVariables(unittest.TestCase):


### PR DESCRIPTION
## Summary
- publish encoder and sync-feedback status keys from the first status query
- use null placeholders until the relevant hardware is initialized
- preserve hardware-specific status values after startup
- add regression coverage for pre-ready and ready status shapes

## Testing
- ./venv/bin/python -m unittest test.test_mmu_bootup
- ./venv/bin/python -m unittest test.test_mmu_encoder test.test_mmu_tangle_prevention test.test_mmu_local_gate