### PR TITLE
Discover CAN UUIDs across available interfaces

### DIFF
--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -84,7 +84,7 @@
 serial                   : [[ (PARAM_MMU_SERIAL_DEVICE_|d)[i] ]]
 [% elif CHOICE_MMU_CONNECTION_TYPE_CANBUS %]
 canbus_uuid              : [[ (PARAM_MMU_CANBUS_UUID_|d)[i] ]]
-canbus_interface         : can0
+canbus_interface         : [[ (PARAM_MMU_CANBUS_INTERFACE_|d)[i] ]]
 [% else %]
 #serial:
 #canbus_uuid:
@@ -98,6 +98,7 @@ canbus_interface         : can0
 serial                   : [[PARAM_MMU_SERIAL_DEVICE]]
 [% elif CHOICE_MMU_CONNECTION_TYPE_CANBUS %]
 canbus_uuid              : [[PARAM_MMU_CANBUS_UUID]]
+canbus_interface         : [[PARAM_MMU_CANBUS_INTERFACE]]
 [% else %]
 #serial:
 #canbus_uuid:
@@ -110,6 +111,7 @@ canbus_uuid              : [[PARAM_MMU_CANBUS_UUID]]
 serial                   : [[PARAM_BUFFER_SERIAL_DEVICE]]
 [% elif CHOICE_BUFFER_CONNECTION_TYPE_CANBUS %]
 canbus_uuid              : [[PARAM_BUFFER_CANBUS_UUID]]
+canbus_interface         : [[PARAM_BUFFER_CANBUS_INTERFACE]]
 [% else %]
 #serial:
 #canbus_uuid:

