### PR TITLE
Console: add startup profile picker

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -205,6 +205,14 @@ simulation:
 make console
 ```
 
+At an interactive terminal this first presents the available simulator profiles; press
+Enter for the default `ercf_vvd`, or choose by number or name. Skip the picker by supplying
+the profile explicitly:
+
+```bash
+make console ARGS='--profile boxturtle'
+```
+
 ```
 > MMU_CHANGE_TOOL TOOL=1
 Tool change requested: T1
@@ -327,8 +335,8 @@ stamped; the rest are indented to line up under it:
 Useful flags — `make console ARGS='...'`:
 
 ```bash
---profile boxturtle            # or tradrack, emu, encoder, nfc_single, nfc_spoolman, ...
-                               # (default is ercf_vvd, a real 2-unit machine)
+--profile boxturtle            # skip the startup picker; or tradrack, emu, encoder, ...
+                               # non-interactive default: ercf_vvd, a real 2-unit machine
 --profile /path/to/config      # your own installed config - see below
 --header machine,sensors,filament,selector,gates,leds   # or 'all' / 'off'
 --inline-header                # reprint above each prompt instead of pinning it

--- a/test/console.py
+++ b/test/console.py
@@ -72,6 +72,7 @@ except Exception:                                   # pragma: no cover - Windows
 # precondition Happy Hare requires before a preload can start (test/README.md section 5).
 TIP_AT_GATE = -40.0
 DEFAULT_TEMP = 220
+DEFAULT_PROFILE = 'ercf_vvd'
 # Gate availability values accepted by MMU_GATE_MAP. These stay local because importing
 # production `extras` before hh_session installs fake Klipper contaminates module resolution.
 GATE_EMPTY = 0
@@ -2388,12 +2389,68 @@ class LogPager:
 ##### Driver #####
 ##################
 
+def choose_startup_profile(entries=None, input_fn=None):
+    """Show the console-ready profiles and return the selected name.
+
+    Kept separate from parse_args so the menu is directly testable without pretending the
+    whole unittest process is a terminal. `entries` accepts Profile-like objects for the
+    same reason; production always reads CONSOLE_PROFILES.
+    """
+    if entries is None:
+        from test.hh.profiles import CONSOLE_PROFILES
+        entries = CONSOLE_PROFILES
+    entries = list(entries)
+    if not entries:
+        return DEFAULT_PROFILE
+
+    # The default is entry 1 even if the registry is later reordered.
+    entries.sort(key=lambda profile: (profile.name != DEFAULT_PROFILE, profile.name))
+    by_name = {profile.name.lower(): profile.name for profile in entries}
+    width = max(len(profile.name) for profile in entries)
+
+    print('Happy Hare simulator profiles')
+    print()
+    for index, profile in enumerate(entries, 1):
+        suffix = ' (default)' if profile.name == DEFAULT_PROFILE else ''
+        print('  %2d  %-*s  %s%s' %
+              (index, width, profile.name, profile.description, suffix))
+    print()
+
+    read = input if input_fn is None else input_fn
+    while True:
+        try:
+            answer = read('Profile [1]: ').strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            raise SystemExit(0)
+        if not answer:
+            return entries[0].name
+        if answer.lower() in ('q', 'quit'):
+            raise SystemExit(0)
+        if answer.isdigit():
+            index = int(answer)
+            if 1 <= index <= len(entries):
+                return entries[index - 1].name
+        elif answer.lower() in by_name:
+            return by_name[answer.lower()]
+        print('Choose 1-%d, enter a profile name, or q to quit.' % len(entries))
+
+
+def select_startup_profile(args):
+    """Apply the picker at the executable boundary, leaving parse_args side-effect free."""
+    if (args.profile_omitted and args.script is None
+            and sys.stdin.isatty() and sys.stdout.isatty()):
+        args.profile = choose_startup_profile()
+    return args
+
+
 def parse_args(argv=None):
     p = argparse.ArgumentParser(
         prog='make console',
         description='Interactive MMU console on the Happy Hare test harness.')
-    p.add_argument('--profile', default='ercf_vvd',
-                   help='harness profile name. Default ercf_vvd is a real 2-unit machine '
+    p.add_argument('--profile', default=None,
+                   help='harness profile name. When omitted at a terminal, choose from a '
+                        'startup list; otherwise ercf_vvd is used. ercf_vvd is a real 2-unit machine '
                         '(ERCF 1.1sb + ViViD 1.0, 13 gates). Others: boxturtle, tradrack, '
                         'emu, encoder, nfc_single, nfc_per_gate, nfc_spoolman, ...')
     p.add_argument('--temp', type=float, default=DEFAULT_TEMP,
@@ -2480,11 +2537,14 @@ def parse_args(argv=None):
         args.header = header_groups(args.header, Console.GROUPS)
     except ValueError as exc:
         p.error(str(exc))
+    args.profile_omitted = args.profile is None
+    if args.profile_omitted:
+        args.profile = DEFAULT_PROFILE
     return args
 
 
 def main(argv=None):
-    args = parse_args(argv)
+    args = select_startup_profile(parse_args(argv))
     console = Console(args)
     if not args.script:
         # boot() builds a whole fake printer and preloads every gate, which is fifteen to

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -358,18 +358,9 @@ ENCODER = BOXTURTLE.derive(
     },
     description='BoxTurtle + encoder, gate_homing_endstop=encoder')
 
-# NOTE on ADC coverage: `emu` brings a proportional sensor with its machine type and
-# `ercf_vvd`'s unit0 enables one explicitly (MMU_HAS_SENSOR_BUFFER_PROPORTIONAL +
-# PIN_BUFFER_ANALOG).
-#
-# The second of those used to be considered unsafe: this note said enabling a proportional
-# buffer outside its intended starter leaves dependent params (analog_max_tension,
-# analog_sensor_threshold) blank and renders a section HH cannot parse. That is no longer
-# true - Kconfig.sync_feedback_buffer:207-252 now defaults every one of them (threshold 0.9,
-# max_compression 1.0, max_tension 0.0, neutral 0.5, gamma 1.0), and ercf_vvd renders and
-# boots with it. The general lesson still holds though, and it is why the claim was worth
-# rechecking rather than inheriting: render the profile and READ the section, do not assume
-# either way. MmuAdcHelper's compat shim is covered directly by test_mmu_adc_compat.py.
+# NOTE on ADC coverage: `emu` brings a proportional sensor with its machine type and is the
+# shipped profile used to exercise that path. MmuAdcHelper's compat shim is covered directly
+# by test_mmu_adc_compat.py.
 # The only MULTI-UNIT profile, and a transcription of a REAL machine rather than a
 # combination assembled to hit features. Two genuinely different units on one printer:
 #
@@ -478,13 +469,6 @@ ERCF_VVD = Profile(
             'PARAM_ENTRY_LEDS': 'neopixel:_unit0_leds (1-9)',
             'PARAM_STATUS_LEDS': 'neopixel:_unit0_leds (10-13)',
             'PARAM_LOGO_LEDS': 'neopixel:_unit0_leds (14-16)',
-            # The analog buffer sensor. Unlike the note further up this file, enabling one
-            # outside EMU is now safe: Kconfig.sync_feedback_buffer:207-252 defaults every
-            # dependent param.
-            'MMU_HAS_SYNC_FEEDBACK_BUFFER': True,
-            'CHOICE_BUFFER_SPRING_STATE_TENSION': True,
-            'MMU_HAS_SENSOR_BUFFER_PROPORTIONAL': True,
-            'PIN_BUFFER_ANALOG': 'PF6',
             'CHOICE_EXTRUDER_HOMING_ENDSTOP_ENCODER': True,
             # A shared PN532 over host serial - the only NFC transport that is not
             # MCU-mediated. Lives on unit0 (generic wiring prompts) rather than unit1: VVD's
@@ -511,6 +495,22 @@ ERCF_VVD = Profile(
         }),
     ],
     description='ERCF 1.1sb (9 gates) + ViViD 1.0 (4 gates) - the only multi-unit profile')
+
+# Synthetic variant for tests that specifically need unit-scoped sync-feedback state on BOTH
+# sides of a unit hand-off. Keep it out of the default console profile: the real ERCF unit0
+# above has no sync-feedback buffer, and adding one makes its filament status line lie.
+ERCF_VVD_BUFFERS = ERCF_VVD.derive(
+    'ercf_vvd_buffers',
+    units=[
+        ERCF_VVD.units[0].derive(syms={
+            'MMU_HAS_SYNC_FEEDBACK_BUFFER': True,
+            'CHOICE_BUFFER_SPRING_STATE_TENSION': True,
+            'MMU_HAS_SENSOR_BUFFER_PROPORTIONAL': True,
+            'PIN_BUFFER_ANALOG': 'PF6',
+        }),
+        ERCF_VVD.units[1],
+    ],
+    description='Synthetic ercf_vvd variant with buffers on both units')
 
 # The only machine whose two units drive DIFFERENT physical extruders. Everything else, including
 # ercf_vvd itself, leaves both on the default one and so shares a single MmuExtruderWrapper - which
@@ -551,13 +551,18 @@ uart_pin: mcu:PB6
 run_current: 0.6
 """
 
-PROFILES = {p.name: p for p in (BOXTURTLE, TRADRACK, CHAMELEON, PICO_MMU, MMX, EMU, ENCODER, NFC_SINGLE,
-                                NFC_PER_GATE, NFC_NEIGHBOR_CHECK, NFC_NEIGHBOR_EVICT,
-                                NFC_PN5180, NFC_PN5180_PER_GATE,
-                                NFC_PN532, NFC_PN532_SW_I2C,
-                                NFC_PN532_UART, NFC_PN532_UART_PER_GATE,
-                                NFC_SPOOLMAN, NFC_SPOOLMAN_SHARED,
-                                ERCF_VVD, ERCF_VVD_DUAL_EXTRUDER)}
+# Profiles that `make console` can boot without extra fixture-only printer sections. This is
+# also the startup picker's source, so its list and the accepted profile objects stay one
+# thing. The buffered and dual-extruder ERCF variants below are registered for tests but are
+# deliberately absent: one is synthetic and the other needs EXTRA_EXTRUDER_STUB.
+CONSOLE_PROFILES = (ERCF_VVD, BOXTURTLE, TRADRACK, CHAMELEON, PICO_MMU, MMX, EMU, ENCODER,
+                    NFC_SINGLE, NFC_PER_GATE, NFC_NEIGHBOR_CHECK, NFC_NEIGHBOR_EVICT,
+                    NFC_PN5180, NFC_PN5180_PER_GATE, NFC_PN532, NFC_PN532_SW_I2C,
+                    NFC_PN532_UART, NFC_PN532_UART_PER_GATE,
+                    NFC_SPOOLMAN, NFC_SPOOLMAN_SHARED)
+
+PROFILES = {p.name: p for p in CONSOLE_PROFILES +
+            (ERCF_VVD_BUFFERS, ERCF_VVD_DUAL_EXTRUDER)}
 
 
 def get(name):

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -21,6 +21,7 @@ import sys
 import tempfile
 import time
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 from test.hh import cfg as cfg_mod
@@ -1418,6 +1419,60 @@ class TestSlicedAdvance(unittest.TestCase):
         console.hh.reactor.advance.assert_not_called()
 
 
+class TestProfilePicker(unittest.TestCase):
+
+    def profiles(self):
+        return [
+            SimpleNamespace(name='zeta', description='Last profile'),
+            SimpleNamespace(name='ercf_vvd', description='Default profile'),
+            SimpleNamespace(name='alpha', description='First profile'),
+        ]
+
+    def choose(self, answers):
+        answers = iter(answers)
+        return console_mod.choose_startup_profile(
+            self.profiles(), input_fn=lambda _prompt: next(answers))
+
+    def test_enter_chooses_the_default(self):
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(self.choose(['']), 'ercf_vvd')
+
+    def test_a_number_or_name_selects_a_profile(self):
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(self.choose(['2']), 'alpha')
+            self.assertEqual(self.choose(['ZETA']), 'zeta')
+
+    def test_invalid_choice_reprompts_with_guidance(self):
+        with contextlib.redirect_stdout(io.StringIO()) as out:
+            self.assertEqual(self.choose(['99', 'alpha']), 'alpha')
+        self.assertIn('Choose 1-3', out.getvalue())
+
+    def test_noninteractive_omission_keeps_the_default(self):
+        with no_tty(), mock.patch.object(console_mod, 'choose_startup_profile') as choose:
+            args = console_mod.select_startup_profile(console_mod.parse_args([]))
+        self.assertEqual(args.profile, 'ercf_vvd')
+        choose.assert_not_called()
+
+    def test_interactive_omission_opens_the_picker(self):
+        with mock.patch.object(sys, 'stdin', FakeTty()), \
+                mock.patch.object(sys, 'stdout', FakeTty()), \
+                mock.patch.object(console_mod, 'choose_startup_profile', return_value='emu') as choose:
+            args = console_mod.select_startup_profile(console_mod.parse_args([]))
+        self.assertEqual(args.profile, 'emu')
+        choose.assert_called_once_with()
+
+    def test_explicit_profile_and_script_skip_the_picker(self):
+        for argv in (['--profile', 'boxturtle'], ['--script', 'commands.txt']):
+            with self.subTest(argv=argv), \
+                    mock.patch.object(sys, 'stdin', FakeTty()), \
+                    mock.patch.object(sys, 'stdout', FakeTty()), \
+                    mock.patch.object(console_mod, 'choose_startup_profile') as choose:
+                args = console_mod.select_startup_profile(console_mod.parse_args(argv))
+            choose.assert_not_called()
+            self.assertEqual(args.profile,
+                             'boxturtle' if '--profile' in argv else 'ercf_vvd')
+
+
 class TestHeaderGroups(unittest.TestCase):
     """
     header_groups() - shared by --header and /header so the two cannot drift. They used to
@@ -1852,6 +1907,20 @@ class TestTheDefaultProfile(unittest.TestCase):
     def test_it_boots_cleanly(self):
         self.assertTrue(self.console.hh.fired('mmu:bootup'))
         self.assertEqual(self.console.hh.errors, [])
+
+    def test_ercf_filament_line_does_not_show_a_sync_feedback_buffer(self):
+        """The default multi-unit fixture must reflect which unit actually owns a buffer."""
+        mmu = self.console.hh.mmu
+        self.assertEqual(mmu.mmu_unit(0).name, 'unit0')
+        self.assertFalse(mmu.mmu_unit(0).has_buffer(), 'ERCF fixture gained a phantom buffer')
+        mmu.gate_selected = 0
+        ercf_line = mmu.get_filament_position_string()
+        self.assertNotIn(' [   ] ', ercf_line)
+
+        self.assertTrue(mmu.mmu_unit(9).has_buffer(), 'ViViD fixture lost its real buffer')
+        mmu.gate_selected = 9
+        vivid_line = mmu.get_filament_position_string()
+        self.assertIn(' [   ] ', vivid_line)
 
     def test_it_moves_filament_on_the_last_gate(self):
         """

--- a/test/test_mmu_dev_test.py
+++ b/test/test_mmu_dev_test.py
@@ -34,10 +34,10 @@
 #   RUN_SEQUENCE,       Run, but every timing is 0.0 because macro bodies never execute.
 #   RUN_CHANGE_SEQUENCE
 #
-# PINNED TO THE DEFAULT PROFILE. ercf_vvd is the only shipped profile with a toolhead sensor
-# (profiles.py:351), and the movement probes default to ENDSTOP=toolhead with no way to
-# redirect some of them. It also has two units, an encoder and a buffer, so every option has
-# the hardware it needs.
+# PINNED TO THE BUFFERED MULTI-UNIT TEST PROFILE. ercf_vvd is the only shipped profile with a
+# toolhead sensor, and the movement probes default to ENDSTOP=toolhead with no way to redirect
+# some of them. The synthetic variant adds a buffer to its ERCF unit so every option has the
+# hardware it needs without making the default console claim that the real ERCF owns one.
 #
 #   ./venv/bin/python -m unittest test.test_mmu_dev_test
 #
@@ -60,7 +60,7 @@ class DevTestCase(unittest.TestCase):
     would read.
     """
 
-    PROFILE = 'ercf_vvd'
+    PROFILE = 'ercf_vvd_buffers'
 
     def setUp(self):
         self.hh = session(self.PROFILE)

--- a/test/test_mmu_sensor_enable.py
+++ b/test/test_mmu_sensor_enable.py
@@ -139,7 +139,7 @@ class SensorEnableMultiUnitTestCase(unittest.TestCase):
     """ercf_vvd: a bare name that collides across units, and the no-cascading guarantee."""
 
     def setUp(self):
-        self.hh = session('ercf_vvd')
+        self.hh = session('ercf_vvd_buffers')
         self.hh.boot()
         self.assertEqual(self.hh.errors, [], 'bootup was not clean')
 

--- a/test/test_mmu_sensor_runout.py
+++ b/test/test_mmu_sensor_runout.py
@@ -221,10 +221,10 @@ class TestRunoutArming(RunoutFilterTestCase):
 
 
 class TestRunoutArmingAcrossUnits(unittest.TestCase):
-    """ercf_vvd is the only multi-unit profile - ERCF (gates 0-8) plus ViViD (gates 9-12)."""
+    """Use the synthetic two-buffer variant to exercise both sides of the hand-off."""
 
     def setUp(self):
-        self.hh = session('ercf_vvd')
+        self.hh = session('ercf_vvd_buffers')
         self.hh.boot(calibrate=True)
         self.mmu = self.hh.mmu
 


### PR DESCRIPTION
## Summary
- show an interactive list of console-ready simulator profiles when --profile is omitted
- preserve deterministic ercf_vvd fallback for scripts, pipes, and explicit profile startup
- remove the artificial sync-feedback buffer from the default ERCF fixture and move two-buffer coverage to a synthetic test profile
- document the picker and add regression coverage

## Testing
- make ALL=1 test (1115 tests passed; 1 skipped; 4 expected failures)
- python -m unittest -q test.test_mmu_console (191 tests passed)