### PR TITLE
Rename FlowGuard plotting target to plot_sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifeq ($(CHECK_OUTPUT_SYNC),)
   # 'console' and 'test' must stay in this list: --output-sync buffers a recipe's output
   # until it finishes, which for an interactive prompt means no prompt at all. 'test' opens
   # the file picker in test/select.py
-  ifeq ($(strip $(filter menuconfig uninstall variables gen_kconfig fix_links console test shots plot-sync,$(MAKECMDGOALS))),)
+  ifeq ($(strip $(filter menuconfig uninstall variables gen_kconfig fix_links console test shots plot_sync,$(MAKECMDGOALS))),)
     ifneq ($(wildcard $(KCONFIG_CONFIG)),)
       # Check whether $KCONFIG_CONFIG is outdated. if so menuconfig will be triggered and output-sync should stay disabled
       ifeq ($(shell $(MAKE) CHECK_OUTPUT_SYNC=y -q $(KCONFIG_CONFIG) >/dev/null 2>&1 && echo y),y)
@@ -176,7 +176,7 @@ restart_klipper = 0
 .SECONDEXPANSION:
 .DEFAULT_GOAL := build
 .PRECIOUS: $(KCONFIG_CONFIG) $(KCONFIG_CONFIG)_%
-.PHONY: menuconfig install uninstall check_version diff test console filament_display plot-sync shots venv installer_venv clean_venv build clean variables python_deps fix_links gen_kconfig kconfig_needs_update olddefconfig verify_pickle
+.PHONY: menuconfig install uninstall check_version diff test console filament_display plot_sync shots venv installer_venv clean_venv build clean variables python_deps fix_links gen_kconfig kconfig_needs_update olddefconfig verify_pickle
 .SECONDARY: \
 	$(call backup_name,$(KLIPPER_CONFIG_HOME)/mmu) \
 	$(call backup_name,$(KLIPPER_CONFIG_HOME)/$(MOONRAKER_CONFIG_FILE)) \
@@ -619,7 +619,7 @@ filament_display: $(test_prereqs)
 PLOT_LOG_DIR ?= $(if $(strip $(KLIPPER_CONFIG_HOME)),$(patsubst %/,%,$(dir $(KLIPPER_CONFIG_HOME)))/logs,$(HOME)/printer_data/logs)
 PLOT_OUT     ?= sync_feedback_plot.png
 
-plot-sync: $(UTILS_STAMP)
+plot_sync: $(UTILS_STAMP)
 	$(Q)MPLCONFIGDIR="$(VENV)/.matplotlib" PYTHON="$(VENV_PY)" $(SRC)/utils/plot_sync_feedback.sh \
 		$(if $(strip $(LOG)),--log "$(LOG)") \
 		--log-dir "$(PLOT_LOG_DIR)" --out "$(PLOT_OUT)" -- $(ARGS)

--- a/utils/README.md
+++ b/utils/README.md
@@ -19,11 +19,11 @@ enabled — see the commented-out line in `config/base/mmu_parameters.cfg`).
 ```bash
 ./plot_sync_feedback.sh                    # picks from ~/printer_data/logs/sync_*.jsonl
 ./plot_sync_feedback.sh /path/to/sync_1.jsonl
-make plot-sync                             # installs plotting deps and offers a gate picker
-make plot-sync LOG=/path/to/sync_1.jsonl   # skip the picker
+make plot_sync                             # installs plotting deps and offers a gate picker
+make plot_sync LOG=/path/to/sync_1.jsonl   # skip the picker
 ```
 
-`make plot-sync` creates or reuses `./venv` and automatically installs the
+`make plot_sync` creates or reuses `./venv` and automatically installs the
 dependencies in `utils/requirements.txt`. Override discovery or output with
 `PLOT_LOG_DIR=/path/to/logs` and `PLOT_OUT=/path/to/graph.png`.
 

--- a/utils/plot_sync_feedback.sh
+++ b/utils/plot_sync_feedback.sh
@@ -80,6 +80,8 @@ if [ -z "$log" ]; then
 
     if [ "${#logs[@]}" -eq 0 ]; then
         echo "No FlowGuard telemetry logs found in '$log_dir'" >&2
+        echo "Is 'sync_feedback_debug_log' enabled?" >&2
+        echo "Use PLOT_LOG_DIR=<dir> to point make at a non-standard directory." >&2
         exit 1
     elif [ "${#logs[@]}" -eq 1 ]; then
         log="${logs[0]}"
@@ -125,7 +127,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mmu_dir="${script_dir}/../extras/mmu"
 export PYTHONPATH="${mmu_dir}${PYTHONPATH:+:${PYTHONPATH}}"
 
-# make plot-sync supplies the managed venv explicitly. Direct invocations reuse
+# make plot_sync supplies the managed venv explicitly. Direct invocations reuse
 # that venv when present, then fall back to Klipper's environment or PATH.
 if [ -n "${PYTHON:-}" ]; then
     python_bin="$PYTHON"

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,5 +1,5 @@
 # FlowGuard telemetry plotting dependencies. Deliberately separate from the
-# production installer and test harness: `make plot-sync` creates ./venv and
+# production installer and test harness: `make plot_sync` creates ./venv and
 # installs or refreshes these automatically via Makefile's generic stamp rule.
 
 matplotlib


### PR DESCRIPTION
## Summary

- rename the FlowGuard plotting Make target from `plot-sync` to `plot_sync`
- update output-sync handling, `.PHONY`, documentation, and utility comments consistently
- add clearer guidance when no telemetry logs are found

## Verification

- `git diff --check`
- `bash -n utils/plot_sync_feedback.sh`
- `make plot_sync LOG=/tmp/sync_0.jsonl PLOT_OUT=/tmp/plot_sync_rule_test.png ARGS='--show-ticks --x-mm signed'`
- confirmed no stale `plot-sync` references remain in Makefile or `utils/`