--- a/installer/Kconfig
+++ b/installer/Kconfig
@@ -127,14 +127,20 @@ mmu_serial_config    = $(shell, basename '$(serial_device,$(1),$(2))' | sed 's/-
 mmu_serial_config_pg = $(shell, basename '$(serial_device,$(2),$(3))' | sed 's/-/_/g' | awk -v gate=$(1) 'BEGIN{out="CHOICE_MMU_SERIAL_DEVICE_NONE_GATE_" gate } NF && $$0!="." {out="CHOICE_MMU_SERIAL_DEVICE_" toupper($$0) "_GATE_" gate} END{print out}')
 buffer_serial_config = $(shell, basename '$(serial_device,$(1),$(2))' | sed 's/-/_/g' | awk 'BEGIN{out="CHOICE_BUFFER_SERIAL_DEVICE_NONE"} NF && $$0!="." {out="CHOICE_BUFFER_SERIAL_DEVICE_" toupper($$0)} END{print out}')
 
-# Grab the UUIDs that are not in use by klipper as a space-separated list, e.g. "43a8... 25ff... aab3..."
-canbus_query        := $(shell, echo "$(KLIPPER_HOME)/../klippy-env/bin/python $(KLIPPER_HOME)/scripts/canbus_query.py can0")
-canbus_uuids        := $(shell, $(canbus_query) 2>/dev/null | sed -n 's/.*canbus_uuid=\([0-9a-fA-F][0-9a-fA-F]*\).*/\1/p')
-canbus_uuid_count   := $(count, $(canbus_uuids))
-canbus_uuid          = $(shell, echo $(canbus_uuids) | awk -v n=$(1) '{ print $n }')
-mmu_canbus_config    = $(shell, echo $(canbus_uuid,$(1)) | awk 'BEGIN{out="CHOICE_MMU_CANBUS_UUID_NONE"} NF {out="CHOICE_MMU_CANBUS_UUID_" toupper($$0)} END{print out}')
-mmu_canbus_config_pg = $(shell, echo $(canbus_uuid,$(2)) | awk -v gate=$(1) 'BEGIN{out="CHOICE_MMU_CANBUS_UUID_NONE_GATE_" gate} NF {out="CHOICE_MMU_CANBUS_UUID_" toupper($$0) "_GATE_" gate} END{print out}')
-buffer_canbus_config = $(shell, echo $(canbus_uuid,$(1)) | awk 'BEGIN{out="CHOICE_BUFFER_CANBUS_UUID_NONE"} NF {out="CHOICE_BUFFER_CANBUS_UUID_" toupper($$0)} END{print out}')
+# Grab UUIDs that are not in use by Klipper from all available CAN interfaces.
+# Keep each interface attached to its UUID, e.g. "can0:43a8... vlan1:25ff...".
+canbus_query        := $(shell, echo "$(KLIPPER_HOME)/../klippy-env/bin/python $(KLIPPER_HOME)/scripts/canbus_query.py")
+canbus_interfaces   := $(shell, (ip -o link show type can | awk -F': ' '{print $2}') 2>/dev/null || true)
+canbus_connections  := $(shell, (for interface in $(canbus_interfaces); do $(canbus_query) "$interface" | sed -n 's/.*canbus_uuid=\([0-9a-fA-F][0-9a-fA-F]*\).*/\1/p' | while IFS= read -r uuid; do printf '%s:%s\n' "$interface" "$uuid"; done; done) 2>/dev/null || true)
+canbus_uuid_count   := $(count, $(canbus_connections))
+canbus_connection    = $(shell, echo $(canbus_connections) | awk -v n=$(1) '{ print $n }')
+canbus_interface     = $(shell, echo $(canbus_connection,$(1)) | cut -d: -f1)
+canbus_uuid          = $(shell, echo $(canbus_connection,$(1)) | cut -d: -f2)
+saved_canbus_interface = $(shell, [ -n '$(saved-config-value,$(1))' ] && echo '$(saved-config-value,$(1))' || echo can0)
+saved_canbus_connection = $(saved_canbus_interface,$(1)):$(saved-config-value,$(2))
+mmu_canbus_config    = $(shell, echo $(canbus_connection,$(1)) | tr ':a-z' '_A-Z' | sed 's/[^A-Z0-9_]/_/g' | awk 'BEGIN{out="CHOICE_MMU_CANBUS_UUID_NONE"} NF {out="CHOICE_MMU_CANBUS_UUID_" $0} END{print out}')
+mmu_canbus_config_pg = $(shell, echo $(canbus_connection,$(2)) | tr ':a-z' '_A-Z' | sed 's/[^A-Z0-9_]/_/g' | awk -v gate=$(1) 'BEGIN{out="CHOICE_MMU_CANBUS_UUID_NONE_GATE_" gate} NF {out="CHOICE_MMU_CANBUS_UUID_" $0 "_GATE_" gate} END{print out}')
+buffer_canbus_config = $(shell, echo $(canbus_connection,$(1)) | tr ':a-z' '_A-Z' | sed 's/[^A-Z0-9_]/_/g' | awk 'BEGIN{out="CHOICE_BUFFER_CANBUS_UUID_NONE"} NF {out="CHOICE_BUFFER_CANBUS_UUID_" $0} END{print out}')
 
 # Used for comment padding
 pad = $(shell, printf "%-$(1)s" "$(2)")

--- a/installer/connection/Kconfig.buffer_mcu
+++ b/installer/connection/Kconfig.buffer_mcu
@@ -6,6 +6,7 @@
 #   CHOICE_BUFFER_CONNECTION_TYPE_CANBUS
 #   PARAM_BUFFER_SERIAL_DEVICE
 #   PARAM_BUFFER_CANBUS_UUID
+#   PARAM_BUFFER_CANBUS_INTERFACE
 
 choice CHOICE_BUFFER_CONNECTION_TYPE
   prompt "MCU connection for sync-feedback buffer"
@@ -91,12 +92,12 @@ if CHOICE_BUFFER_CONNECTION_TYPE_CANBUS
       "Other" and enter it manually.
 
     config CHOICE_BUFFER_CANBUS_UUID_PREVIOUS
-      bool "Previous selection: $(saved-config-value,PARAM_BUFFER_CANBUS_UUID)"
+      bool "Previous selection: $(saved_canbus_connection,PARAM_BUFFER_CANBUS_INTERFACE,PARAM_BUFFER_CANBUS_UUID)"
       depends on "$(saved-config-value,PARAM_BUFFER_CANBUS_UUID)" != ""
 
     @repeat var=i min=1 max=10@
     config $(buffer_canbus_config,$(i))
-      bool "$(canbus_uuid,$(i))"
+      bool "$(canbus_connection,$(i))"
       depends on $(canbus_uuid_count) >= $(i)
     @endrepeat@
 
@@ -110,9 +111,12 @@ if CHOICE_BUFFER_CONNECTION_TYPE_CANBUS
           Specify the CANbus UUID that is used for connection to the sync-feedback buffer
           It is a 6 byte ID represented in hex.
           This can be found with:
-            ~/klipper/klippy-env/bin/python ~/klipper/klipper/scripts/canbus_query.py can0
+            ~/klipper/klippy-env/bin/python ~/klipper/klipper/scripts/canbus_query.py <interface>
           Enter only the uuid portion (12 hex digits)
             E.g. 127081e7e3c6
+      config BUFFER_CANBUS_INTERFACE_OTHER
+        string "Enter CANbus interface"
+        default "can0"
     endif
   endchoice
 
@@ -123,5 +127,13 @@ if CHOICE_BUFFER_CONNECTION_TYPE_CANBUS
     default "$(canbus_uuid,$(i))" if $(buffer_canbus_config,$(i))
     @endrepeat@
     default BUFFER_CANBUS_UUID_OTHER if CHOICE_BUFFER_CANBUS_UUID_OTHER
+
+  config PARAM_BUFFER_CANBUS_INTERFACE
+    string
+    default "$(saved_canbus_interface,PARAM_BUFFER_CANBUS_INTERFACE)" if CHOICE_BUFFER_CANBUS_UUID_PREVIOUS
+    @repeat var=i min=1 max=10@
+    default "$(canbus_interface,$(i))" if $(buffer_canbus_config,$(i))
+    @endrepeat@
+    default BUFFER_CANBUS_INTERFACE_OTHER if CHOICE_BUFFER_CANBUS_UUID_OTHER
 
 endif

--- a/installer/connection/Kconfig.mmu_mcu
+++ b/installer/connection/Kconfig.mmu_mcu
@@ -6,12 +6,14 @@
 #   CHOICE_MMU_CONNECTION_TYPE_CANBUS
 #   PARAM_MMU_SERIAL_DEVICE
 #   PARAM_MMU_CANBUS_UUID
+#   PARAM_MMU_CANBUS_INTERFACE
 #
 # If F_PER_GATE_MCU (EMU design) the special inclusion macro
 # will include the extra Kconfig logic. This is relatively expensive
 # so it is not normally included. Additional params will be set:
 #   PARAM_MMU_SERIAL_DEVICE_<gate>
 #   PARAM_MMU_CANBUS_UUID_<gate>
+#   PARAM_MMU_CANBUS_INTERFACE_<gate>
 
 
 choice CHOICE_MMU_CONNECTION_TYPE
@@ -86,12 +88,12 @@ if !MMU_HAS_PER_GATE_MCU
       default CHOICE_MMU_CANBUS_UUID_OTHER if $(canbus_uuid_count) = 0
 
       config CHOICE_MMU_CANBUS_UUID_PREVIOUS
-        bool "Previous selection: $(saved-config-value,PARAM_MMU_CANBUS_UUID)"
+        bool "Previous selection: $(saved_canbus_connection,PARAM_MMU_CANBUS_INTERFACE,PARAM_MMU_CANBUS_UUID)"
         depends on "$(saved-config-value,PARAM_MMU_CANBUS_UUID)" != ""
 
       @repeat var=i min=1 max=10@
       config $(mmu_canbus_config,$(i))
-        bool "$(canbus_uuid,$(i))"
+        bool "$(canbus_connection,$(i))"
         depends on $(canbus_uuid_count) >= $(i)
       @endrepeat@
 
@@ -102,6 +104,9 @@ if !MMU_HAS_PER_GATE_MCU
         config MMU_CANBUS_UUID_OTHER
           string "Enter CANbus uuid"
           default "-enter-canbus-id-"
+        config MMU_CANBUS_INTERFACE_OTHER
+          string "Enter CANbus interface"
+          default "can0"
       endif
     endchoice
 
@@ -112,6 +117,14 @@ if !MMU_HAS_PER_GATE_MCU
       default "$(canbus_uuid,$(i))" if $(mmu_canbus_config,$(i))
       @endrepeat@
       default MMU_CANBUS_UUID_OTHER if CHOICE_MMU_CANBUS_UUID_OTHER
+
+    config PARAM_MMU_CANBUS_INTERFACE
+      string
+      default "$(saved_canbus_interface,PARAM_MMU_CANBUS_INTERFACE)" if CHOICE_MMU_CANBUS_UUID_PREVIOUS
+      @repeat var=i min=1 max=10@
+      default "$(canbus_interface,$(i))" if $(mmu_canbus_config,$(i))
+      @endrepeat@
+      default MMU_CANBUS_INTERFACE_OTHER if CHOICE_MMU_CANBUS_UUID_OTHER
 
   endif
 
@@ -175,12 +188,12 @@ if MMU_HAS_PER_GATE_MCU
         default CHOICE_MMU_CANBUS_UUID_OTHER_$(gate) if $(canbus_uuid_count) = 0
 
         config CHOICE_MMU_CANBUS_UUID_PREVIOUS_$(gate)
-          bool "Previous selection: $(saved-config-value,PARAM_MMU_CANBUS_UUID_$(gate))"
+          bool "Previous selection: $(saved_canbus_connection,PARAM_MMU_CANBUS_INTERFACE_$(gate),PARAM_MMU_CANBUS_UUID_$(gate))"
           depends on "$(saved-config-value,PARAM_MMU_CANBUS_UUID_$(gate))" != ""
 
         @repeat var=i min=1 max=10@
         config CHOICE_MMU_CANBUS_UUID_$(gate)_$(i)
-          bool "$(canbus_uuid,$(i))"
+          bool "$(canbus_connection,$(i))"
           depends on $(canbus_uuid_count) >= $(i)
         @endrepeat@
 
@@ -191,6 +204,9 @@ if MMU_HAS_PER_GATE_MCU
           config MMU_CANBUS_UUID_OTHER_$(gate)
             string "Enter CANbus uuid"
             default "-enter-canbus-id-"
+          config MMU_CANBUS_INTERFACE_OTHER_$(gate)
+            string "Enter CANbus interface"
+            default "can0"
         endif
       endchoice
 
@@ -201,6 +217,14 @@ if MMU_HAS_PER_GATE_MCU
         default "$(canbus_uuid,$(i))" if CHOICE_MMU_CANBUS_UUID_$(gate)_$(i)
         @endrepeat@
         default MMU_CANBUS_UUID_OTHER_$(gate) if CHOICE_MMU_CANBUS_UUID_OTHER_$(gate)
+
+      config PARAM_MMU_CANBUS_INTERFACE_$(gate)
+        string
+        default "$(saved_canbus_interface,PARAM_MMU_CANBUS_INTERFACE_$(gate))" if CHOICE_MMU_CANBUS_UUID_PREVIOUS_$(gate)
+        @repeat var=i min=1 max=10@
+        default "$(canbus_interface,$(i))" if CHOICE_MMU_CANBUS_UUID_$(gate)_$(i)
+        @endrepeat@
+        default MMU_CANBUS_INTERFACE_OTHER_$(gate) if CHOICE_MMU_CANBUS_UUID_OTHER_$(gate)
 
     endif
 

--- a/test/test_mmu_config.py
+++ b/test/test_mmu_config.py
@@ -427,18 +427,98 @@ config PARAM_DEVICE
                          'DEVICE_OTHER')
         self.assertEqual(kc.syms['PARAM_DEVICE'].str_value, '/dev/other')
 
