### PR TITLE
Fix self-update for branches without upstream tracking

### DIFF
--- a/installer/self_update.sh
+++ b/installer/self_update.sh
@@ -49,6 +49,10 @@ self_update() {
 
     if [ "${switch}" -eq 1 ]; then
         git checkout "${current_branch}" --quiet
+        # A branch selected with -b may already exist locally without an upstream.
+        # Point it at the remote branch explicitly so this and future pulls do not
+        # depend on how the local branch was originally created.
+        git branch --quiet --set-upstream-to="origin/${current_branch}" "${current_branch}"
         git pull --quiet --force
         git_version=$(git describe --tags)
         echo "${C_NOTICE}Now on git version: ${git_version}${C_OFF}"


### PR DESCRIPTION
## Summary

- configure the checked-out update branch to track its matching origin branch
- allow installer invocations with `-b` to update local branches created without upstream tracking
- preserve the existing pull and self-update behavior

## Verification

- reproduced with an isolated local Git remote and a local feature branch without an upstream
- verified initial update and a subsequent remote update both succeed
- `sh -n installer/self_update.sh`
- `git diff --check`