### PR TITLE
Stabilize tests on live Klipper hosts

### DIFF
--- a/test/test_mmu_config.py
+++ b/test/test_mmu_config.py
@@ -454,6 +454,11 @@ config PARAM_DEVICE
         }
         emu_syms = dict(profiles.get('emu').syms)
         emu_syms['CHOICE_MMU_CONNECTION_TYPE_SERIAL'] = True
+        # Select the saved entries explicitly.  Board Kconfigs can prefer a currently
+        # discovered MCU, and letting /dev/serial/by-id leak into this fixture makes the
+        # result depend on whether the test happens to run on a live printer.
+        for gate in range(5):
+            emu_syms['CHOICE_MMU_SERIAL_DEVICE_PREVIOUS_%d' % gate] = True
         with cfg._env(env):
             kc = cfg._kconfig('previous-connection-selections', emu_syms)
 
@@ -480,6 +485,7 @@ config PARAM_DEVICE
         }
         buffer_syms = dict(vvd.syms)
         buffer_syms['CHOICE_BUFFER_CONNECTION_TYPE_SERIAL'] = True
+        buffer_syms['CHOICE_BUFFER_SERIAL_DEVICE_PREVIOUS'] = True
         with cfg._env(buffer_env):
             kc = cfg._kconfig('previous-buffer-selection', buffer_syms)
 
@@ -502,6 +508,7 @@ config PARAM_DEVICE
         })
         base_syms = dict(profiles.get('boxturtle').syms)
         base_syms['CHOICE_MMU_CONNECTION_TYPE_CANBUS'] = True
+        base_syms['CHOICE_MMU_CANBUS_UUID_PREVIOUS'] = True
         with cfg._env(base_env):
             kc = cfg._kconfig('previous-base-canbus-selection', base_syms)
 

--- a/test/test_mmu_import.py
+++ b/test/test_mmu_import.py
@@ -209,6 +209,9 @@ class TestMmuMachineImportGuard(unittest.TestCase):
     def _restore_symlink_and_reimport(self):
         if not os.path.exists(self.victim):
             os.symlink(self.victim_target, self.victim)
+        # FileFinder caches directory contents.  A fast unlink/recreate can leave the
+        # negative lookup cached on filesystems whose directory timestamp did not tick.
+        importlib.invalidate_caches()
         self._evict_from_module_cache()
         # Leave the shared, process-wide overlay/module cache healthy for every test
         # that runs after this one, regardless of suite ordering.
@@ -222,6 +225,7 @@ class TestMmuMachineImportGuard(unittest.TestCase):
         restoring it and the shared module cache once the test is done."""
         self.addCleanup(self._restore_symlink_and_reimport)
         os.unlink(self.victim)
+        importlib.invalidate_caches()
         self._evict_from_module_cache()
         mod = importlib.import_module('extras.mmu_machine')
         self.assertIsNotNone(mod._IMPORT_ERROR,


### PR DESCRIPTION
## Summary

- explicitly select saved connection entries in the Kconfig fixture so attached /dev/serial/by-id hardware cannot change the result
- invalidate importlib caches when the fake Klipper overlay removes or restores mmu_unit.py
- keep production behavior unchanged

## Test plan

- ./venv/bin/python -m unittest -v test.test_mmu_config test.test_mmu_import
- 37 tests passed