+    def test_canbus_discovery_aggregates_interfaces_and_splits_selection(self):
+        klipper_home = os.path.join(self.tmpdir.name, 'klipper')
+        python_path = os.path.join(self.tmpdir.name, 'klippy-env', 'bin', 'python')
+        mock_bin = os.path.join(self.tmpdir.name, 'bin')
+        os.makedirs(os.path.dirname(python_path))
+        os.makedirs(mock_bin)
+        os.makedirs(os.path.join(klipper_home, 'scripts'))
+        ip_path = os.path.join(mock_bin, 'ip')
+        with open(ip_path, 'w') as f:
+            f.write('''#!/bin/sh
+echo "2: can0: <NOARP,UP> mtu 16 qdisc pfifo_fast state UNKNOWN mode DEFAULT group default"
+echo "3: vlan-1: <NOARP,UP> mtu 16 qdisc pfifo_fast state UNKNOWN mode DEFAULT group default"
+echo "4: can1: <NOARP,UP> mtu 16 qdisc pfifo_fast state UNKNOWN mode DEFAULT group default"
+''')
+        os.chmod(ip_path, 0o755)
+        with open(python_path, 'w') as f:
+            f.write('''#!/bin/sh
+case "$2" in
+  can0) echo "Found canbus_uuid=aaa111aaa111" ;;
+  vlan-1) echo "Found canbus_uuid=bbb222bbb222" ;;
+  can1) echo "Found canbus_uuid=ccc333ccc333" ;;
+esac
+''')
+        os.chmod(python_path, 0o755)
+
+        syms = dict(profiles.get('boxturtle').syms)
+        syms['CHOICE_MMU_CONNECTION_TYPE_SERIAL'] = False
+        syms['CHOICE_MMU_CONNECTION_TYPE_CANBUS'] = True
+        with cfg._env({'KLIPPER_HOME': klipper_home,
+                       'PATH': mock_bin + os.pathsep + os.environ['PATH']}):
+            kc = cfg._kconfig('multi-interface-canbus-discovery', syms)
+
+        choice = kc.named_choices['CHOICE_MMU_CANBUS_CONNECTION']
+        prompts = [node.prompt[0] for symbol in choice.syms
+                   for node in symbol.nodes if node.prompt]
+        self.assertIn('can0:aaa111aaa111', prompts)
+        self.assertIn('vlan-1:bbb222bbb222', prompts)
+        self.assertIn('can1:ccc333ccc333', prompts)
+
+        kc.syms['CHOICE_MMU_CANBUS_UUID_VLAN_1_BBB222BBB222'].set_value(2)
+        self.assertEqual(kc.syms['PARAM_MMU_CANBUS_UUID'].str_value,
+                         'bbb222bbb222')
+        self.assertEqual(kc.syms['PARAM_MMU_CANBUS_INTERFACE'].str_value,
+                         'vlan-1')
+
+    def test_failed_canbus_queries_produce_no_discovered_choices(self):
+        klipper_home = os.path.join(self.tmpdir.name, 'klipper')
+        python_path = os.path.join(self.tmpdir.name, 'klippy-env', 'bin', 'python')
+        mock_bin = os.path.join(self.tmpdir.name, 'bin')
+        os.makedirs(os.path.dirname(python_path))
+        os.makedirs(mock_bin)
+        os.makedirs(os.path.join(klipper_home, 'scripts'))
+
+        ip_path = os.path.join(mock_bin, 'ip')
+        with open(ip_path, 'w') as f:
+            f.write('#!/bin/sh\necho "2: vlan1: <NOARP,UP> mtu 16"\n')
+        os.chmod(ip_path, 0o755)
+        with open(python_path, 'w') as f:
+            f.write('#!/bin/sh\necho "CAN query failed" >&2\nexit 1\n')
+        os.chmod(python_path, 0o755)
+
+        syms = dict(profiles.get('boxturtle').syms)
+        syms['CHOICE_MMU_CONNECTION_TYPE_SERIAL'] = False
+        syms['CHOICE_MMU_CONNECTION_TYPE_CANBUS'] = True
+        with cfg._env({'KLIPPER_HOME': klipper_home,
+                       'PATH': mock_bin + os.pathsep + os.environ['PATH']}):
+            kc = cfg._kconfig('failed-canbus-query', syms)
+
+        choice = kc.named_choices['CHOICE_MMU_CANBUS_CONNECTION']
+        discovered = [node.prompt[0] for symbol in choice.syms
+                      for node in symbol.nodes
+                      if node.prompt and ':' in node.prompt[0]
+                      and not node.prompt[0].startswith('Previous selection:')]
+        self.assertEqual(discovered, [])
+        self.assertEqual(choice.selection.name,
+                         'CHOICE_MMU_CANBUS_UUID_OTHER')
+
     def test_all_real_connection_choices_expose_their_previous_values(self):
         values = {
             'PARAM_MMU_SERIAL_DEVICE': '/dev/previous-main',
             'PARAM_MMU_CANBUS_UUID': 'abc123def456',
             'PARAM_BUFFER_SERIAL_DEVICE': '/dev/previous-buffer',
             'PARAM_BUFFER_CANBUS_UUID': 'def456abc123',
+            'PARAM_BUFFER_CANBUS_INTERFACE': 'can2',
         }
         for gate in range(5):
             values['PARAM_MMU_SERIAL_DEVICE_%d' % gate] = \
                 '/dev/previous-gate-%d' % gate
             values['PARAM_MMU_CANBUS_UUID_%d' % gate] = \
                 'abc123def4%02d' % gate
+            values['PARAM_MMU_CANBUS_INTERFACE_%d' % gate] = \
+                'can%d' % (gate % 3)
         with open(self.config_path, 'w') as f:
             for name, value in values.items():
                 f.write('CONFIG_%s="%s" #~DEFAULT~#\n' % (name, value))
@@ -465,8 +545,22 @@ config PARAM_DEVICE
             self.assertEqual(kc.syms[name].str_value, values[name])
             canbus = kc.syms['CHOICE_MMU_CANBUS_UUID_PREVIOUS_%d' % gate]
             self.assertEqual(canbus.nodes[0].prompt[0],
-                             'Previous selection: %s' %
-                             values['PARAM_MMU_CANBUS_UUID_%d' % gate])
+                             'Previous selection: %s:%s' % (
+                                 values['PARAM_MMU_CANBUS_INTERFACE_%d' % gate],
+                                 values['PARAM_MMU_CANBUS_UUID_%d' % gate]))
+
+        emu_canbus_syms = dict(profiles.get('emu').syms)
+        emu_canbus_syms['CHOICE_MMU_CONNECTION_TYPE_SERIAL'] = False
+        emu_canbus_syms['CHOICE_MMU_CONNECTION_TYPE_CANBUS'] = True
+        with cfg._env(env):
+            kc = cfg._kconfig('previous-canbus-gate-selections',
+                              emu_canbus_syms)
+        for gate in range(5):
+            choice = kc.named_choices['CHOICE_MMU_CANBUS_CONNECTION_%d' % gate]
+            self.assertEqual(choice.selection.name,
+                             'CHOICE_MMU_CANBUS_UUID_PREVIOUS_%d' % gate)
+            interface = 'PARAM_MMU_CANBUS_INTERFACE_%d' % gate
+            self.assertEqual(kc.syms[interface].str_value, values[interface])
 
         vvd = profiles.get('ercf_vvd').units[1]
         buffer_env = {
@@ -490,8 +584,18 @@ config PARAM_DEVICE
                          values['PARAM_BUFFER_SERIAL_DEVICE'])
         buffer_canbus = kc.syms['CHOICE_BUFFER_CANBUS_UUID_PREVIOUS']
         self.assertEqual(buffer_canbus.nodes[0].prompt[0],
-                         'Previous selection: %s' %
-                         values['PARAM_BUFFER_CANBUS_UUID'])
+                         'Previous selection: %s:%s' % (
+                             values['PARAM_BUFFER_CANBUS_INTERFACE'],
+                             values['PARAM_BUFFER_CANBUS_UUID']))
+
+        buffer_canbus_syms = dict(vvd.syms)
+        buffer_canbus_syms['CHOICE_BUFFER_CONNECTION_TYPE_SERIAL'] = False
+        buffer_canbus_syms['CHOICE_BUFFER_CONNECTION_TYPE_CANBUS'] = True
+        with cfg._env(buffer_env):
+            kc = cfg._kconfig('previous-buffer-canbus-selection',
+                              buffer_canbus_syms)
+        self.assertEqual(kc.syms['PARAM_BUFFER_CANBUS_INTERFACE'].str_value,
+                         values['PARAM_BUFFER_CANBUS_INTERFACE'])
 
         base_env = dict(buffer_env)
         base_env.update({
@@ -509,6 +613,11 @@ config PARAM_DEVICE
         self.assertEqual(base_choice.selection.name,
                          'CHOICE_MMU_CANBUS_UUID_PREVIOUS')
         self.assertEqual(kc.syms['PARAM_MMU_CANBUS_UUID'].str_value,
+                         values['PARAM_MMU_CANBUS_UUID'])
+        self.assertEqual(kc.syms['PARAM_MMU_CANBUS_INTERFACE'].str_value,
+                         'can0')
+        self.assertEqual(base_choice.selection.nodes[0].prompt[0],
+                         'Previous selection: can0:%s' %
                          values['PARAM_MMU_CANBUS_UUID'])
         base_serial = kc.syms['CHOICE_MMU_SERIAL_DEVICE_PREVIOUS']
         self.assertEqual(base_serial.nodes[0].prompt[0],


### PR DESCRIPTION
## Summary
- discover CAN interfaces dynamically from `ip -o link show type can`
- present discovered devices as `interface:uuid` and persist both values
- apply interface selection to main, buffer, and per-gate MCUs
- handle interface/query failures without disrupting Kconfig
- preserve legacy CAN selections with a `can0` fallback

## Testing
- `./venv/bin/python -m unittest -q test.test_mmu_config`
- 27 tests passed