### PR TITLE
NFC neighbor arbitration: escalate ratification to a deliberate self-jog

### DIFF
--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -551,15 +551,19 @@ nfc_preload_jog_scan_window : [[PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW]]
 nfc_neighbor_check          : [[PARAM_NFC_NEIGHBOR_CHECK]]
 
 # Reads per "is anything in this reader's field?" probe. Used by nfc_neighbor_check/_evict_distance
-# and nfc_self_verify_distance.
+# and nfc_gate_clear_distance/nfc_preload_clear_distance.
 nfc_field_probe_reads       : [[PARAM_NFC_FIELD_PROBE_READS]]
 
 # Also jog a neighbor's filament aside to clear its tag from this gate's field. Signed mm, 0=off (default).
 nfc_neighbor_evict_distance : [[PARAM_NFC_NEIGHBOR_EVICT_DISTANCE]]
 
-# Independent of the above: jog THIS gate's own filament further off park to confirm an
-# unconfirmed tag before discarding it. Signed mm, 0=off (default).
-nfc_self_verify_distance    : [[PARAM_NFC_SELF_VERIFY_DISTANCE]]
+# Independent of the above and of each other: jog THIS gate's own filament further off park to
+# confirm an unconfirmed tag before discarding it, during MMU_NFC_SCAN. Signed mm, 0=off (default).
+nfc_gate_clear_distance     : [[PARAM_NFC_GATE_CLEAR_DISTANCE]]
+
+# As above, but during MMU_PRELOAD - can differ (including in sign) since preload may home/park
+# via a different endstop. Defaults to nfc_gate_clear_distance.
+nfc_preload_clear_distance  : [[PARAM_NFC_PRELOAD_CLEAR_DISTANCE]]
 
 # NFC reader LED feedback segment. '' = auto.
 nfc_led_segment             : [[PARAM_NFC_LED_SEGMENT]]

--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -538,29 +538,27 @@ heater_rotate_interval      : [[PARAM_HEATER_ROTATE_INTERVAL]]			# Interval in m
 # ██║ ╚████║██║     ╚██████╗    ██║  ██║███████╗██║  ██║██████╔╝███████╗██║  ██║
 # ╚═╝  ╚═══╝╚═╝      ╚═════╝    ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═════╝ ╚══════╝╚═╝  ╚═╝
 #
-# NFC / RFID tag reading. See menuconfig ("NFC/RFID params") for full details of each option.
+# NFC / RFID tag reading.
+
+# Whether to attempt deep tag read for metadata equipped tags
 nfc_deep_read               : [[PARAM_NFC_DEEP_READ]]
 
-# Jog search range (mm) from the homing datum for the RFID tag. "0, 0" disables jog scanning.
-nfc_gate_jog_scan_window    : [[PARAM_NFC_GATE_JOG_SCAN_WINDOW]]
-
-# As above (datum-relative), for MMU_PRELOAD's scan. Defaults to nfc_gate_jog_scan_window.
-nfc_preload_jog_scan_window : [[PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW]]
+# Jog search range (-ve, +ve) in mm relative to the homing point. "0, 0" disables jog scanning.
+nfc_gate_jog_scan_window    : [[PARAM_NFC_GATE_JOG_SCAN_WINDOW]]			# For MMU_NFC_SCAN
+nfc_preload_jog_scan_window : [[PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW]]			# For MMU_PRELOAD
 
 # Refuse (rather than misattribute) a tag identified as a neighboring gate's own. 0=off (default).
 nfc_neighbor_check          : [[PARAM_NFC_NEIGHBOR_CHECK]]
 
-# Reads per reader-field probe. Used by nfc_neighbor_check/_evict_distance and the clear distances.
+# Reads per reader-field probe - used by nfc_neighbor_check/_evict_distance and the clear distances. Default 3.
 nfc_field_probe_reads       : [[PARAM_NFC_FIELD_PROBE_READS]]
 
 # Jog a neighbor aside, from the homing datum, to clear its tag from this gate's field. Signed mm, 0=off.
 nfc_neighbor_evict_distance : [[PARAM_NFC_NEIGHBOR_EVICT_DISTANCE]]
 
-# Jog THIS gate's own filament further off PARK to confirm an unconfirmed tag during MMU_NFC_SCAN. Signed mm, 0=off.
-nfc_gate_clear_distance     : [[PARAM_NFC_GATE_CLEAR_DISTANCE]]
-
-# As above (from PARK), for MMU_PRELOAD - can differ, including in sign. Defaults to nfc_gate_clear_distance.
-nfc_preload_clear_distance  : [[PARAM_NFC_PRELOAD_CLEAR_DISTANCE]]
+# Jog distance to move a tag off the reader for validation purposes. Signed mm, 0=off.
+nfc_gate_clear_distance     : [[PARAM_NFC_GATE_CLEAR_DISTANCE]]			# For MMU_NFC_SCAN
+nfc_preload_clear_distance  : [[PARAM_NFC_PRELOAD_CLEAR_DISTANCE]]			# For MMU_PRELOAD
 
 # NFC reader LED feedback segment. '' = auto.
 nfc_led_segment             : [[PARAM_NFC_LED_SEGMENT]]

--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -550,11 +550,16 @@ nfc_preload_jog_scan_window : [[PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW]]
 # Refuse (rather than misattribute) a tag identified as a neighboring gate's own. 0=off (default).
 nfc_neighbor_check          : [[PARAM_NFC_NEIGHBOR_CHECK]]
 
-# Reads per "is anything in this reader's field?" probe. Used by nfc_neighbor_check/_evict_distance.
+# Reads per "is anything in this reader's field?" probe. Used by nfc_neighbor_check/_evict_distance
+# and nfc_self_verify_distance.
 nfc_field_probe_reads       : [[PARAM_NFC_FIELD_PROBE_READS]]
 
 # Also jog a neighbor's filament aside to clear its tag from this gate's field. Signed mm, 0=off (default).
 nfc_neighbor_evict_distance : [[PARAM_NFC_NEIGHBOR_EVICT_DISTANCE]]
+
+# Independent of the above: jog THIS gate's own filament further off park to confirm an
+# unconfirmed tag before discarding it. Signed mm, 0=off (default).
+nfc_self_verify_distance    : [[PARAM_NFC_SELF_VERIFY_DISTANCE]]
 
 # NFC reader LED feedback segment. '' = auto.
 nfc_led_segment             : [[PARAM_NFC_LED_SEGMENT]]

--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -556,7 +556,7 @@ nfc_field_probe_reads       : [[PARAM_NFC_FIELD_PROBE_READS]]
 # Jog a neighbor aside, from the homing datum, to clear its tag from this gate's field. Signed mm, 0=off.
 nfc_neighbor_evict_distance : [[PARAM_NFC_NEIGHBOR_EVICT_DISTANCE]]
 
-# Jog distance to move a tag off the reader for validation purposes. Signed mm, 0=off.
+# Park-relative jog to move a tag off the reader for validation. Signed mm, 0=off; must fit the matching homing reach.
 nfc_gate_clear_distance     : [[PARAM_NFC_GATE_CLEAR_DISTANCE]]			# For MMU_NFC_SCAN
 nfc_preload_clear_distance  : [[PARAM_NFC_PRELOAD_CLEAR_DISTANCE]]			# For MMU_PRELOAD
 

--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -541,28 +541,25 @@ heater_rotate_interval      : [[PARAM_HEATER_ROTATE_INTERVAL]]			# Interval in m
 # NFC / RFID tag reading. See menuconfig ("NFC/RFID params") for full details of each option.
 nfc_deep_read               : [[PARAM_NFC_DEEP_READ]]
 
-# Jog search range (mm) for the RFID tag at the gate. "0, 0" disables jog scanning.
+# Jog search range (mm) from the homing datum for the RFID tag. "0, 0" disables jog scanning.
 nfc_gate_jog_scan_window    : [[PARAM_NFC_GATE_JOG_SCAN_WINDOW]]
 
-# As above, but for MMU_PRELOAD's scan. Defaults to nfc_gate_jog_scan_window.
+# As above (datum-relative), for MMU_PRELOAD's scan. Defaults to nfc_gate_jog_scan_window.
 nfc_preload_jog_scan_window : [[PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW]]
 
 # Refuse (rather than misattribute) a tag identified as a neighboring gate's own. 0=off (default).
 nfc_neighbor_check          : [[PARAM_NFC_NEIGHBOR_CHECK]]
 
-# Reads per "is anything in this reader's field?" probe. Used by nfc_neighbor_check/_evict_distance
-# and nfc_gate_clear_distance/nfc_preload_clear_distance.
+# Reads per reader-field probe. Used by nfc_neighbor_check/_evict_distance and the clear distances.
 nfc_field_probe_reads       : [[PARAM_NFC_FIELD_PROBE_READS]]
 
-# Also jog a neighbor's filament aside to clear its tag from this gate's field. Signed mm, 0=off (default).
+# Jog a neighbor aside, from the homing datum, to clear its tag from this gate's field. Signed mm, 0=off.
 nfc_neighbor_evict_distance : [[PARAM_NFC_NEIGHBOR_EVICT_DISTANCE]]
 
-# Independent of the above and of each other: jog THIS gate's own filament further off park to
-# confirm an unconfirmed tag before discarding it, during MMU_NFC_SCAN. Signed mm, 0=off (default).
+# Jog THIS gate's own filament further off PARK to confirm an unconfirmed tag during MMU_NFC_SCAN. Signed mm, 0=off.
 nfc_gate_clear_distance     : [[PARAM_NFC_GATE_CLEAR_DISTANCE]]
 
-# As above, but during MMU_PRELOAD - can differ (including in sign) since preload may home/park
-# via a different endstop. Defaults to nfc_gate_clear_distance.
+# As above (from PARK), for MMU_PRELOAD - can differ, including in sign. Defaults to nfc_gate_clear_distance.
 nfc_preload_clear_distance  : [[PARAM_NFC_PRELOAD_CLEAR_DISTANCE]]
 
 # NFC reader LED feedback segment. '' = auto.

--- a/extras/mmu/commands/mmu_dev_test.py
+++ b/extras/mmu/commands/mmu_dev_test.py
@@ -1285,9 +1285,11 @@ class MmuTestCommand(BaseCommand):
                 u = mmu.mmu_unit(gate)
                 armed = mmu._nfc_field_arm(gate) is not None
                 log("NFC_FIELD: arbitration %s (nfc_neighbor_check=%d, "
-                    "nfc_neighbor_evict_distance=%.1f, probe reads=%d)"
+                    "nfc_neighbor_evict_distance=%.1f, nfc_self_verify_distance=%.1f, "
+                    "probe reads=%d)"
                     % ("ARMED" if armed else "not armed", u.p.nfc_neighbor_check,
-                       u.p.nfc_neighbor_evict_distance, u.p.nfc_field_probe_reads))
+                       u.p.nfc_neighbor_evict_distance, u.p.nfc_self_verify_distance,
+                       u.p.nfc_field_probe_reads))
 
                 if verdict == NFC_FIELD_NEIGHBOR:
                     candidates = arbiter._neighbor_candidates(gate, owner)

--- a/extras/mmu/commands/mmu_dev_test.py
+++ b/extras/mmu/commands/mmu_dev_test.py
@@ -1283,11 +1283,16 @@ class MmuTestCommand(BaseCommand):
                 # Arming and eligibility are config/machine-state, not part of the pure
                 # ladder - reported separately so a caller can see both without any I/O.
                 u = mmu.mmu_unit(gate)
-                armed = mmu._nfc_field_arm(gate) is not None
-                log("NFC_FIELD: arbitration %s (nfc_neighbor_check=%d, "
+                scan_armed = mmu._nfc_field_arm(
+                    gate, clear_distance=u.p.nfc_gate_clear_distance) is not None
+                preload_endstop = u.p.gate_preload_endstop or u.p.gate_homing_endstop
+                preload_armed = mmu._nfc_field_arm(
+                    gate, preload_endstop, u.p.nfc_preload_clear_distance) is not None
+                log("NFC_FIELD: arbitration scan=%s, preload=%s (nfc_neighbor_check=%d, "
                     "nfc_neighbor_evict_distance=%.1f, nfc_gate_clear_distance=%.1f, "
                     "nfc_preload_clear_distance=%.1f, probe reads=%d)"
-                    % ("ARMED" if armed else "not armed", u.p.nfc_neighbor_check,
+                    % ("ARMED" if scan_armed else "not armed",
+                       "ARMED" if preload_armed else "not armed", u.p.nfc_neighbor_check,
                        u.p.nfc_neighbor_evict_distance, u.p.nfc_gate_clear_distance,
                        u.p.nfc_preload_clear_distance, u.p.nfc_field_probe_reads))
 

--- a/extras/mmu/commands/mmu_dev_test.py
+++ b/extras/mmu/commands/mmu_dev_test.py
@@ -1285,11 +1285,11 @@ class MmuTestCommand(BaseCommand):
                 u = mmu.mmu_unit(gate)
                 armed = mmu._nfc_field_arm(gate) is not None
                 log("NFC_FIELD: arbitration %s (nfc_neighbor_check=%d, "
-                    "nfc_neighbor_evict_distance=%.1f, nfc_self_verify_distance=%.1f, "
-                    "probe reads=%d)"
+                    "nfc_neighbor_evict_distance=%.1f, nfc_gate_clear_distance=%.1f, "
+                    "nfc_preload_clear_distance=%.1f, probe reads=%d)"
                     % ("ARMED" if armed else "not armed", u.p.nfc_neighbor_check,
-                       u.p.nfc_neighbor_evict_distance, u.p.nfc_self_verify_distance,
-                       u.p.nfc_field_probe_reads))
+                       u.p.nfc_neighbor_evict_distance, u.p.nfc_gate_clear_distance,
+                       u.p.nfc_preload_clear_distance, u.p.nfc_field_probe_reads))
 
                 if verdict == NFC_FIELD_NEIGHBOR:
                     candidates = arbiter._neighbor_candidates(gate, owner)

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -536,16 +536,19 @@ class MmuFilamentMovement:
         self.nfc_arbiter.clear_field() is an inert passthrough and the caller behaves exactly
         as it did before this feature existed.
 
-        Deliberately off by default: neither nfc_neighbor_check nor nfc_neighbor_evict_distance
-        is armed out of the box, so a stock machine never probes, never warns, and pays no
-        extra reader I/O.
+        Deliberately off by default: none of nfc_neighbor_check, nfc_neighbor_evict_distance,
+        or nfc_self_verify_distance is armed out of the box, so a stock machine never probes,
+        never warns, and pays no extra reader I/O.
 
         'profile_endstop' is the gate endstop the caller's enclosed operation will itself home
         to (preload passes its profile endstop; MMU_NFC_SCAN homes to the reader itself and
         passes nothing).
         """
         u = self.mmu_unit(gate)
-        if not u.p.nfc_neighbor_check and not u.p.nfc_neighbor_evict_distance:
+        # nfc_self_verify_distance arms this on its own - a machine that wants only the
+        # self-jog ratification escalation, with neither neighbor check nor eviction, must
+        # still reach clear_field()/_ratify() for there to be anything to escalate.
+        if not u.p.nfc_neighbor_check and not u.p.nfc_neighbor_evict_distance and not u.p.nfc_self_verify_distance:
             return None
         if profile_endstop == SENSOR_ENCODER:
             # Encoder homing can't be compounded with the reader (see

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -190,9 +190,13 @@ class MmuFilamentMovement:
         # NFC leg anyway (strong pending, or encoder homing).
         arb_mgr = None
         if not have_strong_pending and profile.endstop != SENSOR_ENCODER:
-            arb_mgr = self._nfc_field_arm(gate, profile.endstop)
+            arb_mgr = self._nfc_field_arm(gate, profile.endstop, profile.clear_distance)
 
-        with self.nfc_arbiter.clear_field(gate, arb_mgr, endstop=profile.endstop, clear_distance=profile.clear_distance) as outcome:
+        with self.nfc_arbiter.clear_field(
+                gate, arb_mgr, endstop=profile.endstop,
+                clear_distance=profile.clear_distance,
+                parking_distance=profile.parking_distance,
+                homing_max=profile.homing_max) as outcome:
             # Decide the NFC path HERE, above the banner, so the banner cannot promise a scan
             # that won't happen. _build_gate_nfc_compound() declines (returns None) when there is
             # no reader, the reader is disabled, or the gate endstop isn't a real MCU switch.
@@ -528,21 +532,21 @@ class MmuFilamentMovement:
         return nfc_mgr
 
 
-    def _nfc_field_arm(self, gate, profile_endstop=None):
+    def _nfc_field_arm(self, gate, profile_endstop=None, clear_distance=0.0):
         """
         Should NFC neighbor-field arbitration run for gate 'gate'? Returns the gate's NFC
         manager if so, else None (clear_field() is then an inert passthrough).
 
-        Off by default: none of nfc_neighbor_check, nfc_neighbor_evict_distance,
-        nfc_gate_clear_distance, nfc_preload_clear_distance is armed out of the box.
+        Off by default: the shared neighbor options and this operation's clear distance
+        are all zero/off out of the box. The other operation's clear distance is irrelevant.
 
         'profile_endstop': the endstop the caller will itself home to (preload's own
         endstop; MMU_NFC_SCAN passes nothing, it homes to the reader).
         """
         u = self.mmu_unit(gate)
-        # each of the four params can arm this on its own
+        # Neighbor handling is shared; self-jog arming is specific to this operation.
         if (not u.p.nfc_neighbor_check and not u.p.nfc_neighbor_evict_distance
-                and not u.p.nfc_gate_clear_distance and not u.p.nfc_preload_clear_distance):
+                and not clear_distance):
             return None
         if profile_endstop == SENSOR_ENCODER:
             return None # can't compound with the reader, nothing to protect
@@ -761,8 +765,12 @@ class MmuFilamentMovement:
 
         # Settle field ownership before trusting the fast path or sweep - unlike preload, an
         # unattributable verdict fails the command outright (there's nothing else to report).
-        arb_mgr = self._nfc_field_arm(gate)
-        with self.nfc_arbiter.clear_field(gate, arb_mgr, endstop=profile.endstop, clear_distance=profile.clear_distance) as outcome:
+        arb_mgr = self._nfc_field_arm(gate, clear_distance=profile.clear_distance)
+        with self.nfc_arbiter.clear_field(
+                gate, arb_mgr, endstop=profile.endstop,
+                clear_distance=profile.clear_distance,
+                parking_distance=profile.parking_distance,
+                homing_max=profile.homing_max) as outcome:
             if outcome.verdict == NFC_FIELD_FOREIGN:
                 raise MmuError("Cannot scan gate %d: %s" % (gate, outcome.reason))
 

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -49,7 +49,7 @@ from .mmu_sensor_utils    import MmuVirtualEndstopSensor, MmuCompoundEndstop
 # gate_preload_* set (_preload_profile). Every gate homing/parking primitive is driven by
 # one of them, so the endstop, homing budget, parking distance and NFC jog scan window
 # always travel together.
-GateHomeProfile = namedtuple('GateHomeProfile', ['endstop', 'homing_max', 'parking_distance', 'attempts', 'jog_scan_window'])
+GateHomeProfile = namedtuple('GateHomeProfile', ['endstop', 'homing_max', 'parking_distance', 'attempts', 'jog_scan_window', 'clear_distance'])
 
 
 class MmuFilamentMovement:
@@ -71,6 +71,7 @@ class MmuFilamentMovement:
             parking_distance=u.p.gate_parking_distance,
             attempts=(u.p.gate_load_attempts if allow_retry else 1),
             jog_scan_window=u.p.nfc_gate_jog_scan_window,
+            clear_distance=u.p.nfc_gate_clear_distance,
         )
 
 
@@ -87,6 +88,7 @@ class MmuFilamentMovement:
             parking_distance=u.p.gate_preload_parking_distance,
             attempts=u.p.gate_preload_attempts,
             jog_scan_window=u.p.nfc_preload_jog_scan_window,
+            clear_distance=u.p.nfc_preload_clear_distance,
         )
 
 
@@ -193,7 +195,7 @@ class MmuFilamentMovement:
         if not have_strong_pending and profile.endstop != SENSOR_ENCODER:
             arb_mgr = self._nfc_field_arm(gate, profile.endstop)
 
-        with self.nfc_arbiter.clear_field(gate, arb_mgr, endstop=profile.endstop) as outcome:
+        with self.nfc_arbiter.clear_field(gate, arb_mgr, endstop=profile.endstop, clear_distance=profile.clear_distance) as outcome:
             # Decide the NFC path HERE, above the banner, so the banner cannot promise a scan
             # that won't happen. _build_gate_nfc_compound() declines (returns None) when there is
             # no reader, the reader is disabled, or the gate endstop isn't a real MCU switch.
@@ -537,18 +539,20 @@ class MmuFilamentMovement:
         as it did before this feature existed.
 
         Deliberately off by default: none of nfc_neighbor_check, nfc_neighbor_evict_distance,
-        or nfc_self_verify_distance is armed out of the box, so a stock machine never probes,
-        never warns, and pays no extra reader I/O.
+        nfc_gate_clear_distance, or nfc_preload_clear_distance is armed out of the box, so a
+        stock machine never probes, never warns, and pays no extra reader I/O.
 
         'profile_endstop' is the gate endstop the caller's enclosed operation will itself home
         to (preload passes its profile endstop; MMU_NFC_SCAN homes to the reader itself and
         passes nothing).
         """
         u = self.mmu_unit(gate)
-        # nfc_self_verify_distance arms this on its own - a machine that wants only the
-        # self-jog ratification escalation, with neither neighbor check nor eviction, must
-        # still reach clear_field()/_ratify() for there to be anything to escalate.
-        if not u.p.nfc_neighbor_check and not u.p.nfc_neighbor_evict_distance and not u.p.nfc_self_verify_distance:
+        # nfc_gate_clear_distance/nfc_preload_clear_distance each arm this on their own - a
+        # machine that wants only one operation's self-jog ratification escalation, with
+        # neither neighbor check nor eviction, must still reach clear_field()/_ratify() for
+        # there to be anything to escalate.
+        if (not u.p.nfc_neighbor_check and not u.p.nfc_neighbor_evict_distance
+                and not u.p.nfc_gate_clear_distance and not u.p.nfc_preload_clear_distance):
             return None
         if profile_endstop == SENSOR_ENCODER:
             # Encoder homing can't be compounded with the reader (see
@@ -776,7 +780,7 @@ class MmuFilamentMovement:
         # report. arb_mgr is None (clear_field() then an inert passthrough) whenever
         # arbitration isn't armed for this gate.
         arb_mgr = self._nfc_field_arm(gate)
-        with self.nfc_arbiter.clear_field(gate, arb_mgr, endstop=profile.endstop) as outcome:
+        with self.nfc_arbiter.clear_field(gate, arb_mgr, endstop=profile.endstop, clear_distance=profile.clear_distance) as outcome:
             if outcome.verdict == NFC_FIELD_FOREIGN:
                 raise MmuError("Cannot scan gate %d: %s" % (gate, outcome.reason))
 

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -193,7 +193,7 @@ class MmuFilamentMovement:
         if not have_strong_pending and profile.endstop != SENSOR_ENCODER:
             arb_mgr = self._nfc_field_arm(gate, profile.endstop)
 
-        with self.nfc_arbiter.clear_field(gate, arb_mgr) as outcome:
+        with self.nfc_arbiter.clear_field(gate, arb_mgr, endstop=profile.endstop) as outcome:
             # Decide the NFC path HERE, above the banner, so the banner cannot promise a scan
             # that won't happen. _build_gate_nfc_compound() declines (returns None) when there is
             # no reader, the reader is disabled, or the gate endstop isn't a real MCU switch.
@@ -773,7 +773,7 @@ class MmuFilamentMovement:
         # report. arb_mgr is None (clear_field() then an inert passthrough) whenever
         # arbitration isn't armed for this gate.
         arb_mgr = self._nfc_field_arm(gate)
-        with self.nfc_arbiter.clear_field(gate, arb_mgr) as outcome:
+        with self.nfc_arbiter.clear_field(gate, arb_mgr, endstop=profile.endstop) as outcome:
             if outcome.verdict == NFC_FIELD_FOREIGN:
                 raise MmuError("Cannot scan gate %d: %s" % (gate, outcome.reason))
 

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -185,12 +185,9 @@ class MmuFilamentMovement:
         has_material = tag is not None and isinstance(tag[1], dict) and tag[1].get('material')
         have_strong_pending = spool_id > 0 or has_material
 
-        # A neighboring gate's spool sitting in this gate's reader field could satisfy the NFC
-        # leg of the compound below at (near) zero distance and be misattributed to this gate.
-        # Settle who is actually in the field - jogging an identified neighbor aside when
-        # arbitration has a motion budget for it - before deciding the NFC path. arb_mgr is
-        # None (clear_field() then an inert passthrough) whenever we wouldn't attempt an NFC
-        # leg at all anyway (strong pending, or encoder homing), so this costs nothing then.
+        # A neighboring gate's spool could satisfy the NFC leg below and get misattributed -
+        # settle field ownership first. arb_mgr stays None (inert) if we wouldn't attempt an
+        # NFC leg anyway (strong pending, or encoder homing).
         arb_mgr = None
         if not have_strong_pending and profile.endstop != SENSOR_ENCODER:
             arb_mgr = self._nfc_field_arm(gate, profile.endstop)
@@ -533,32 +530,22 @@ class MmuFilamentMovement:
 
     def _nfc_field_arm(self, gate, profile_endstop=None):
         """
-        Should NFC neighbor-field arbitration (MmuNfcFieldArbiter) run for gate 'gate'?
-        Returns the gate's NFC manager when it should, else None - in which case
-        self.nfc_arbiter.clear_field() is an inert passthrough and the caller behaves exactly
-        as it did before this feature existed.
+        Should NFC neighbor-field arbitration run for gate 'gate'? Returns the gate's NFC
+        manager if so, else None (clear_field() is then an inert passthrough).
 
-        Deliberately off by default: none of nfc_neighbor_check, nfc_neighbor_evict_distance,
-        nfc_gate_clear_distance, or nfc_preload_clear_distance is armed out of the box, so a
-        stock machine never probes, never warns, and pays no extra reader I/O.
+        Off by default: none of nfc_neighbor_check, nfc_neighbor_evict_distance,
+        nfc_gate_clear_distance, nfc_preload_clear_distance is armed out of the box.
 
-        'profile_endstop' is the gate endstop the caller's enclosed operation will itself home
-        to (preload passes its profile endstop; MMU_NFC_SCAN homes to the reader itself and
-        passes nothing).
+        'profile_endstop': the endstop the caller will itself home to (preload's own
+        endstop; MMU_NFC_SCAN passes nothing, it homes to the reader).
         """
         u = self.mmu_unit(gate)
-        # nfc_gate_clear_distance/nfc_preload_clear_distance each arm this on their own - a
-        # machine that wants only one operation's self-jog ratification escalation, with
-        # neither neighbor check nor eviction, must still reach clear_field()/_ratify() for
-        # there to be anything to escalate.
+        # each of the four params can arm this on its own
         if (not u.p.nfc_neighbor_check and not u.p.nfc_neighbor_evict_distance
                 and not u.p.nfc_gate_clear_distance and not u.p.nfc_preload_clear_distance):
             return None
         if profile_endstop == SENSOR_ENCODER:
-            # Encoder homing can't be compounded with the reader (see
-            # _build_gate_nfc_compound), so no tag is ever read on that path and there is
-            # nothing here worth protecting.
-            return None
+            return None # can't compound with the reader, nothing to protect
         return self._gate_nfc_reader(gate)
 
 
@@ -772,13 +759,8 @@ class MmuFilamentMovement:
             for mgr in [unit.nfc_manager] if mgr is not None
         ]
 
-        # Settle who is in this gate's reader field before trusting either the fast path or
-        # the sweep below - a neighboring gate's tag sitting in range is just as capable of
-        # fooling a sweep as it is the fast path. MMU_NFC_SCAN's whole point is to read a tag,
-        # so unlike preload, a verdict we can't attribute fails the command outright rather
-        # than falling back to a plain (non-NFC) operation - there is nothing legitimate to
-        # report. arb_mgr is None (clear_field() then an inert passthrough) whenever
-        # arbitration isn't armed for this gate.
+        # Settle field ownership before trusting the fast path or sweep - unlike preload, an
+        # unattributable verdict fails the command outright (there's nothing else to report).
         arb_mgr = self._nfc_field_arm(gate)
         with self.nfc_arbiter.clear_field(gate, arb_mgr, endstop=profile.endstop, clear_distance=profile.clear_distance) as outcome:
             if outcome.verdict == NFC_FIELD_FOREIGN:

--- a/extras/mmu/mmu_nfc_arbiter.py
+++ b/extras/mmu/mmu_nfc_arbiter.py
@@ -26,12 +26,13 @@
 # clear_field() context manager and an arm check, so this bookkeeping doesn't grow those
 # already-large functions further.
 #
-# Off by default: none of nfc_neighbor_check, nfc_neighbor_evict_distance, or
-# nfc_self_verify_distance is armed out of the box, and clear_field() is an inert passthrough
-# when arbitration isn't armed for a gate - a stock machine does no extra reader I/O and
-# behaves exactly as it did before this module existed. nfc_self_verify_distance is
-# independent of the other two - it controls only whether _ratify() escalates a PROVISIONAL
-# verdict to a deliberate self-jog, not neighbor eviction.
+# Off by default: none of nfc_neighbor_check, nfc_neighbor_evict_distance,
+# nfc_gate_clear_distance, or nfc_preload_clear_distance is armed out of the box, and
+# clear_field() is an inert passthrough when arbitration isn't armed for a gate - a stock
+# machine does no extra reader I/O and behaves exactly as it did before this module existed.
+# nfc_gate_clear_distance/nfc_preload_clear_distance are independent of neighbor eviction and
+# of each other - each controls only whether _ratify() escalates a PROVISIONAL verdict to a
+# deliberate self-jog for its own operation (MMU_NFC_SCAN / MMU_PRELOAD respectively).
 #
 # (\_/)
 # ( *,*)
@@ -299,7 +300,7 @@ class MmuNfcFieldArbiter:
 
     # ---- Provisional-verdict ratification ------------------------------------------------------
 
-    def _ratify(self, gate, nfc_mgr, endstop):
+    def _ratify(self, gate, nfc_mgr, endstop, clear_distance=0.0):
         """
         Re-probe gate 'gate's reader once, after the caller's own natural motion (preload's
         homing+park, or a jog-scan's sweep with its fast path suppressed) has completed, to
@@ -314,16 +315,22 @@ class MmuNfcFieldArbiter:
         there".
 
         If that passive check still finds a tag, and there is a motion budget
-        (nfc_self_verify_distance != 0 - independent of nfc_neighbor_evict_distance, which
-        only governs neighbor eviction) that is safe to spend in this direction for
-        'endstop' (see _verify_by_self_jog), escalate to a deliberate causal test rather than
-        settling for "whatever the operation's own incidental motion happened to leave
-        behind" - a tag physically mounted such that it stays in range at the normal park
-        position would otherwise fail the passive check every single time, forever, even
-        when it is genuinely this gate's own spool. 'endstop' is the caller's own homing
-        endstop (gate_preload_endstop for preload, gate_homing_endstop for a scan) - expected
-        non-None whenever the verdict reaching here is NFC_FIELD_PROVISIONAL; both current
-        callers always pass it.
+        ('clear_distance' != 0 - independent of nfc_neighbor_evict_distance, which only
+        governs neighbor eviction) that is safe to spend in this direction for 'endstop'
+        (see _verify_by_self_jog), escalate to a deliberate causal test rather than settling
+        for "whatever the operation's own incidental motion happened to leave behind" - a tag
+        physically mounted such that it stays in range at the normal park position would
+        otherwise fail the passive check every single time, forever, even when it is
+        genuinely this gate's own spool.
+
+        'clear_distance' and 'endstop' both describe the CALLER's own context - the caller
+        picks its own matching config value (nfc_gate_clear_distance/gate_homing_endstop for
+        MMU_NFC_SCAN, nfc_preload_clear_distance/gate_preload_endstop for preload - they can
+        differ, including in sign, since the two operations can home/park via different
+        endstops) and passes both in; this method has no opinion on which parameter a value
+        came from, only on whether it's safe/worth spending. Both are expected non-None
+        whenever the verdict reaching here is NFC_FIELD_PROVISIONAL; both current callers
+        always pass them.
 
         The caller (clear_field) uses the final return value to decide whether to commit the
         held read (release_held_attribution) or drop it (discard_held_attribution) - nothing
@@ -335,7 +342,7 @@ class MmuNfcFieldArbiter:
                                 "clear after the operation's own motion)" % gate)
             return True
 
-        distance = self.mmu.mmu_unit(gate).p.nfc_self_verify_distance
+        distance = clear_distance
         if distance and not (distance > 0 and endstop in SHARED_GATE_ENDSTOPS):
             if self._verify_by_self_jog(gate, nfc_mgr, distance):
                 self.mmu.log_debug(
@@ -364,10 +371,10 @@ class MmuNfcFieldArbiter:
     def _verify_by_self_jog(self, gate, nfc_mgr, distance):
         """
         Escalate the passive ratification check into a deliberate, causal one: jog gate's own
-        already-parked filament ANOTHER 'distance' mm further off its park position
-        (nfc_self_verify_distance's sign/direction convention - independent of, but shaped
-        the same way as, nfc_neighbor_evict_distance), re-probe, and see whether detection
-        tracks that deliberate motion. This is materially stronger evidence than the passive
+        already-parked filament ANOTHER 'distance' mm further off its park position (the
+        caller's own nfc_gate_clear_distance/nfc_preload_clear_distance value, already
+        resolved by _ratify - this method doesn't care which), re-probe, and see whether
+        detection tracks that deliberate motion. This is materially stronger evidence than the passive
         check alone, which only observes whatever incidental settling the caller's own
         necessary motion happened to produce.
 
@@ -454,18 +461,19 @@ class MmuNfcFieldArbiter:
     # ---- Public entry point ---------------------------------------------------------------------
 
     @contextlib.contextmanager
-    def clear_field(self, gate, nfc_mgr, endstop=None):
+    def clear_field(self, gate, nfc_mgr, endstop=None, clear_distance=0.0):
         """
         Ensure gate 'gate's NFC reader field is settled for the duration of the enclosed
         operation, temporarily jogging identified neighboring gates' filament off their park
         position when arbitration has a motion budget for it.
 
-        'endstop' is the caller's own homing endstop for this operation (gate_preload_endstop
-        for preload, gate_homing_endstop for a scan) - used only if ratification needs to
-        escalate to a deliberate self-jog, to decide whether a forward jog is safe (see
-        MmuNfcFieldArbiter._ratify). Both current callers always pass it; a caller that
-        forgets to would be treated as "forward is safe" (None is not a SHARED_GATE_ENDSTOPS
-        member), so don't add a new caller without it.
+        'endstop' and 'clear_distance' both describe the CALLER's own context (see
+        MmuNfcFieldArbiter._ratify) - used only if ratification needs to escalate to a
+        deliberate self-jog: 'clear_distance' is the caller's own matching config value
+        (nfc_gate_clear_distance for a scan, nfc_preload_clear_distance for preload), and
+        'endstop' decides whether jogging it forward is safe. Both current callers always
+        pass both; a caller that forgets 'endstop' would be treated as "forward is safe"
+        (None is not a SHARED_GATE_ENDSTOPS member), so don't add a new caller without it.
 
         Yields a NfcFieldOutcome, whose 'verdict' is one of:
             NFC_FIELD_CLEAR       nothing in the field, or arbitration isn't armed for this
@@ -524,7 +532,7 @@ class MmuNfcFieldArbiter:
             # neighbor stranded off its park position, or leave a hold armed forever.
             if provisional:
                 try:
-                    ratified = self._ratify(gate, nfc_mgr, endstop)
+                    ratified = self._ratify(gate, nfc_mgr, endstop, clear_distance)
                 except Exception as e:
                     self.mmu.log_error("NFC: gate %d: ratification check failed: %s" % (gate, str(e)))
                     ratified = False # Safer to discard an unconfirmed read than commit it blind

--- a/extras/mmu/mmu_nfc_arbiter.py
+++ b/extras/mmu/mmu_nfc_arbiter.py
@@ -5,34 +5,13 @@
 #
 # Goal: NFC "noisy neighbor" reader-field arbitration
 #
-# Per-gate NFC readers can sit close enough that a spool parked at a neighboring gate is
-# physically inside gate G's own RF field - satisfying the preload NFC endstop, or a jog-scan's
-# fast path, with a tag that was never gate G's own. Before either trusts "a tag is at my
-# reader" to mean "this gate's tag", MmuNfcFieldArbiter settles who is actually there:
+# A neighboring gate's tag can trigger gate G's own reader. MmuNfcFieldArbiter settles
+# ownership before trusting it: registered to G -> mine; registered to a same-unit
+# neighbor -> evict by jogging it aside; different unit -> impossible, map stale, ignore;
+# unrecognised and un-evictable -> PROVISIONAL, confirmed later by the caller's own motion.
 #
-#   - a UID the gate map already attributes to gate G (or that it doesn't recognise at all)
-#     is treated as this gate's own,
-#   - a UID registered to a specific neighboring gate on the SAME unit is evicted by
-#     temporarily loading that gate and jogging its filament out of the way,
-#   - a UID registered to a gate on a DIFFERENT unit is physically impossible, so the map is
-#     stale - never attributed, never a candidate,
-#   - an unregistered tag that survives eviction attempts (or that arbitration has no motion
-#     budget to evict at all) is only a PROVISIONAL "assumed mine": the caller's own necessary
-#     motion (preload's homing+park; a jog-scan's sweep) is the only thing that can actually
-#     tell it apart from a neighbor's unregistered spool, so clear_field()'s caller must run
-#     that motion as normal and this class re-checks the field afterwards.
-#
-# Deliberately kept out of mmu_filament_movement.py: _preload_gate and _jog_scan gain only the
-# clear_field() context manager and an arm check, so this bookkeeping doesn't grow those
-# already-large functions further.
-#
-# Off by default: none of nfc_neighbor_check, nfc_neighbor_evict_distance,
-# nfc_gate_clear_distance, or nfc_preload_clear_distance is armed out of the box, and
-# clear_field() is an inert passthrough when arbitration isn't armed for a gate - a stock
-# machine does no extra reader I/O and behaves exactly as it did before this module existed.
-# nfc_gate_clear_distance/nfc_preload_clear_distance are independent of neighbor eviction and
-# of each other - each controls only whether _ratify() escalates a PROVISIONAL verdict to a
-# deliberate self-jog for its own operation (MMU_NFC_SCAN / MMU_PRELOAD respectively).
+# Off by default: nfc_neighbor_check, nfc_neighbor_evict_distance, nfc_gate_clear_distance,
+# nfc_preload_clear_distance are all independent and all 0/off out of the box.
 #
 # (\_/)
 # ( *,*)
@@ -50,22 +29,10 @@ from .mmu_utils      import MmuError
 
 class NfcFieldOutcome:
     """
-    What clear_field() yields. 'verdict' is known immediately (before the caller's enclosed
-    operation runs); 'ratified' is only known afterwards, once clear_field()'s own `finally`
-    has re-probed the field - so it stays None (not applicable) for the duration of the
-    `with` block itself, and callers must read it only after the block has closed.
+    clear_field()'s yield value. 'verdict' is known immediately; 'ratified' only after the
+    `with` block closes (None if not PROVISIONAL, else True/False).
 
-    ratified is:
-        None  - verdict was not NFC_FIELD_PROVISIONAL; there was nothing to ratify.
-        True  - a provisional read was confirmed and committed to the gate map.
-        False - a provisional read could not be confirmed and was discarded, never
-                committed at all - callers should downgrade their own "tag read"/"found"
-                reporting to match, since nothing was actually attributed.
-
-    'reason' is a short, caller-agnostic explanation for a NFC_FIELD_FOREIGN verdict - None
-    for every other verdict. A caller that turns FOREIGN into a hard failure (MMU_NFC_SCAN)
-    can fold this straight into its own error message instead of pointing the user back at
-    the log for a warning that was written for the console record, not for embedding.
+    'reason': short explanation for a FOREIGN verdict, for the caller's own error message.
     """
     __slots__ = ('verdict', 'ratified', 'reason')
 
@@ -77,10 +44,8 @@ class NfcFieldOutcome:
 
 class MmuNfcFieldArbiter:
     """
-    Owns the classification ladder, candidate selection, eviction-by-jogging and provisional-
-    verdict ratification for NFC neighbor-field arbitration. One instance serves the whole
-    machine (candidates are always resolved within a single unit, so no per-unit state is
-    needed here); constructed once by the controller alongside its other manager objects.
+    Classification, candidate selection, eviction-by-jogging and ratification for NFC
+    neighbor-field arbitration. One instance per machine.
     """
 
     def __init__(self, mmu):
@@ -91,20 +56,11 @@ class MmuNfcFieldArbiter:
 
     def _field_verdict(self, gate, uid):
         """
-        Classify a UID found in gate 'gate's reader field against the gate map. No I/O and no
-        motion, so the whole ladder is exercisable with _MMU_TEST NFC_FIELD=1.
-
+        Classify a UID against the gate map. No I/O, no motion.
         Returns (verdict, owner_gate, diagnostic):
-            NFC_FIELD_MINE      registered to this gate - positively confirmed.
-            NFC_FIELD_NEIGHBOR registered to another gate on the SAME unit (evictable), OR
-                                 unrecognised by the gate map at all (owner_gate is then None -
-                                 most likely this gate's own spool that hasn't been scanned
-                                 yet, but not yet distinguishable from an unregistered
-                                 neighbor's spool without motion; see _settle/clear_field).
-            NFC_FIELD_FOREIGN   registered to a gate on a DIFFERENT unit - physically
-                                 impossible, so the gate map itself is stale. Never a
-                                 candidate for eviction under any circumstances.
-        'owner_gate' is None only for the unregistered sub-case of NFC_FIELD_NEIGHBOR.
+            MINE     - registered to this gate
+            NEIGHBOR - registered to a same-unit gate, or unrecognised (owner_gate=None)
+            FOREIGN  - registered to a different unit; map is stale, never a candidate
         """
         if not uid:
             return NFC_FIELD_CLEAR, None, ""
@@ -127,10 +83,7 @@ class MmuNfcFieldArbiter:
 
 
     def _field_check(self, gate, nfc_mgr):
-        """
-        Probe gate 'gate's reader field and classify whatever is in it. No motion.
-        Returns (verdict, uid, owner_gate, diagnostic); NFC_FIELD_CLEAR when nothing is there.
-        """
+        """Probe and classify. No motion. Returns (verdict, uid, owner_gate, diagnostic)."""
         uid = nfc_mgr.probe_gate_field(gate)
         if not uid:
             return NFC_FIELD_CLEAR, None, None, ""
@@ -141,11 +94,7 @@ class MmuNfcFieldArbiter:
     # ---- Candidate selection: identity first, physical neighbors as fallback ---------------
 
     def _neighbor_candidates(self, gate, owner):
-        """
-        Gates worth trying to evict out of gate 'gate's reader field, in priority order: the
-        positively-identified owner first (if it's a real gate on the same unit), then the
-        physical neighbors (gate-1, gate+1), bounds-checked to the unit and deduplicated.
-        """
+        """Eviction candidates in priority order: identified owner first, then gate-1/gate+1."""
         unit = self.mmu.mmu_unit(gate)
         candidates = []
         if owner is not None and unit.owns_gate(owner):
@@ -158,16 +107,8 @@ class MmuNfcFieldArbiter:
 
     def _evict_reject(self, gate, candidate):
         """
-        Why can gate 'candidate' not be jogged out of gate 'gate's reader field right now?
-        Returns a short reason for the diagnostic, or None when it is eligible to try.
-        "Already tried this call" is filtered by the caller (_next_candidate), not here - this
-        is purely about the candidate's own current state.
-
-        The shared-gate-path-occupancy check is re-evaluated for every candidate, not just
-        once up front: evicting one neighbor can leave it homed at its own gate (not parked),
-        which - if that gate's endstop is a per-unit SHARED_GATE_ENDSTOPS resource - would
-        make loading a second candidate onto the same shared path unsafe. See the
-        gate-endstop-invariants skill for why this check can't be skipped.
+        Why 'candidate' can't be evicted right now, or None if eligible. Re-checked per
+        candidate, not just once - evicting one can leave it occupying a shared endstop.
         """
         if candidate == gate:
             return "it is this gate"
@@ -189,7 +130,7 @@ class MmuNfcFieldArbiter:
                 continue
             reason = self._evict_reject(gate, candidate)
             if reason:
-                tried.add(candidate) # Don't re-derive/re-reject it again next iteration
+                tried.add(candidate) # don't re-check it again
                 self.mmu.log_debug("NFC: gate %d: candidate gate %d not evictable (%s)"
                                     % (gate, candidate, reason))
                 continue
@@ -201,19 +142,9 @@ class MmuNfcFieldArbiter:
 
     def _jog_off(self, distance):
         """
-        Move the CURRENTLY SELECTED gate's filament 'distance' mm off its reference position.
-        Signed: positive travels forward of the gate, negative behind it. Assumes the
-        filament is homed at the gate or already parked (the caller is responsible for
-        getting it there first - _load_gate() for a fresh neighbor candidate, or nothing
-        further for a gate already sitting at its own park).
-
-        A plain move, not a homing move - there is nothing to home against here, the whole
-        point is to travel past wherever the tag currently sits.
-
-        Used both to evict a *neighboring* gate's tag out of a different gate's reader field
-        (_evict_one), and to deliberately jog THIS gate's own filament during self-jog
-        ratification (_verify_by_self_jog) - the motion is identical either way, only the
-        reason differs, so the log message below stays purpose-agnostic.
+        Jog the CURRENTLY SELECTED gate's filament 'distance' mm off its reference (+ve
+        forward, -ve back). Plain move, not homing. Used for both neighbor eviction and
+        self-jog ratification.
         """
         self.mmu.log_debug("NFC: gate %d: jogging %.0fmm %s off its park reference"
                             % (self.mmu.gate_selected, abs(distance),
@@ -223,19 +154,15 @@ class MmuNfcFieldArbiter:
 
     def _evict_one(self, gate, candidate, distance, evicted):
         """
-        Load 'candidate' and jog it 'distance' mm off its park position, out of gate 'gate's
-        reader field. Appends (candidate, saved_status) to 'evicted' the moment the load
-        succeeds - even if the jog itself then fails - so the caller always re-parks/restores
-        it; recorded before the jog so a failed jog (or an error escaping it) still gets
-        restored instead of silently left loaded.
+        Load 'candidate' and jog it 'distance' mm out of gate 'gate's field. Appends to
+        'evicted' as soon as the load succeeds, so a failed jog still gets restored.
         """
         saved_status = self.mmu.gate_status[candidate]
         try:
             self.mmu.select_gate(candidate)
             self.mmu._load_gate(allow_retry=False)
         except MmuError as e:
-            # Nothing to jog (no filament, or a jam). Nothing was moved, so nothing owes a
-            # re-park - just put the status back.
+            # nothing moved, so nothing owes a re-park - just restore status
             self.mmu.gate_maps.set_gate_status(candidate, saved_status)
             self.mmu.log_debug("NFC: gate %d: could not load gate %d to move it aside: %s"
                                 % (gate, candidate, str(e)))
@@ -250,16 +177,8 @@ class MmuNfcFieldArbiter:
 
     def _settle(self, gate, nfc_mgr, distance, evicted):
         """
-        Probe gate 'gate's field and, while motion is available, jog identified candidates out
-        of it until it clears (or nothing more can be tried). Bounded to the unit's gate count
-        (at worst every other gate gets tried once).
-
-        Returns (verdict, reason): verdict is one of NFC_FIELD_CLEAR / NFC_FIELD_MINE /
-        NFC_FIELD_FOREIGN / NFC_FIELD_PROVISIONAL - never the intermediate NFC_FIELD_NEIGHBOR,
-        which is resolved into one of the above before returning. 'reason' is a short
-        explanation of a NFC_FIELD_FOREIGN verdict (the fuller warning with remediation
-        advice is logged here regardless), for a caller to embed in its own error message
-        instead of pointing back at the log; None for every other verdict.
+        Probe and jog candidates out of the field until clear or exhausted (bounded to
+        num_gates+1 tries). Returns (verdict, reason) - CLEAR/MINE/FOREIGN/PROVISIONAL only.
         """
         tried = set()
         verdict = uid = owner = diag = None
@@ -273,7 +192,7 @@ class MmuNfcFieldArbiter:
                 break
             tried.add(candidate)
             self._evict_one(gate, candidate, distance, evicted)
-            # Loop back around to re-probe with this candidate out of the way
+            # loop back and re-probe with this candidate out of the way
 
         if verdict in (NFC_FIELD_CLEAR, NFC_FIELD_MINE):
             if diag:
@@ -283,12 +202,9 @@ class MmuNfcFieldArbiter:
             self.mmu.log_warning(diag)
             return NFC_FIELD_FOREIGN, "tag %s is registered to a gate on a different unit" % uid
 
-        # Still NFC_FIELD_NEIGHBOR: either there was no motion budget to begin with, or every
-        # reachable candidate was tried/rejected and the field never cleared.
+        # still NEIGHBOR: no motion budget, or every candidate tried/rejected
         if owner is not None:
-            # Positive evidence the tag belongs to a specific other gate - "assume it's ours
-            # anyway" would be wrong regardless of whether eviction succeeded, so this is a
-            # hard FOREIGN, not a provisional one.
+            # known owner, still uncleared: hard FOREIGN, not provisional
             self.mmu.log_warning(
                 "NFC: gate %d: tag %s belongs to gate %d and could not be moved out of the way "
                 "- proceeding without reading a tag. If that spool was moved by hand, clear "
@@ -302,39 +218,17 @@ class MmuNfcFieldArbiter:
 
     def _ratify(self, gate, nfc_mgr, endstop, clear_distance=0.0):
         """
-        Re-probe gate 'gate's reader once, after the caller's own natural motion (preload's
-        homing+park, or a jog-scan's sweep with its fast path suppressed) has completed, to
-        confirm or reject a NFC_FIELD_PROVISIONAL verdict. Returns True (ratified) or False
-        (not ratified).
+        Re-probe once after the caller's own motion completes, to confirm/reject a
+        PROVISIONAL verdict. Raw presence check, not _field_check - re-deriving ownership
+        would be circular since the held read is about to write that same map entry.
 
-        Deliberately a raw presence check (nfc_mgr.probe_gate_field), NOT _field_check /
-        _field_verdict: find_gate_by_rfid would resolve ownership against whatever the read
-        this verdict is protecting is ABOUT to write (see clear_field - attribution is held,
-        not yet committed, while this runs), which is a different but related circularity to
-        guard against. The only question that isn't circular either way is "is anything still
-        there".
+        If still present and 'clear_distance' gives a safe motion budget for 'endstop',
+        escalate to a deliberate self-jog (_verify_by_self_jog) instead of trusting
+        incidental motion alone. 'clear_distance'/'endstop' are the CALLER's own values
+        (nfc_gate_clear_distance/gate_homing_endstop for scan, nfc_preload_clear_distance/
+        gate_preload_endstop for preload).
 
-        If that passive check still finds a tag, and there is a motion budget
-        ('clear_distance' != 0 - independent of nfc_neighbor_evict_distance, which only
-        governs neighbor eviction) that is safe to spend in this direction for 'endstop'
-        (see _verify_by_self_jog), escalate to a deliberate causal test rather than settling
-        for "whatever the operation's own incidental motion happened to leave behind" - a tag
-        physically mounted such that it stays in range at the normal park position would
-        otherwise fail the passive check every single time, forever, even when it is
-        genuinely this gate's own spool.
-
-        'clear_distance' and 'endstop' both describe the CALLER's own context - the caller
-        picks its own matching config value (nfc_gate_clear_distance/gate_homing_endstop for
-        MMU_NFC_SCAN, nfc_preload_clear_distance/gate_preload_endstop for preload - they can
-        differ, including in sign, since the two operations can home/park via different
-        endstops) and passes both in; this method has no opinion on which parameter a value
-        came from, only on whether it's safe/worth spending. Both are expected non-None
-        whenever the verdict reaching here is NFC_FIELD_PROVISIONAL; both current callers
-        always pass them.
-
-        The caller (clear_field) uses the final return value to decide whether to commit the
-        held read (release_held_attribution) or drop it (discard_held_attribution) - nothing
-        is attributed to the wrong gate here, it just hasn't been committed yet either way.
+        Returns True/False; caller (clear_field) commits or discards the held read.
         """
         uid = nfc_mgr.probe_gate_field(gate)
         if not uid:
@@ -358,8 +252,7 @@ class MmuNfcFieldArbiter:
                 "neighboring gate's spool has been moved or registered" % (gate, uid, gate, abs(distance)))
             return False
 
-        # No motion budget, or the direction isn't safe for this endstop - plain discard,
-        # wording unchanged from before self-jog escalation existed.
+        # no motion budget or unsafe direction - plain discard
         self.mmu.log_warning(
             "NFC: gate %d: could not confirm this gate's own tag - the reader still shows "
             "tag %s after gate %d's own filament settled, so the read is being discarded "
@@ -370,35 +263,12 @@ class MmuNfcFieldArbiter:
 
     def _verify_by_self_jog(self, gate, nfc_mgr, distance):
         """
-        Escalate the passive ratification check into a deliberate, causal one: jog gate's own
-        already-parked filament ANOTHER 'distance' mm further off its park position (the
-        caller's own nfc_gate_clear_distance/nfc_preload_clear_distance value, already
-        resolved by _ratify - this method doesn't care which), re-probe, and see whether
-        detection tracks that deliberate motion. This is materially stronger evidence than the passive
-        check alone, which only observes whatever incidental settling the caller's own
-        necessary motion happened to produce.
-
-        Deliberately reuses _jog_off (called once forward, once reversed) rather than a
-        homing-based restore like _repark_evicted's: at this point the filament is sitting at
-        a precisely known position (the caller's own park move, executed moments earlier, is
-        itself a plain dead-reckoned move - see _park_at_gate's "Final parking" - not a
-        homing move), so an equal-and-opposite plain jog is exactly as trustworthy as that
-        just-established park and needs no knowledge of which parameter profile (gate_* vs
-        gate_preload_*) established it. _repark_evicted's reverse-home + park is solving a
-        different problem - a NEIGHBOR candidate whose post-eviction position is genuinely
-        less certain (freshly loaded, then jogged) - and reusing it here would silently
-        re-park THIS gate to the wrong (always-normal-profile) position when called from
-        preload's ratify. Do not merge the two.
-
-        Returns True if the field cleared under the self-jog, False if the tag is still seen
-        even after deliberately moving this gate's own filament further away and back.
-
-        Caller (_ratify) decides WHETHER it is safe/worth calling this at all (nonzero
-        distance, direction safe for the endstop in effect) - this method does no gating of
-        its own, only the motion and the probe.
+        Jog this gate's own already-parked filament 'distance' mm further, re-probe, jog
+        back. Plain jog-and-restore, not _repark_evicted's reverse-home+park (that's for a
+        freshly loaded neighbor whose position is less certain; reusing it here risks the
+        wrong profile's park). Returns True if the field cleared.
         """
-        self.mmu.select_gate(gate)  # _ratify runs before _restore_evicted's own reselect,
-                                    # so a neighbor may still be selected at this point
+        self.mmu.select_gate(gate)  # a neighbor may still be selected at this point
         with self.mmu.wrap_suspend_filament_monitoring():
             try:
                 self._jog_off(distance)
@@ -417,22 +287,17 @@ class MmuNfcFieldArbiter:
 
     # ---- Restore ------------------------------------------------------------------------------
 
-    # NOTE: _verify_by_self_jog (above) deliberately does NOT reuse this reverse-home + park
-    # restore for the gate under test - see its docstring for why (wrong profile risk). Don't
-    # "simplify" by merging the two.
+    # _verify_by_self_jog does NOT reuse this restore for the gate under test (wrong-profile risk).
     def _repark_evicted(self, gate, distance, evicted):
-        """The re-park half of _restore_evicted, in reverse eviction order."""
+        """Re-park half of _restore_evicted, reverse eviction order."""
         while evicted:
             candidate, saved_status = evicted.pop()
             try:
                 self.mmu.select_gate(candidate)
                 if distance > 0:
-                    # Filament is forward of the gate: reverse-home + park
-                    self.mmu._unload_gate(extra_homing=abs(distance))
+                    self.mmu._unload_gate(extra_homing=abs(distance)) # forward: reverse-home + park
                 else:
-                    # Filament is behind the gate: home forward back to the gate, then
-                    # reverse-home + park (reuses the proven parking, incl. encoder overshoot)
-                    self.mmu._load_gate(allow_retry=False)
+                    self.mmu._load_gate(allow_retry=False) # behind: home to gate, then reverse-home + park
                     self.mmu._unload_gate()
                 self.mmu.gate_maps.set_gate_status(candidate, saved_status)
             except Exception as e:
@@ -444,11 +309,7 @@ class MmuNfcFieldArbiter:
 
 
     def _restore_evicted(self, gate, distance, evicted):
-        """
-        Re-park every gate that was jogged aside, in reverse order, and restore its saved
-        gate_status. Always leaves 'gate' selected, as the caller expects - including when
-        eviction blew up part-way and left a neighbor selected.
-        """
+        """Re-park all evicted gates in reverse order; always leaves 'gate' selected."""
         if evicted:
             self._repark_evicted(gate, distance, evicted)
         try:
@@ -463,46 +324,22 @@ class MmuNfcFieldArbiter:
     @contextlib.contextmanager
     def clear_field(self, gate, nfc_mgr, endstop=None, clear_distance=0.0):
         """
-        Ensure gate 'gate's NFC reader field is settled for the duration of the enclosed
-        operation, temporarily jogging identified neighboring gates' filament off their park
-        position when arbitration has a motion budget for it.
+        Settle gate 'gate's NFC field for the enclosed operation, evicting neighbors when
+        armed.
 
-        'endstop' and 'clear_distance' both describe the CALLER's own context (see
-        MmuNfcFieldArbiter._ratify) - used only if ratification needs to escalate to a
-        deliberate self-jog: 'clear_distance' is the caller's own matching config value
-        (nfc_gate_clear_distance for a scan, nfc_preload_clear_distance for preload), and
-        'endstop' decides whether jogging it forward is safe. Both current callers always
-        pass both; a caller that forgets 'endstop' would be treated as "forward is safe"
-        (None is not a SHARED_GATE_ENDSTOPS member), so don't add a new caller without it.
+        'endstop'/'clear_distance' are the caller's own context (nfc_gate_clear_distance/
+        gate_homing_endstop for scan, nfc_preload_clear_distance/gate_preload_endstop for
+        preload) - used only if ratification escalates to a self-jog.
 
-        Yields a NfcFieldOutcome, whose 'verdict' is one of:
-            NFC_FIELD_CLEAR       nothing in the field, or arbitration isn't armed for this
-                                   gate (nfc_mgr is None) - either way the caller does exactly
-                                   what it always did.
-            NFC_FIELD_MINE        the tag is positively confirmed as this gate's own -
-                                   attributed immediately, as always, by the caller's own read.
-            NFC_FIELD_FOREIGN     a tag known not to be this gate's, uncleared - the caller
-                                   must not attribute it (see per-caller handling in
-                                   _preload_gate / _jog_scan). The outcome's 'reason' is a
-                                   short explanation a caller can embed directly in its own
-                                   error message (see MMU_NFC_SCAN's MmuError).
-            NFC_FIELD_PROVISIONAL an unregistered tag tentatively treated as MINE - the caller
-                                   proceeds as it would for MINE, EXCEPT a jog-scan must not
-                                   take its "already at reader" fast path, since there would be
-                                   nothing left to observe clearing. Any read the caller's
-                                   operation makes under this verdict is HELD, not committed
-                                   (see MmuNfcManager.hold_attribution) - committed only if
-                                   ratified once the caller's own natural motion has
-                                   completed, discarded otherwise. Only readable via the
-                                   outcome's 'ratified' attribute AFTER the `with` block
-                                   closes (see NfcFieldOutcome).
+        Yields a NfcFieldOutcome:
+            CLEAR       - nothing there, or arbitration not armed
+            MINE        - confirmed this gate's own, attributed immediately
+            FOREIGN     - known not this gate's; caller must not attribute (see outcome.reason)
+            PROVISIONAL - unregistered, tentatively mine; read is HELD until ratified after
+                          the `with` block (outcome.ratified, readable only afterward)
 
-        On exit, every jogged gate is re-parked and its prior gate_status restored, in reverse
-        order, even when the enclosed block raised, and 'gate' is left selected.
-
-        Filament monitoring is suspended around this method's own moves only, never across the
-        yield - both callers already suspend it inside their own enclosed block and that
-        contextmanager does not nest.
+        Re-parks evicted gates on exit, even on error, leaving 'gate' selected. Suspends
+        filament monitoring around its own moves only, never across the yield.
         """
         if nfc_mgr is None:
             yield NfcFieldOutcome(NFC_FIELD_CLEAR)
@@ -515,34 +352,28 @@ class MmuNfcFieldArbiter:
         try:
             with self.mmu.wrap_suspend_filament_monitoring():
                 verdict, reason = self._settle(gate, nfc_mgr, distance, evicted)
-                self.mmu.select_gate(gate) # The enclosed block runs on 'gate', as it did before
+                self.mmu.select_gate(gate)
             provisional = (verdict == NFC_FIELD_PROVISIONAL)
             outcome = NfcFieldOutcome(verdict, reason)
             if provisional:
-                # Hold any read the enclosed operation makes for this gate rather than let it
-                # commit immediately - whether it should be trusted at all isn't known until
-                # ratification re-probes below, once that operation's own motion is done.
+                # hold rather than commit - trust isn't known until ratification below
                 nfc_mgr.hold_attribution(gate)
             yield outcome
         finally:
-            # Ratify BEFORE restoring evicted neighbors: the ratification re-probe must see the
-            # field as the caller's own operation left it, not after neighbors are re-parked
-            # (which is itself extra motion that could disturb the reading). Guarded on its own:
-            # an unexpected error here must never skip the restore below and leave an evicted
-            # neighbor stranded off its park position, or leave a hold armed forever.
+            # ratify before restoring neighbors (restore is itself motion that could disturb
+            # the read); guarded so an error here can't skip the restore below
             if provisional:
                 try:
                     ratified = self._ratify(gate, nfc_mgr, endstop, clear_distance)
                 except Exception as e:
                     self.mmu.log_error("NFC: gate %d: ratification check failed: %s" % (gate, str(e)))
-                    ratified = False # Safer to discard an unconfirmed read than commit it blind
+                    ratified = False # safer to discard than commit blind
                 if outcome is not None:
                     outcome.ratified = ratified
                 if ratified:
                     nfc_mgr.release_held_attribution()
                 else:
                     nfc_mgr.discard_held_attribution()
-            # Unconditional: eviction/settling can raise part-way with a neighbor selected and
-            # nothing yet recorded in 'evicted', and the caller must still get its gate back.
+            # unconditional: must restore even if settling raised before recording anything
             with self.mmu.wrap_suspend_filament_monitoring():
                 self._restore_evicted(gate, distance, evicted)

--- a/extras/mmu/mmu_nfc_arbiter.py
+++ b/extras/mmu/mmu_nfc_arbiter.py
@@ -198,18 +198,24 @@ class MmuNfcFieldArbiter:
 
     def _jog_off(self, distance):
         """
-        Move the CURRENTLY SELECTED gate's filament 'distance' mm off the gate reference so
-        its RFID tag leaves a *neighboring* gate's reader field. Signed: positive travels
-        forward of the gate, negative behind it. Assumes the filament is homed at the gate
-        (the caller does _load_gate() first).
+        Move the CURRENTLY SELECTED gate's filament 'distance' mm off its reference position.
+        Signed: positive travels forward of the gate, negative behind it. Assumes the
+        filament is homed at the gate or already parked (the caller is responsible for
+        getting it there first - _load_gate() for a fresh neighbor candidate, or nothing
+        further for a gate already sitting at its own park).
 
         A plain move, not a homing move - there is nothing to home against here, the whole
         point is to travel past wherever the tag currently sits.
+
+        Used both to evict a *neighboring* gate's tag out of a different gate's reader field
+        (_evict_one), and to deliberately jog THIS gate's own filament during self-jog
+        ratification (_verify_by_self_jog) - the motion is identical either way, only the
+        reason differs, so the log message below stays purpose-agnostic.
         """
-        self.mmu.log_debug("NFC: gate %d: jogging %.0fmm %s to clear a neighbor's reader field"
+        self.mmu.log_debug("NFC: gate %d: jogging %.0fmm %s off its park reference"
                             % (self.mmu.gate_selected, abs(distance),
                                "forward" if distance > 0 else "back"))
-        self.mmu.move_filament("NFC: neighbor evict", distance, motor="gear")
+        self.mmu.move_filament("NFC: gate jog", distance, motor="gear")
 
 
     def _evict_one(self, gate, candidate, distance, evicted):
@@ -291,7 +297,7 @@ class MmuNfcFieldArbiter:
 
     # ---- Provisional-verdict ratification ------------------------------------------------------
 
-    def _ratify(self, gate, nfc_mgr):
+    def _ratify(self, gate, nfc_mgr, endstop):
         """
         Re-probe gate 'gate's reader once, after the caller's own natural motion (preload's
         homing+park, or a jog-scan's sweep with its fast path suppressed) has completed, to
@@ -305,15 +311,45 @@ class MmuNfcFieldArbiter:
         guard against. The only question that isn't circular either way is "is anything still
         there".
 
-        The caller (clear_field) uses this return value to decide whether to commit the held
-        read (release_held_attribution) or drop it (discard_held_attribution) - nothing is
-        attributed to the wrong gate here, it just hasn't been committed yet either way.
+        If that passive check still finds a tag, and there is a motion budget
+        (nfc_neighbor_evict_distance != 0) that is safe to spend in this direction for
+        'endstop' (see _verify_by_self_jog), escalate to a deliberate causal test rather than
+        settling for "whatever the operation's own incidental motion happened to leave
+        behind" - a tag physically mounted such that it stays in range at the normal park
+        position would otherwise fail the passive check every single time, forever, even
+        when it is genuinely this gate's own spool. 'endstop' is the caller's own homing
+        endstop (gate_preload_endstop for preload, gate_homing_endstop for a scan) - expected
+        non-None whenever the verdict reaching here is NFC_FIELD_PROVISIONAL; both current
+        callers always pass it.
+
+        The caller (clear_field) uses the final return value to decide whether to commit the
+        held read (release_held_attribution) or drop it (discard_held_attribution) - nothing
+        is attributed to the wrong gate here, it just hasn't been committed yet either way.
         """
         uid = nfc_mgr.probe_gate_field(gate)
         if not uid:
             self.mmu.log_debug("NFC: gate %d: provisional tag attribution ratified (field "
                                 "clear after the operation's own motion)" % gate)
             return True
+
+        distance = self.mmu.mmu_unit(gate).p.nfc_neighbor_evict_distance
+        if distance and not (distance > 0 and endstop in SHARED_GATE_ENDSTOPS):
+            if self._verify_by_self_jog(gate, nfc_mgr, distance):
+                self.mmu.log_debug(
+                    "NFC: gate %d: provisional tag attribution ratified via a deliberate "
+                    "self-jog (field cleared when this gate's own filament was jogged %.0fmm "
+                    "further off its park position, and returned to it)" % (gate, abs(distance)))
+                return True
+            self.mmu.log_warning(
+                "NFC: gate %d: could not confirm this gate's own tag - the reader still shows "
+                "tag %s even after gate %d's own filament was deliberately jogged %.0fmm "
+                "further off its park position and back, so the read is being discarded "
+                "rather than attributed. If this is a new/unregistered spool, re-run once the "
+                "neighboring gate's spool has been moved or registered" % (gate, uid, gate, abs(distance)))
+            return False
+
+        # No motion budget, or the direction isn't safe for this endstop - plain discard,
+        # wording unchanged from before self-jog escalation existed.
         self.mmu.log_warning(
             "NFC: gate %d: could not confirm this gate's own tag - the reader still shows "
             "tag %s after gate %d's own filament settled, so the read is being discarded "
@@ -322,8 +358,58 @@ class MmuNfcFieldArbiter:
         return False
 
 
+    def _verify_by_self_jog(self, gate, nfc_mgr, distance):
+        """
+        Escalate the passive ratification check into a deliberate, causal one: jog gate's own
+        already-parked filament ANOTHER 'distance' mm further off its park position (reusing
+        nfc_neighbor_evict_distance's own sign/direction convention - same value, same
+        meaning, no new config parameter), re-probe, and see whether detection tracks that
+        deliberate motion. This is materially stronger evidence than the passive check alone,
+        which only observes whatever incidental settling the caller's own necessary motion
+        happened to produce.
+
+        Deliberately reuses _jog_off (called once forward, once reversed) rather than a
+        homing-based restore like _repark_evicted's: at this point the filament is sitting at
+        a precisely known position (the caller's own park move, executed moments earlier, is
+        itself a plain dead-reckoned move - see _park_at_gate's "Final parking" - not a
+        homing move), so an equal-and-opposite plain jog is exactly as trustworthy as that
+        just-established park and needs no knowledge of which parameter profile (gate_* vs
+        gate_preload_*) established it. _repark_evicted's reverse-home + park is solving a
+        different problem - a NEIGHBOR candidate whose post-eviction position is genuinely
+        less certain (freshly loaded, then jogged) - and reusing it here would silently
+        re-park THIS gate to the wrong (always-normal-profile) position when called from
+        preload's ratify. Do not merge the two.
+
+        Returns True if the field cleared under the self-jog, False if the tag is still seen
+        even after deliberately moving this gate's own filament further away and back.
+
+        Caller (_ratify) decides WHETHER it is safe/worth calling this at all (nonzero
+        distance, direction safe for the endstop in effect) - this method does no gating of
+        its own, only the motion and the probe.
+        """
+        self.mmu.select_gate(gate)  # _ratify runs before _restore_evicted's own reselect,
+                                    # so a neighbor may still be selected at this point
+        with self.mmu.wrap_suspend_filament_monitoring():
+            try:
+                self._jog_off(distance)
+                try:
+                    uid = nfc_mgr.probe_gate_field(gate)
+                finally:
+                    self._jog_off(-distance)
+            except Exception as e:
+                self.mmu.gate_maps.set_gate_status(gate, GATE_UNKNOWN)
+                self.mmu.log_error(
+                    "NFC: gate %d: self-jog verification move failed: %s. Gate marked "
+                    "unknown - check for a jam" % (gate, str(e)))
+                raise
+        return not uid
+
+
     # ---- Restore ------------------------------------------------------------------------------
 
+    # NOTE: _verify_by_self_jog (above) deliberately does NOT reuse this reverse-home + park
+    # restore for the gate under test - see its docstring for why (wrong profile risk). Don't
+    # "simplify" by merging the two.
     def _repark_evicted(self, gate, distance, evicted):
         """The re-park half of _restore_evicted, in reverse eviction order."""
         while evicted:
@@ -365,11 +451,18 @@ class MmuNfcFieldArbiter:
     # ---- Public entry point ---------------------------------------------------------------------
 
     @contextlib.contextmanager
-    def clear_field(self, gate, nfc_mgr):
+    def clear_field(self, gate, nfc_mgr, endstop=None):
         """
         Ensure gate 'gate's NFC reader field is settled for the duration of the enclosed
         operation, temporarily jogging identified neighboring gates' filament off their park
         position when arbitration has a motion budget for it.
+
+        'endstop' is the caller's own homing endstop for this operation (gate_preload_endstop
+        for preload, gate_homing_endstop for a scan) - used only if ratification needs to
+        escalate to a deliberate self-jog, to decide whether a forward jog is safe (see
+        MmuNfcFieldArbiter._ratify). Both current callers always pass it; a caller that
+        forgets to would be treated as "forward is safe" (None is not a SHARED_GATE_ENDSTOPS
+        member), so don't add a new caller without it.
 
         Yields a NfcFieldOutcome, whose 'verdict' is one of:
             NFC_FIELD_CLEAR       nothing in the field, or arbitration isn't armed for this
@@ -428,7 +521,7 @@ class MmuNfcFieldArbiter:
             # neighbor stranded off its park position, or leave a hold armed forever.
             if provisional:
                 try:
-                    ratified = self._ratify(gate, nfc_mgr)
+                    ratified = self._ratify(gate, nfc_mgr, endstop)
                 except Exception as e:
                     self.mmu.log_error("NFC: gate %d: ratification check failed: %s" % (gate, str(e)))
                     ratified = False # Safer to discard an unconfirmed read than commit it blind

--- a/extras/mmu/mmu_nfc_arbiter.py
+++ b/extras/mmu/mmu_nfc_arbiter.py
@@ -26,10 +26,12 @@
 # clear_field() context manager and an arm check, so this bookkeeping doesn't grow those
 # already-large functions further.
 #
-# Off by default: neither nfc_neighbor_check nor nfc_neighbor_evict_distance is armed out of
-# the box, and clear_field() is an inert passthrough when arbitration isn't armed for a gate -
-# a stock machine does no extra reader I/O and behaves exactly as it did before this module
-# existed.
+# Off by default: none of nfc_neighbor_check, nfc_neighbor_evict_distance, or
+# nfc_self_verify_distance is armed out of the box, and clear_field() is an inert passthrough
+# when arbitration isn't armed for a gate - a stock machine does no extra reader I/O and
+# behaves exactly as it did before this module existed. nfc_self_verify_distance is
+# independent of the other two - it controls only whether _ratify() escalates a PROVISIONAL
+# verdict to a deliberate self-jog, not neighbor eviction.
 #
 # (\_/)
 # ( *,*)
@@ -312,7 +314,8 @@ class MmuNfcFieldArbiter:
         there".
 
         If that passive check still finds a tag, and there is a motion budget
-        (nfc_neighbor_evict_distance != 0) that is safe to spend in this direction for
+        (nfc_self_verify_distance != 0 - independent of nfc_neighbor_evict_distance, which
+        only governs neighbor eviction) that is safe to spend in this direction for
         'endstop' (see _verify_by_self_jog), escalate to a deliberate causal test rather than
         settling for "whatever the operation's own incidental motion happened to leave
         behind" - a tag physically mounted such that it stays in range at the normal park
@@ -332,7 +335,7 @@ class MmuNfcFieldArbiter:
                                 "clear after the operation's own motion)" % gate)
             return True
 
-        distance = self.mmu.mmu_unit(gate).p.nfc_neighbor_evict_distance
+        distance = self.mmu.mmu_unit(gate).p.nfc_self_verify_distance
         if distance and not (distance > 0 and endstop in SHARED_GATE_ENDSTOPS):
             if self._verify_by_self_jog(gate, nfc_mgr, distance):
                 self.mmu.log_debug(
@@ -361,12 +364,12 @@ class MmuNfcFieldArbiter:
     def _verify_by_self_jog(self, gate, nfc_mgr, distance):
         """
         Escalate the passive ratification check into a deliberate, causal one: jog gate's own
-        already-parked filament ANOTHER 'distance' mm further off its park position (reusing
-        nfc_neighbor_evict_distance's own sign/direction convention - same value, same
-        meaning, no new config parameter), re-probe, and see whether detection tracks that
-        deliberate motion. This is materially stronger evidence than the passive check alone,
-        which only observes whatever incidental settling the caller's own necessary motion
-        happened to produce.
+        already-parked filament ANOTHER 'distance' mm further off its park position
+        (nfc_self_verify_distance's sign/direction convention - independent of, but shaped
+        the same way as, nfc_neighbor_evict_distance), re-probe, and see whether detection
+        tracks that deliberate motion. This is materially stronger evidence than the passive
+        check alone, which only observes whatever incidental settling the caller's own
+        necessary motion happened to produce.
 
         Deliberately reuses _jog_off (called once forward, once reversed) rather than a
         homing-based restore like _repark_evicted's: at this point the filament is sitting at

--- a/extras/mmu/mmu_nfc_arbiter.py
+++ b/extras/mmu/mmu_nfc_arbiter.py
@@ -216,7 +216,8 @@ class MmuNfcFieldArbiter:
 
     # ---- Provisional-verdict ratification ------------------------------------------------------
 
-    def _ratify(self, gate, nfc_mgr, endstop, clear_distance=0.0):
+    def _ratify(self, gate, nfc_mgr, endstop, clear_distance=0.0,
+                parking_distance=None, homing_max=None):
         """
         Re-probe once after the caller's own motion completes, to confirm/reject a
         PROVISIONAL verdict. Raw presence check, not _field_check - re-deriving ownership
@@ -237,7 +238,14 @@ class MmuNfcFieldArbiter:
             return True
 
         distance = clear_distance
-        if distance and not (distance > 0 and endstop in SHARED_GATE_ENDSTOPS):
+        safe_reach = (
+            homing_max is None
+            or (abs(distance) <= homing_max
+                and (parking_distance is None
+                     or parking_distance + distance >= -homing_max))
+        )
+        if (distance and safe_reach
+                and not (distance > 0 and endstop in SHARED_GATE_ENDSTOPS)):
             if self._verify_by_self_jog(gate, nfc_mgr, distance):
                 self.mmu.log_debug(
                     "NFC: gate %d: provisional tag attribution ratified via a deliberate "
@@ -322,7 +330,8 @@ class MmuNfcFieldArbiter:
     # ---- Public entry point ---------------------------------------------------------------------
 
     @contextlib.contextmanager
-    def clear_field(self, gate, nfc_mgr, endstop=None, clear_distance=0.0):
+    def clear_field(self, gate, nfc_mgr, endstop=None, clear_distance=0.0,
+                    parking_distance=None, homing_max=None):
         """
         Settle gate 'gate's NFC field for the enclosed operation, evicting neighbors when
         armed.
@@ -364,7 +373,9 @@ class MmuNfcFieldArbiter:
             # the read); guarded so an error here can't skip the restore below
             if provisional:
                 try:
-                    ratified = self._ratify(gate, nfc_mgr, endstop, clear_distance)
+                    ratified = self._ratify(
+                        gate, nfc_mgr, endstop, clear_distance,
+                        parking_distance, homing_max)
                 except Exception as e:
                     self.mmu.log_error("NFC: gate %d: ratification check failed: %s" % (gate, str(e)))
                     ratified = False # safer to discard than commit blind

--- a/extras/mmu/unit/mmu_unit_parameters.py
+++ b/extras/mmu/unit/mmu_unit_parameters.py
@@ -74,12 +74,29 @@ class MmuUnitParameters(TunableParametersBase):
             self._validate_gate_parking_distance(self.gate_parking_distance)
             if not self.gate_preload_endstop:
                 self._validate_gate_preload_parking_distance(self.gate_preload_parking_distance)
+                self._validate_nfc_preload_clear_distance(self.nfc_preload_clear_distance)
             self._validate_nfc_neighbor_evict_distance(self.nfc_neighbor_evict_distance)
             self._validate_nfc_gate_clear_distance(self.nfc_gate_clear_distance)
 
     def _on_gate_preload_endstop(self, old, new):
         if new != old:
             self._validate_gate_preload_parking_distance(self.gate_preload_parking_distance)
+            self._validate_nfc_preload_clear_distance(self.nfc_preload_clear_distance)
+
+    def _on_gate_homing_max(self, old, new):
+        if new != old:
+            self._validate_nfc_gate_clear_distance(self.nfc_gate_clear_distance)
+
+    def _on_gate_parking_distance(self, old, new):
+        if new != old:
+            self._validate_nfc_gate_clear_distance(self.nfc_gate_clear_distance)
+
+    def _on_gate_preload_homing_max(self, old, new):
+        if new != old:
+            self._validate_nfc_preload_clear_distance(self.nfc_preload_clear_distance)
+
+    def _on_gate_preload_parking_distance(self, old, new):
+        if new != old:
             self._validate_nfc_preload_clear_distance(self.nfc_preload_clear_distance)
 
     def _on_flowguard_tuning_change(self, old, new):
@@ -153,9 +170,12 @@ class MmuUnitParameters(TunableParametersBase):
                 % (SENSOR_EXIT_PREFIX, self.gate_homing_endstop, value))
 
     def _validate_nfc_gate_clear_distance(self, value):
-        # 0 disables; park-relative jog-and-restore, no window-fit check (no re-home involved)
+        # 0 disables; park-relative jog-and-restore, bounded by the gate homing budget
         if not value:
             return
+        self._validate_nfc_clear_reach(
+            'nfc_gate_clear_distance', value, self.gate_parking_distance,
+            self.gate_homing_max)
         if value > 0 and self.gate_homing_endstop in SHARED_GATE_ENDSTOPS:
             raise ValueError(
                 "nfc_gate_clear_distance must be a backward jog (< 0) unless "
@@ -167,12 +187,29 @@ class MmuUnitParameters(TunableParametersBase):
         # 0 disables; independent of nfc_gate_clear_distance, can differ including in sign
         if not value:
             return
+        self._validate_nfc_clear_reach(
+            'nfc_preload_clear_distance', value, self.gate_preload_parking_distance,
+            self.gate_preload_homing_max)
         endstop = self.gate_preload_endstop or self.gate_homing_endstop # '' inherits gate_homing_endstop
         if value > 0 and endstop in SHARED_GATE_ENDSTOPS:
             raise ValueError(
                 "nfc_preload_clear_distance must be a backward jog (< 0) unless the preload "
                 "endstop is '%s' - every gate shares the forward path through '%s' (got %.1f)"
                 % (SENSOR_EXIT_PREFIX, endstop, value))
+
+    def _validate_nfc_clear_reach(self, name, value, parking_distance, homing_max):
+        # The move is relative to park, but both its magnitude and its furthest backward
+        # target must stay inside the profile's configured recovery reach. Otherwise the
+        # open-loop return can lose the filament after retracting it out of the drive.
+        target = parking_distance + value
+        if abs(value) > homing_max:
+            raise ValueError(
+                "%s jog magnitude (%.1fmm) cannot exceed its homing maximum (%.1fmm)"
+                % (name, abs(value), homing_max))
+        if target < -homing_max:
+            raise ValueError(
+                "%s reaches %.1fmm behind the homing datum after parking, beyond its "
+                "homing maximum (%.1fmm)" % (name, target, homing_max))
 
     # Parking distance sign convention: -ve = retraction (toward the gate/gears), +ve =
     # extrusion (forward, past the sensor). Parking forward past the sensor is only safe
@@ -200,14 +237,14 @@ class MmuUnitParameters(TunableParametersBase):
     _SPECS: Sequence[ParamSpec] = (
         # Gate loading
         ParamSpec('gate_homing_endstop',              'choice', SENSOR_ENCODER, section="GATE HOMING", choices={o: o for o in GATE_ENDSTOPS}, on_change=_on_gate_homing_endstop),
-        ParamSpec('gate_homing_max',                  'float', 100.0, section="GATE HOMING", limits=dict(minval=10)),
-        ParamSpec('gate_parking_distance',            'float', -10.0, section="GATE HOMING", validator=_validate_gate_parking_distance),
+        ParamSpec('gate_homing_max',                  'float', 100.0, section="GATE HOMING", limits=dict(minval=10), on_change=_on_gate_homing_max),
+        ParamSpec('gate_parking_distance',            'float', -10.0, section="GATE HOMING", validator=_validate_gate_parking_distance, on_change=_on_gate_parking_distance),
         ParamSpec('gate_load_attempts',               'int',       1, section="GATE HOMING", limits=dict(minval=1, maxval=20)),
 
         # Gate preloading
         ParamSpec('gate_preload_endstop',             'choice',   '', section="GATE HOMING", choices={o: o for o in (GATE_ENDSTOPS + [''])}, on_change=_on_gate_preload_endstop),
-        ParamSpec('gate_preload_homing_max',          'float', lambda self: self.gate_homing_max, section="GATE HOMING"),
-        ParamSpec('gate_preload_parking_distance',    'float', -10.0, section="GATE HOMING", validator=_validate_gate_preload_parking_distance),
+        ParamSpec('gate_preload_homing_max',          'float', lambda self: self.gate_homing_max, section="GATE HOMING", on_change=_on_gate_preload_homing_max),
+        ParamSpec('gate_preload_parking_distance',    'float', -10.0, section="GATE HOMING", validator=_validate_gate_preload_parking_distance, on_change=_on_gate_preload_parking_distance),
         ParamSpec('gate_preload_attempts',            'int',       2, section="GATE HOMING", limits=dict(minval=1, maxval=20)),
         ParamSpec('gate_autoload',                    'int',       1, section="GATE HOMING", limits=dict(minval=0, maxval=1)),
 

--- a/extras/mmu/unit/mmu_unit_parameters.py
+++ b/extras/mmu/unit/mmu_unit_parameters.py
@@ -84,12 +84,15 @@ class MmuUnitParameters(TunableParametersBase):
             # (see _validate_nfc_neighbor_evict_distance) - same reasoning as the parking
             # distance re-checks just above.
             self._validate_nfc_neighbor_evict_distance(self.nfc_neighbor_evict_distance)
-            # Same reasoning again for the independent self-verify distance.
-            self._validate_nfc_self_verify_distance(self.nfc_self_verify_distance)
+            # Same reasoning again for the gate-context clear distance.
+            self._validate_nfc_gate_clear_distance(self.nfc_gate_clear_distance)
 
     def _on_gate_preload_endstop(self, old, new):
         if new != old:
             self._validate_gate_preload_parking_distance(self.gate_preload_parking_distance)
+            # nfc_preload_clear_distance's forward-jog legality depends on this endstop, same
+            # reasoning as nfc_gate_clear_distance above.
+            self._validate_nfc_preload_clear_distance(self.nfc_preload_clear_distance)
 
     def _on_flowguard_tuning_change(self, old, new):
         # Push live FlowGuard tuning (relief) to a running controller
@@ -183,41 +186,36 @@ class MmuUnitParameters(TunableParametersBase):
                 "'%s' (got %.1f)"
                 % (SENSOR_EXIT_PREFIX, self.gate_homing_endstop, value))
 
-    def _validate_nfc_self_verify_distance(self, value):
-        # 0 disables self-jog ratification entirely - independent of nfc_neighbor_evict_distance,
-        # so a machine can have one without the other (see MmuNfcFieldArbiter._ratify).
+    def _validate_nfc_gate_clear_distance(self, value):
+        # 0 disables self-jog ratification entirely for MMU_NFC_SCAN - independent of
+        # nfc_neighbor_evict_distance and of nfc_preload_clear_distance below, so a machine
+        # can arm any combination of these (see MmuNfcFieldArbiter._ratify).
         if not value:
             return
-        window = self.nfc_gate_jog_scan_window
-        if not window or len(window) != 2 or (window[0] == 0 and window[1] == 0):
-            raise ValueError(
-                "nfc_self_verify_distance requires nfc_gate_jog_scan_window to be "
-                "configured - the self-jog travels within that same window regardless of "
-                "which operation (preload or MMU_NFC_SCAN) it is protecting")
-        neg, pos = window[0], window[1]
-        # Same physical travel corridor as the eviction jog above - it must fit inside the
-        # matching half of the window that already bounds nfc_gate_jog_scan_window itself.
-        if value > pos:
-            raise ValueError(
-                "nfc_self_verify_distance forward jog (%.1fmm) cannot exceed the forward "
-                "reach of nfc_gate_jog_scan_window (%.1fmm)" % (value, pos))
-        if value < neg:
-            raise ValueError(
-                "nfc_self_verify_distance backward jog (%.1fmm) cannot exceed the backward "
-                "reach of nfc_gate_jog_scan_window (%.1fmm)" % (value, neg))
-        # Same forward-jog restriction as nfc_neighbor_evict_distance, checked here against
-        # gate_homing_endstop as a baseline sanity check (matches a plain MMU_NFC_SCAN). The
-        # self-jog can also run from preload's ratify, where the gate is actually parked via
-        # gate_preload_endstop instead - that combination can't be caught at config time (it
-        # depends on which operation is running), so MmuNfcFieldArbiter._ratify re-checks the
-        # ACTUAL endstop in effect at runtime and skips escalation there if it's unsafe. This
-        # static check stays as a first line of defence against the common misconfiguration.
+        # No window-fit check: unlike neighbor eviction, this jog and its restore are both
+        # plain relative moves off the already-established park position (see
+        # MmuNfcFieldArbiter._verify_by_self_jog) - there is no re-home involved and so no
+        # re-homing budget this needs to fit inside. Deliberately left to the user to size
+        # sensibly for their machine.
         if value > 0 and self.gate_homing_endstop in SHARED_GATE_ENDSTOPS:
             raise ValueError(
-                "nfc_self_verify_distance must be a backward jog (< 0) unless "
+                "nfc_gate_clear_distance must be a backward jog (< 0) unless "
                 "gate_homing_endstop is '%s' - every gate shares the forward path through "
                 "'%s' (got %.1f)"
                 % (SENSOR_EXIT_PREFIX, self.gate_homing_endstop, value))
+
+    def _validate_nfc_preload_clear_distance(self, value):
+        # 0 disables self-jog ratification entirely for MMU_PRELOAD - independent of the
+        # gate-context distance above, since preload can home/park via a different endstop
+        # and may need a different (even oppositely-signed) clear jog.
+        if not value:
+            return
+        endstop = self.gate_preload_endstop or self.gate_homing_endstop # '' inherits gate_homing_endstop
+        if value > 0 and endstop in SHARED_GATE_ENDSTOPS:
+            raise ValueError(
+                "nfc_preload_clear_distance must be a backward jog (< 0) unless the preload "
+                "endstop is '%s' - every gate shares the forward path through '%s' (got %.1f)"
+                % (SENSOR_EXIT_PREFIX, endstop, value))
 
     # Parking distance sign convention: -ve = retraction (toward the gate/gears), +ve =
     # extrusion (forward, past the sensor). Parking forward past the sensor is only safe
@@ -265,10 +263,14 @@ class MmuUnitParameters(TunableParametersBase):
         ParamSpec('nfc_neighbor_check',                'int',    0,    section="NFC", limits=dict(minval=0, maxval=1)),
         # Declared after nfc_gate_jog_scan_window so the validator can cross-check it
         ParamSpec('nfc_neighbor_evict_distance',       'float',  0.0,  section="NFC", validator=_validate_nfc_neighbor_evict_distance),
-        # Independent of nfc_neighbor_evict_distance above - controls only the self-jog
-        # ratification escalation (MmuNfcFieldArbiter._verify_by_self_jog), not neighbor
-        # eviction. Off by default; a machine can arm either, both, or neither.
-        ParamSpec('nfc_self_verify_distance',          'float',  0.0,  section="NFC", validator=_validate_nfc_self_verify_distance),
+        # Independent of nfc_neighbor_evict_distance and of each other - each controls only
+        # its own operation's self-jog ratification escalation (MmuNfcFieldArbiter._ratify /
+        # _verify_by_self_jog), not neighbor eviction. Off by default; a machine can arm any
+        # combination. nfc_preload_clear_distance defaults to nfc_gate_clear_distance (same
+        # pattern as nfc_preload_jog_scan_window defaulting to nfc_gate_jog_scan_window) since
+        # preload usually - but not always - wants the same clear jog as a plain scan.
+        ParamSpec('nfc_gate_clear_distance',           'float',  0.0,  section="NFC", validator=_validate_nfc_gate_clear_distance),
+        ParamSpec('nfc_preload_clear_distance',        'float',  lambda self: self.nfc_gate_clear_distance, section="NFC", validator=_validate_nfc_preload_clear_distance),
         ParamSpec('nfc_field_probe_reads',              'int',    3,    section="NFC", limits=dict(minval=1, maxval=10)),
         ParamSpec('nfc_deep_read',                    'int',    0,    section="NFC", limits=dict(minval=0, maxval=1)),
         ParamSpec('nfc_led_segment',                  'str',  'auto', section="NFC"),

--- a/extras/mmu/unit/mmu_unit_parameters.py
+++ b/extras/mmu/unit/mmu_unit_parameters.py
@@ -70,28 +70,16 @@ class MmuUnitParameters(TunableParametersBase):
     def _on_gate_homing_endstop(self, old, new):
         if new != old:
             self._mmu_unit.calibrator.adjust_bowden_lengths_on_homing_change()
-            # gate_parking_distance's legal sign depends on this endstop (see
-            # _validate_gate_parking_distance) - a value that was fine for the old endstop
-            # can be unsafe for the new one (e.g. a positive park, fine on mmu_exit, driving
-            # forward into a now-shared merge zone on encoder/mmu_shared_exit/extruder_entry).
-            # Re-check it now rather than leaving a stale, now-unsafe value in place until
-            # something else happens to touch it. Same for gate_preload_parking_distance
-            # when gate_preload_endstop is '' and so inherits this one.
+            # re-check values whose legal sign/direction depends on this endstop
             self._validate_gate_parking_distance(self.gate_parking_distance)
             if not self.gate_preload_endstop:
                 self._validate_gate_preload_parking_distance(self.gate_preload_parking_distance)
-            # nfc_neighbor_evict_distance's forward-jog legality depends on this endstop too
-            # (see _validate_nfc_neighbor_evict_distance) - same reasoning as the parking
-            # distance re-checks just above.
             self._validate_nfc_neighbor_evict_distance(self.nfc_neighbor_evict_distance)
-            # Same reasoning again for the gate-context clear distance.
             self._validate_nfc_gate_clear_distance(self.nfc_gate_clear_distance)
 
     def _on_gate_preload_endstop(self, old, new):
         if new != old:
             self._validate_gate_preload_parking_distance(self.gate_preload_parking_distance)
-            # nfc_preload_clear_distance's forward-jog legality depends on this endstop, same
-            # reasoning as nfc_gate_clear_distance above.
             self._validate_nfc_preload_clear_distance(self.nfc_preload_clear_distance)
 
     def _on_flowguard_tuning_change(self, old, new):
@@ -108,7 +96,7 @@ class MmuUnitParameters(TunableParametersBase):
     # ---- Validators ----
 
     def _validate_nfc_gate_jog_scan_window(self, value):
-        # Empty (or absent) disables MMU_NFC_SCAN
+        # empty disables MMU_NFC_SCAN; values are targets from the homing datum, not park
         if not value:
             return
         if len(value) != 2:
@@ -116,28 +104,15 @@ class MmuUnitParameters(TunableParametersBase):
         neg, pos = value[0], value[1]
         if neg > 0 or pos < 0:
             raise ValueError("nfc_gate_jog_scan_window must be (neg, pos) with neg <= 0 <= pos")
-        # Both values are TARGETS measured from the gate homing point, not from the parked
-        # position: _jog_scan homes to the gate for a datum first, then sweeps to gate+neg
-        # and gate+pos.
-        #
-        # The return leg no longer constrains this - _load_gate() takes an extra_homing
-        # budget now, so it scales with however far the sweep strayed. What is still worth
-        # rejecting is a backward reach beyond the machine's own gate homing budget, which
-        # means pulling filament further back than gate homing was ever configured to
-        # recover. (The positive side is deliberately left unchecked so no configuration
-        # that loads today stops loading; see the note in the plan.)
         if abs(neg) > self.gate_homing_max:
             raise ValueError(
                 "nfc_gate_jog_scan_window backward reach (%.1fmm) cannot exceed gate_homing_max (%.1fmm)"
                 % (abs(neg), self.gate_homing_max)
             )
-        # Note: a forward reach past a SHARED gate datum is deliberately not rejected here.
-        # Whether that is safe depends on the shared path being unoccupied, which is a
-        # runtime property this validator cannot see. Nothing checks it at scan time
-        # either - a sweep forward of a shared datum can meet another gate's filament.
+        # forward reach past a shared datum is deliberately not rejected here (runtime-only property)
 
     def _validate_nfc_preload_jog_scan_window(self, value):
-        # Empty (or absent) disables the NFC scan-on-miss during MMU_PRELOAD
+        # empty disables scan-on-miss during MMU_PRELOAD; datum-relative like the gate window
         if not value:
             return
         if len(value) != 2:
@@ -145,9 +120,6 @@ class MmuUnitParameters(TunableParametersBase):
         neg, pos = value[0], value[1]
         if neg > 0 or pos < 0:
             raise ValueError("nfc_preload_jog_scan_window must be (neg, pos) with neg <= 0 <= pos")
-        # Same TARGETS-from-the-gate-datum semantics as nfc_gate_jog_scan_window, but
-        # checked against the preload homing budget - preload can home to a different
-        # endstop (e.g. the per-gate mmu_exit sensor) with its own recovery budget.
         if abs(neg) > self.gate_preload_homing_max:
             raise ValueError(
                 "nfc_preload_jog_scan_window backward reach (%.1fmm) cannot exceed gate_preload_homing_max (%.1fmm)"
@@ -155,7 +127,7 @@ class MmuUnitParameters(TunableParametersBase):
             )
 
     def _validate_nfc_neighbor_evict_distance(self, value):
-        # 0 disables neighbor eviction entirely
+        # 0 disables eviction; datum-relative, must fit the gate jog scan window
         if not value:
             return
         window = self.nfc_gate_jog_scan_window
@@ -165,8 +137,6 @@ class MmuUnitParameters(TunableParametersBase):
                 "configured - the eviction jog travels within that same window regardless "
                 "of which operation (preload or MMU_NFC_SCAN) it is protecting")
         neg, pos = window[0], window[1]
-        # The eviction jog is the same physical travel as a scan jog, so it must fit inside
-        # the matching half of the window that already bounds nfc_gate_jog_scan_window itself
         if value > pos:
             raise ValueError(
                 "nfc_neighbor_evict_distance forward jog (%.1fmm) cannot exceed the forward "
@@ -175,10 +145,6 @@ class MmuUnitParameters(TunableParametersBase):
             raise ValueError(
                 "nfc_neighbor_evict_distance backward jog (%.1fmm) cannot exceed the backward "
                 "reach of nfc_gate_jog_scan_window (%.1fmm)" % (value, neg))
-        # A forward jog pushes the evicted neighbor's filament past its own gate. That is
-        # only safe when each gate has its own exit path (gate_homing_endstop == mmu_exit);
-        # every other gate endstop is a per-UNIT shared resource (SHARED_GATE_ENDSTOPS), so a
-        # forward jog would obstruct another gate (see the gate-endstop-invariants skill).
         if value > 0 and self.gate_homing_endstop in SHARED_GATE_ENDSTOPS:
             raise ValueError(
                 "nfc_neighbor_evict_distance must be a backward jog (< 0) unless "
@@ -187,16 +153,9 @@ class MmuUnitParameters(TunableParametersBase):
                 % (SENSOR_EXIT_PREFIX, self.gate_homing_endstop, value))
 
     def _validate_nfc_gate_clear_distance(self, value):
-        # 0 disables self-jog ratification entirely for MMU_NFC_SCAN - independent of
-        # nfc_neighbor_evict_distance and of nfc_preload_clear_distance below, so a machine
-        # can arm any combination of these (see MmuNfcFieldArbiter._ratify).
+        # 0 disables; park-relative jog-and-restore, no window-fit check (no re-home involved)
         if not value:
             return
-        # No window-fit check: unlike neighbor eviction, this jog and its restore are both
-        # plain relative moves off the already-established park position (see
-        # MmuNfcFieldArbiter._verify_by_self_jog) - there is no re-home involved and so no
-        # re-homing budget this needs to fit inside. Deliberately left to the user to size
-        # sensibly for their machine.
         if value > 0 and self.gate_homing_endstop in SHARED_GATE_ENDSTOPS:
             raise ValueError(
                 "nfc_gate_clear_distance must be a backward jog (< 0) unless "
@@ -205,9 +164,7 @@ class MmuUnitParameters(TunableParametersBase):
                 % (SENSOR_EXIT_PREFIX, self.gate_homing_endstop, value))
 
     def _validate_nfc_preload_clear_distance(self, value):
-        # 0 disables self-jog ratification entirely for MMU_PRELOAD - independent of the
-        # gate-context distance above, since preload can home/park via a different endstop
-        # and may need a different (even oppositely-signed) clear jog.
+        # 0 disables; independent of nfc_gate_clear_distance, can differ including in sign
         if not value:
             return
         endstop = self.gate_preload_endstop or self.gate_homing_endstop # '' inherits gate_homing_endstop
@@ -261,14 +218,7 @@ class MmuUnitParameters(TunableParametersBase):
         ParamSpec('nfc_gate_jog_scan_window',         'floatlist', [0.0, 0.0], section="NFC", validator=_validate_nfc_gate_jog_scan_window),
         ParamSpec('nfc_preload_jog_scan_window',      'floatlist', lambda self: self.nfc_gate_jog_scan_window, section="NFC", validator=_validate_nfc_preload_jog_scan_window),
         ParamSpec('nfc_neighbor_check',                'int',    0,    section="NFC", limits=dict(minval=0, maxval=1)),
-        # Declared after nfc_gate_jog_scan_window so the validator can cross-check it
         ParamSpec('nfc_neighbor_evict_distance',       'float',  0.0,  section="NFC", validator=_validate_nfc_neighbor_evict_distance),
-        # Independent of nfc_neighbor_evict_distance and of each other - each controls only
-        # its own operation's self-jog ratification escalation (MmuNfcFieldArbiter._ratify /
-        # _verify_by_self_jog), not neighbor eviction. Off by default; a machine can arm any
-        # combination. nfc_preload_clear_distance defaults to nfc_gate_clear_distance (same
-        # pattern as nfc_preload_jog_scan_window defaulting to nfc_gate_jog_scan_window) since
-        # preload usually - but not always - wants the same clear jog as a plain scan.
         ParamSpec('nfc_gate_clear_distance',           'float',  0.0,  section="NFC", validator=_validate_nfc_gate_clear_distance),
         ParamSpec('nfc_preload_clear_distance',        'float',  lambda self: self.nfc_gate_clear_distance, section="NFC", validator=_validate_nfc_preload_clear_distance),
         ParamSpec('nfc_field_probe_reads',              'int',    3,    section="NFC", limits=dict(minval=1, maxval=10)),

--- a/extras/mmu/unit/mmu_unit_parameters.py
+++ b/extras/mmu/unit/mmu_unit_parameters.py
@@ -84,6 +84,8 @@ class MmuUnitParameters(TunableParametersBase):
             # (see _validate_nfc_neighbor_evict_distance) - same reasoning as the parking
             # distance re-checks just above.
             self._validate_nfc_neighbor_evict_distance(self.nfc_neighbor_evict_distance)
+            # Same reasoning again for the independent self-verify distance.
+            self._validate_nfc_self_verify_distance(self.nfc_self_verify_distance)
 
     def _on_gate_preload_endstop(self, old, new):
         if new != old:
@@ -181,6 +183,42 @@ class MmuUnitParameters(TunableParametersBase):
                 "'%s' (got %.1f)"
                 % (SENSOR_EXIT_PREFIX, self.gate_homing_endstop, value))
 
+    def _validate_nfc_self_verify_distance(self, value):
+        # 0 disables self-jog ratification entirely - independent of nfc_neighbor_evict_distance,
+        # so a machine can have one without the other (see MmuNfcFieldArbiter._ratify).
+        if not value:
+            return
+        window = self.nfc_gate_jog_scan_window
+        if not window or len(window) != 2 or (window[0] == 0 and window[1] == 0):
+            raise ValueError(
+                "nfc_self_verify_distance requires nfc_gate_jog_scan_window to be "
+                "configured - the self-jog travels within that same window regardless of "
+                "which operation (preload or MMU_NFC_SCAN) it is protecting")
+        neg, pos = window[0], window[1]
+        # Same physical travel corridor as the eviction jog above - it must fit inside the
+        # matching half of the window that already bounds nfc_gate_jog_scan_window itself.
+        if value > pos:
+            raise ValueError(
+                "nfc_self_verify_distance forward jog (%.1fmm) cannot exceed the forward "
+                "reach of nfc_gate_jog_scan_window (%.1fmm)" % (value, pos))
+        if value < neg:
+            raise ValueError(
+                "nfc_self_verify_distance backward jog (%.1fmm) cannot exceed the backward "
+                "reach of nfc_gate_jog_scan_window (%.1fmm)" % (value, neg))
+        # Same forward-jog restriction as nfc_neighbor_evict_distance, checked here against
+        # gate_homing_endstop as a baseline sanity check (matches a plain MMU_NFC_SCAN). The
+        # self-jog can also run from preload's ratify, where the gate is actually parked via
+        # gate_preload_endstop instead - that combination can't be caught at config time (it
+        # depends on which operation is running), so MmuNfcFieldArbiter._ratify re-checks the
+        # ACTUAL endstop in effect at runtime and skips escalation there if it's unsafe. This
+        # static check stays as a first line of defence against the common misconfiguration.
+        if value > 0 and self.gate_homing_endstop in SHARED_GATE_ENDSTOPS:
+            raise ValueError(
+                "nfc_self_verify_distance must be a backward jog (< 0) unless "
+                "gate_homing_endstop is '%s' - every gate shares the forward path through "
+                "'%s' (got %.1f)"
+                % (SENSOR_EXIT_PREFIX, self.gate_homing_endstop, value))
+
     # Parking distance sign convention: -ve = retraction (toward the gate/gears), +ve =
     # extrusion (forward, past the sensor). Parking forward past the sensor is only safe
     # on the per-gate mmu_exit sensor; the shared mmu_shared_exit, encoder and
@@ -227,6 +265,10 @@ class MmuUnitParameters(TunableParametersBase):
         ParamSpec('nfc_neighbor_check',                'int',    0,    section="NFC", limits=dict(minval=0, maxval=1)),
         # Declared after nfc_gate_jog_scan_window so the validator can cross-check it
         ParamSpec('nfc_neighbor_evict_distance',       'float',  0.0,  section="NFC", validator=_validate_nfc_neighbor_evict_distance),
+        # Independent of nfc_neighbor_evict_distance above - controls only the self-jog
+        # ratification escalation (MmuNfcFieldArbiter._verify_by_self_jog), not neighbor
+        # eviction. Off by default; a machine can arm either, both, or neither.
+        ParamSpec('nfc_self_verify_distance',          'float',  0.0,  section="NFC", validator=_validate_nfc_self_verify_distance),
         ParamSpec('nfc_field_probe_reads',              'int',    3,    section="NFC", limits=dict(minval=1, maxval=10)),
         ParamSpec('nfc_deep_read',                    'int',    0,    section="NFC", limits=dict(minval=0, maxval=1)),
         ParamSpec('nfc_led_segment',                  'str',  'auto', section="NFC"),

--- a/installer/Kconfig.nfc_reader
+++ b/installer/Kconfig.nfc_reader
@@ -11,6 +11,7 @@
 # PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW
 # PARAM_NFC_NEIGHBOR_CHECK
 # PARAM_NFC_NEIGHBOR_EVICT_DISTANCE
+# PARAM_NFC_SELF_VERIFY_DISTANCE
 # PARAM_NFC_FIELD_PROBE_READS
 # PARAM_NFC_LED_SEGMENT
 #
@@ -655,6 +656,18 @@ if MMU_HAS_NFC_READER
         the warning below). Must fit inside the jog scan window above.
 
         0 disables eviction (default); reader gain is not a substitute.
+
+    config PARAM_NFC_SELF_VERIFY_DISTANCE
+      float "NFC self-jog verification distance"
+      default 0
+      help
+        Independent of the eviction jog above. If a tag is still seen once this
+        gate's own filament settles, jogs THIS gate's own filament this far further
+        and re-checks rather than discarding outright - catches a tag mounted close
+        enough to stay in range at the normal park position. Same signed convention
+        and shared-endstop caution as the eviction jog.
+
+        0 disables this escalation (default).
 
     config PARAM_NFC_FIELD_PROBE_READS
       int "NFC field probe reads"

--- a/installer/Kconfig.nfc_reader
+++ b/installer/Kconfig.nfc_reader
@@ -667,6 +667,7 @@ if MMU_HAS_NFC_READER
         jogs THIS gate's own filament this far further off park and back before discarding -
         catches a tag mounted close enough to stay in range at rest. Signed from
         park position (+ve forward, -ve back; forward needs gate_homing_endstop=mmu_exit).
+        The jog magnitude and its backward target must fit gate_homing_max.
 
         0 disables this escalation for MMU_NFC_SCAN (default).
 
@@ -679,6 +680,7 @@ if MMU_HAS_NFC_READER
         differ, including in sign, from the scan distance. Defaults to it, since
         preload usually wants the same clear jog. Forward requires the preload
         endstop (or, if unset, gate_homing_endstop) to be mmu_exit.
+        The jog magnitude and its backward target must fit gate_preload_homing_max.
 
         0 disables this escalation for MMU_PRELOAD (default).
 
@@ -690,7 +692,7 @@ if MMU_HAS_NFC_READER
         How many times to read a gate's reader when asking "is anything in this field?". A
         tag at the edge of the field - the neighboring-spool signature - reads intermittently,
         so a single read can miss it. Only used when the neighbor check or eviction jog above
-        is enabled.
+        or either self-jog clear distance is enabled.
 
     choice CHOICE_NFC_LED_SEGMENT
       prompt "NFC reader led feedback segment"

--- a/installer/Kconfig.nfc_reader
+++ b/installer/Kconfig.nfc_reader
@@ -609,7 +609,7 @@ if MMU_HAS_NFC_READER
       default 0
 
     config PARAM_NFC_GATE_JOG_SCAN_WINDOW
-      string "NFC reader jog scan window"
+      string "NFC jog scan window (scan)           "
       default "-50, 50"
       array_editor "," 2
       help
@@ -619,7 +619,7 @@ if MMU_HAS_NFC_READER
         E.g. "-100, 400" means can retract -100mm and extruder 400mm. "0, 0" will disable jog scan operation
 
     config PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW
-      string "NFC reader preload jog scan window"
+      string "NFC jog scan window (preload)        "
       default PARAM_NFC_GATE_JOG_SCAN_WINDOW
       array_editor "," 2
       help
@@ -627,7 +627,8 @@ if MMU_HAS_NFC_READER
         Preload often homes to a different endstop (typically the per-gate mmu_exit sensor rather than the
         general gate homing endstop), so the safe scan range can differ. Defaults to the same value as the
         gate jog scan window.
-        E.g. "-100, 400" means can retract -100mm and extrude 400mm. "0, 0" disables jog scanning during preload
+        E.g. "-100, 400" means can retract -100mm and extrude 400mm.
+             "0, 0" disables jog scanning during preload
 
     config BOOL_NFC_NEIGHBOR_CHECK
       bool "NFC neighbor field check"
@@ -647,7 +648,7 @@ if MMU_HAS_NFC_READER
       default 0
 
     config PARAM_NFC_NEIGHBOR_EVICT_DISTANCE
-      float "NFC neighbor eviction jog"
+      float "NFC neighbor eviction jog            "
       default 0
       help
         Adds eviction motion on top of the check above: an identified neighboring
@@ -659,15 +660,13 @@ if MMU_HAS_NFC_READER
         0 disables eviction (default); reader gain is not a substitute.
 
     config PARAM_NFC_GATE_CLEAR_DISTANCE
-      float "NFC self-jog clear distance (scan)"
+      float "NFC self-jog clear distance (scan)   "
       default 0
       help
-        Independent of the eviction jog above and the preload distance below. If
-        a tag is still seen once this gate settles during MMU_NFC_SCAN, jogs THIS
-        gate's own filament this far further off park and back before discarding -
+        If a tag is still seen once this gate finished movement during MMU_NFC_SCAN, this
+        jogs THIS gate's own filament this far further off park and back before discarding -
         catches a tag mounted close enough to stay in range at rest. Signed from
-        park (+ve forward, -ve back; forward needs gate_homing_endstop=mmu_exit).
-        A plain jog-and-restore, not checked against any window - size for your machine.
+        park position (+ve forward, -ve back; forward needs gate_homing_endstop=mmu_exit).
 
         0 disables this escalation for MMU_NFC_SCAN (default).
 
@@ -684,7 +683,7 @@ if MMU_HAS_NFC_READER
         0 disables this escalation for MMU_PRELOAD (default).
 
     config PARAM_NFC_FIELD_PROBE_READS
-      int "NFC field probe reads"
+      int "NFC field probe reads                "
       default 3
       range 1 10
       help

--- a/installer/Kconfig.nfc_reader
+++ b/installer/Kconfig.nfc_reader
@@ -11,7 +11,8 @@
 # PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW
 # PARAM_NFC_NEIGHBOR_CHECK
 # PARAM_NFC_NEIGHBOR_EVICT_DISTANCE
-# PARAM_NFC_SELF_VERIFY_DISTANCE
+# PARAM_NFC_GATE_CLEAR_DISTANCE
+# PARAM_NFC_PRELOAD_CLEAR_DISTANCE
 # PARAM_NFC_FIELD_PROBE_READS
 # PARAM_NFC_LED_SEGMENT
 #
@@ -657,17 +658,30 @@ if MMU_HAS_NFC_READER
 
         0 disables eviction (default); reader gain is not a substitute.
 
-    config PARAM_NFC_SELF_VERIFY_DISTANCE
-      float "NFC self-jog verification distance"
+    config PARAM_NFC_GATE_CLEAR_DISTANCE
+      float "NFC self-jog clear distance (scan)"
       default 0
       help
-        Independent of the eviction jog above. If a tag is still seen once this
-        gate's own filament settles, jogs THIS gate's own filament this far further
-        and re-checks rather than discarding outright - catches a tag mounted close
-        enough to stay in range at the normal park position. Same signed convention
-        and shared-endstop caution as the eviction jog.
+        Independent of the eviction jog above and the preload distance below. If
+        a tag is still seen once this gate settles during MMU_NFC_SCAN, jogs THIS
+        gate's own filament this far further off park and back before discarding -
+        catches a tag mounted close enough to stay in range at rest. Signed from
+        park (+ve forward, -ve back; forward needs gate_homing_endstop=mmu_exit).
+        A plain jog-and-restore, not checked against any window - size for your machine.
 
-        0 disables this escalation (default).
+        0 disables this escalation for MMU_NFC_SCAN (default).
+
+    config PARAM_NFC_PRELOAD_CLEAR_DISTANCE
+      float "NFC self-jog clear distance (preload)"
+      default PARAM_NFC_GATE_CLEAR_DISTANCE
+      help
+        Same as the scan clear distance above, but used during MMU_PRELOAD, which
+        can home/park via a different endstop (gate_preload_endstop) - so this can
+        differ, including in sign, from the scan distance. Defaults to it, since
+        preload usually wants the same clear jog. Forward requires the preload
+        endstop (or, if unset, gate_homing_endstop) to be mmu_exit.
+
+        0 disables this escalation for MMU_PRELOAD (default).
 
     config PARAM_NFC_FIELD_PROBE_READS
       int "NFC field probe reads"

--- a/installer/Kconfig.warnings
+++ b/installer/Kconfig.warnings
@@ -82,6 +82,11 @@ config W16
 config W17
     def_bool y if !CHOICE_GATE_HOMING_ENDSTOP_EXIT && PARAM_NFC_NEIGHBOR_EVICT_DISTANCE > 0
 
+# Same rule as W17, for the independent self-jog verification distance - a forward self-jog
+# pushes THIS gate's own filament past its gate, unsafe on a shared endstop.
+config W18
+    def_bool y if !CHOICE_GATE_HOMING_ENDSTOP_EXIT && PARAM_NFC_SELF_VERIFY_DISTANCE > 0
+
 
 
 if SHOW_PER_UNIT_WARNINGS || SHOW_SHARED_WARNINGS
@@ -112,5 +117,6 @@ if SHOW_PER_UNIT_WARNINGS || SHOW_SHARED_WARNINGS
     comment "Sync-feedback buffer configured but it had no sensors defined"       if W15
     comment "Warning: Sync-feedback buffer configured with both analog and digital inputs" if W16
     comment "NFC neighbor eviction jog must be backward (<=0) unless gate endstop is mmu_exit" if W17
+    comment "NFC self-verify jog must be backward (<=0) unless gate endstop is mmu_exit"     if W18
   endif
 endif

--- a/installer/Kconfig.warnings
+++ b/installer/Kconfig.warnings
@@ -25,7 +25,7 @@ config SW3
 config SHOW_PER_UNIT_WARNINGS
   bool
   depends on !MULTI_UNIT_ENTRY_POINT
-  @repeat var=i min=1 max=17@
+  @repeat var=i min=1 max=19@
     default y if W$(i)
   @endrepeat@
 
@@ -82,10 +82,15 @@ config W16
 config W17
     def_bool y if !CHOICE_GATE_HOMING_ENDSTOP_EXIT && PARAM_NFC_NEIGHBOR_EVICT_DISTANCE > 0
 
-# Same rule as W17, for the independent self-jog verification distance - a forward self-jog
-# pushes THIS gate's own filament past its gate, unsafe on a shared endstop.
+# Same rule as W17, for the independent gate-context self-jog clear distance (MMU_NFC_SCAN) -
+# a forward self-jog pushes THIS gate's own filament past its gate, unsafe on a shared endstop.
 config W18
-    def_bool y if !CHOICE_GATE_HOMING_ENDSTOP_EXIT && PARAM_NFC_SELF_VERIFY_DISTANCE > 0
+    def_bool y if !CHOICE_GATE_HOMING_ENDSTOP_EXIT && PARAM_NFC_GATE_CLEAR_DISTANCE > 0
+
+# Same rule again, for the preload-context clear distance - preload can home/park via its own
+# endstop, so this is checked against that one instead (see W5's same nesting for why).
+config W19
+    def_bool y if !CHOICE_GATE_PRELOAD_ENDSTOP_EXIT && !CHOICE_GATE_HOMING_ENDSTOP_EXIT && PARAM_NFC_PRELOAD_CLEAR_DISTANCE > 0
 
 
 
@@ -117,6 +122,7 @@ if SHOW_PER_UNIT_WARNINGS || SHOW_SHARED_WARNINGS
     comment "Sync-feedback buffer configured but it had no sensors defined"       if W15
     comment "Warning: Sync-feedback buffer configured with both analog and digital inputs" if W16
     comment "NFC neighbor eviction jog must be backward (<=0) unless gate endstop is mmu_exit" if W17
-    comment "NFC self-verify jog must be backward (<=0) unless gate endstop is mmu_exit"     if W18
+    comment "NFC gate clear jog must be backward (<=0) unless gate endstop is mmu_exit"       if W18
+    comment "NFC preload clear jog must be backward (<=0) unless preload endstop is mmu_exit" if W19
   endif
 endif

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -153,14 +153,17 @@ NFC_NEIGHBOR_EVICT = NFC_PER_GATE.derive(
     syms={'PARAM_NFC_NEIGHBOR_EVICT_DISTANCE': '-40'},
     description='BoxTurtle + per-gate NFC readers, neighbor eviction enabled (backward jog)')
 
-# Per-gate readers with the self-jog ratification escalation switched on, independent of
-# neighbor eviction above (nfc_neighbor_evict_distance stays 0 here) - a still-detected tag
-# is confirmed/discarded by jogging THIS gate's own filament further off park, not a
-# neighbor's. Same -40 backward-jog reasoning as NFC_NEIGHBOR_EVICT applies.
-NFC_SELF_VERIFY = NFC_PER_GATE.derive(
-    'nfc_self_verify',
-    syms={'PARAM_NFC_SELF_VERIFY_DISTANCE': '-40'},
-    description='BoxTurtle + per-gate NFC readers, self-jog verification enabled (backward jog)')
+# Per-gate readers with the self-jog ratification escalation switched on for MMU_NFC_SCAN,
+# independent of neighbor eviction above (nfc_neighbor_evict_distance stays 0 here) - a
+# still-detected tag is confirmed/discarded by jogging THIS gate's own filament further off
+# park, not a neighbor's. Backward (-40): no window-fit check applies (this is a plain
+# jog-and-restore off park, not a re-home), only the same shared-endstop direction rule as
+# NFC_NEIGHBOR_EVICT. nfc_preload_clear_distance is left at its default (mirrors this value)
+# so preload gets the same escalation for free.
+NFC_GATE_CLEAR = NFC_PER_GATE.derive(
+    'nfc_gate_clear',
+    syms={'PARAM_NFC_GATE_CLEAR_DISTANCE': '-40'},
+    description='BoxTurtle + per-gate NFC readers, self-jog clear distance enabled (backward jog)')
 
 # PN5180 is the second SPI reader type, and the only one needing pins beyond the SPI
 # bus: BUSY (how the driver paces every command) and RST (its only recovery route).
@@ -566,7 +569,7 @@ run_current: 0.6
 # deliberately absent: one is synthetic and the other needs EXTRA_EXTRUDER_STUB.
 CONSOLE_PROFILES = (ERCF_VVD, BOXTURTLE, TRADRACK, CHAMELEON, PICO_MMU, MMX, EMU, ENCODER,
                     NFC_SINGLE, NFC_PER_GATE, NFC_NEIGHBOR_CHECK, NFC_NEIGHBOR_EVICT,
-                    NFC_SELF_VERIFY,
+                    NFC_GATE_CLEAR,
                     NFC_PN5180, NFC_PN5180_PER_GATE, NFC_PN532, NFC_PN532_SW_I2C,
                     NFC_PN532_UART, NFC_PN532_UART_PER_GATE,
                     NFC_SPOOLMAN, NFC_SPOOLMAN_SHARED)

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -153,6 +153,15 @@ NFC_NEIGHBOR_EVICT = NFC_PER_GATE.derive(
     syms={'PARAM_NFC_NEIGHBOR_EVICT_DISTANCE': '-40'},
     description='BoxTurtle + per-gate NFC readers, neighbor eviction enabled (backward jog)')
 
+# Per-gate readers with the self-jog ratification escalation switched on, independent of
+# neighbor eviction above (nfc_neighbor_evict_distance stays 0 here) - a still-detected tag
+# is confirmed/discarded by jogging THIS gate's own filament further off park, not a
+# neighbor's. Same -40 backward-jog reasoning as NFC_NEIGHBOR_EVICT applies.
+NFC_SELF_VERIFY = NFC_PER_GATE.derive(
+    'nfc_self_verify',
+    syms={'PARAM_NFC_SELF_VERIFY_DISTANCE': '-40'},
+    description='BoxTurtle + per-gate NFC readers, self-jog verification enabled (backward jog)')
+
 # PN5180 is the second SPI reader type, and the only one needing pins beyond the SPI
 # bus: BUSY (how the driver paces every command) and RST (its only recovery route).
 # Both are required by the driver, so the template must emit them or config load dies
@@ -557,6 +566,7 @@ run_current: 0.6
 # deliberately absent: one is synthetic and the other needs EXTRA_EXTRUDER_STUB.
 CONSOLE_PROFILES = (ERCF_VVD, BOXTURTLE, TRADRACK, CHAMELEON, PICO_MMU, MMX, EMU, ENCODER,
                     NFC_SINGLE, NFC_PER_GATE, NFC_NEIGHBOR_CHECK, NFC_NEIGHBOR_EVICT,
+                    NFC_SELF_VERIFY,
                     NFC_PN5180, NFC_PN5180_PER_GATE, NFC_PN532, NFC_PN532_SW_I2C,
                     NFC_PN532_UART, NFC_PN532_UART_PER_GATE,
                     NFC_SPOOLMAN, NFC_SPOOLMAN_SHARED)

--- a/test/test_mmu_nfc_neighbor.py
+++ b/test/test_mmu_nfc_neighbor.py
@@ -184,7 +184,7 @@ class TestEvictReject(NeighborTestCase):
 
 
 class TestFieldArm(NeighborTestCase):
-    """_nfc_field_arm: all three knobs are independent, and all default off."""
+    """Shared neighbor options arm both operations; clear distances arm only their own."""
 
     def test_off_by_default(self):
         self.assertIsNone(self.hh.mmu._nfc_field_arm(0))
@@ -207,14 +207,19 @@ class TestFieldArm(NeighborTestCase):
         """
         self.hh.mmu.mmu_unit(0).p.gate_homing_endstop = 'mmu_exit'
         self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance = -40.0
-        self.assertIsNotNone(self.hh.mmu._nfc_field_arm(0))
+        self.hh.mmu.mmu_unit(0).p.nfc_preload_clear_distance = 0.0
+        self.assertIsNotNone(self.hh.mmu._nfc_field_arm(0, clear_distance=-40.0))
+        self.assertIsNone(self.hh.mmu._nfc_field_arm(
+            0, profile_endstop='mmu_exit', clear_distance=0.0))
 
     def test_preload_clear_distance_alone_arms(self):
         """Same as above, but for the independent preload-context distance."""
         self.hh.mmu.mmu_unit(0).p.gate_homing_endstop = 'mmu_exit'
         self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance = 0.0
         self.hh.mmu.mmu_unit(0).p.nfc_preload_clear_distance = -40.0
-        self.assertIsNotNone(self.hh.mmu._nfc_field_arm(0))
+        self.assertIsNotNone(self.hh.mmu._nfc_field_arm(
+            0, profile_endstop='mmu_exit', clear_distance=-40.0))
+        self.assertIsNone(self.hh.mmu._nfc_field_arm(0, clear_distance=0.0))
 
     def test_encoder_homing_never_arms(self):
         """Encoder homing can't be compounded with the reader - nothing to protect."""
@@ -285,12 +290,10 @@ class TestNeighborEvictDistanceValidation(NeighborTestCase):
 class TestClearDistanceValidation(NeighborTestCase):
     """
     Config validation for nfc_gate_clear_distance / nfc_preload_clear_distance, and their
-    on_change revalidation. Unlike nfc_neighbor_evict_distance, these have NO window-fit
-    check at all: the self-jog and its restore are both plain relative moves off the
-    already-established park position (see MmuNfcFieldArbiter._verify_by_self_jog) - there is
-    no re-home involved, so there is no re-homing budget to bound them against. Only the
-    forward-jog-vs-shared-endstop safety rule applies, same shape as
-    TestNeighborEvictDistanceValidation, checked against each parameter's OWN endstop.
+    on_change revalidation. These are park-relative rather than scan-window targets, but the
+    open-loop jog and return must stay within the corresponding profile's homing reach so the
+    filament cannot be pulled beyond its configured recoverable range. The forward-jog-vs-
+    shared-endstop rule is checked against each parameter's own endstop too.
     """
 
     def test_zero_disables(self):
@@ -298,12 +301,37 @@ class TestClearDistanceValidation(NeighborTestCase):
         self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_preload_clear_distance=0')
         self.assertEqual(self.hh.errors, [])
 
-    def test_any_magnitude_is_accepted_with_no_window_fit_check(self):
-        """Deliberately left to the user to size sensibly - not bounded against anything."""
+    def test_jog_magnitude_cannot_exceed_gate_homing_max(self):
         self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_exit')
-        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=-999')
+        with self.assertRaises(Exception) as cm:
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=-999')
+        self.assertIn('homing maximum', str(cm.exception))
+
+    def test_backward_target_includes_the_existing_park_offset(self):
+        # BoxTurtle parks at -100 with a 300mm homing reach. A -250 jog is individually
+        # smaller than 300, but its final target is -350 and therefore unsafe.
+        with self.assertRaises(Exception) as cm:
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=-250')
+        self.assertIn('behind the homing datum', str(cm.exception))
+
+    def test_normal_clear_distance_inside_recovery_reach_is_accepted(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=-40')
         self.assertEqual(self.hh.errors, [])
-        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance, -999.0)
+
+    def test_parking_change_rechecks_a_stale_clear_reach(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_parking_distance=-10')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=-250')
+        self.assertEqual(self.hh.errors, [])
+        with self.assertRaises(Exception) as cm:
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_parking_distance=-100')
+        self.assertIn('nfc_gate_clear_distance', str(cm.exception))
+
+    def test_homing_max_change_rechecks_a_stale_clear_reach(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=-150')
+        self.assertEqual(self.hh.errors, [])
+        with self.assertRaises(Exception) as cm:
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_max=200')
+        self.assertIn('nfc_gate_clear_distance', str(cm.exception))
 
     def test_gate_forward_jog_rejected_on_shared_endstop(self):
         self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_shared_exit')
@@ -383,6 +411,15 @@ class TestClearDistanceValidation(NeighborTestCase):
         self.assertIn('nfc_preload_clear_distance', str(cm.exception))
         self.assertEqual(self.hh.mmu.mmu_unit(0).p.gate_preload_endstop, 'mmu_shared_exit')
 
+    def test_switching_inherited_gate_endstop_rechecks_preload_clear_distance(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_exit')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_preload_clear_distance=40')
+        self.assertEqual(self.hh.errors, [])
+        with self.assertRaises(Exception) as cm:
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_shared_exit')
+        self.assertIn('nfc_preload_clear_distance', str(cm.exception))
+
     def test_independent_of_neighbor_evict_distance(self):
         """The three parameters must not interfere with each other's validation or value."""
         self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_neighbor_evict_distance=-10')
@@ -453,6 +490,44 @@ class TestArbitrationEndToEnd(NeighborTestCase):
         self.hh.run_gcode('MMU_NFC_SCAN GATE=0')
         self.assertEqual(self.hh.errors, [])
         self.assertIn('tag read', ' '.join(self.hh.console).lower())
+
+    def test_preload_only_clear_distance_does_not_arm_scan(self):
+        """A preload-only option must leave MMU_NFC_SCAN's old zero-motion fast path alone."""
+        u = self.hh.mmu.mmu_unit(0)
+        u.p.nfc_neighbor_check = 0
+        u.p.nfc_neighbor_evict_distance = 0.0
+        u.p.nfc_gate_clear_distance = 0.0
+        u.p.nfc_preload_clear_distance = -40.0
+        self.fil.attach_tag(0, TAG, offset=-20.0)
+        self.hh.mmu.select_gate(0)
+        self.hh.place_filament(0)
+        self.hh.mmu.gate_maps.set_gate_status(0, GATE_AVAILABLE)
+
+        self.hh.run_gcode('MMU_NFC_SCAN GATE=0')
+
+        self.assertEqual(self.hh.errors, [])
+        self.assertEqual(self.hh.mmu.gate_maps.gate_spool_rfid[0], TAG)
+        self.assertEqual(self.fil.history, [],
+                         'a preload-only clear distance must not force scan motion')
+
+    def test_runtime_guard_skips_a_stale_out_of_reach_clear_jog(self):
+        """Direct/stale state cannot bypass the physical reach guard in _ratify."""
+        u = self.hh.mmu.mmu_unit(0)
+        u.p.nfc_neighbor_check = 0
+        u.p.nfc_neighbor_evict_distance = 0.0
+        u.p.nfc_gate_clear_distance = -999.0  # bypass config validator deliberately
+        self.hh.mmu.p.log_level = 4
+        self.fil.attach_tag(0, TAG, offset=-20.0)
+        self.hh.mmu.select_gate(0)
+        self.hh.place_filament(0)
+        self.hh.mmu.gate_maps.set_gate_status(0, GATE_AVAILABLE)
+
+        self.hh.run_gcode('MMU_NFC_SCAN GATE=0')
+
+        self.assertEqual(self.hh.errors, [])
+        self.assertEqual(self.hh.mmu.gate_maps.gate_spool_rfid[0], '')
+        self.assertNotIn('jogging', ' '.join(self.hh.console).lower(),
+                         'an out-of-reach stale value must not execute a self-jog')
 
     def test_scan_raises_when_tag_belongs_to_an_unclearable_neighbor(self):
         """

--- a/test/test_mmu_nfc_neighbor.py
+++ b/test/test_mmu_nfc_neighbor.py
@@ -184,7 +184,7 @@ class TestEvictReject(NeighborTestCase):
 
 
 class TestFieldArm(NeighborTestCase):
-    """_nfc_field_arm: the two knobs are independent, and both default off."""
+    """_nfc_field_arm: all three knobs are independent, and all default off."""
 
     def test_off_by_default(self):
         self.assertIsNone(self.hh.mmu._nfc_field_arm(0))
@@ -196,6 +196,16 @@ class TestFieldArm(NeighborTestCase):
     def test_evict_distance_alone_arms(self):
         self.hh.mmu.mmu_unit(0).p.gate_homing_endstop = 'mmu_exit'
         self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = -40.0
+        self.assertIsNotNone(self.hh.mmu._nfc_field_arm(0))
+
+    def test_self_verify_distance_alone_arms(self):
+        """
+        A machine that only wants the self-jog ratification escalation, with neither
+        neighbor check nor eviction, must still reach clear_field()/_ratify() - otherwise
+        nfc_self_verify_distance would be configured but silently do nothing.
+        """
+        self.hh.mmu.mmu_unit(0).p.gate_homing_endstop = 'mmu_exit'
+        self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance = -40.0
         self.assertIsNotNone(self.hh.mmu._nfc_field_arm(0))
 
     def test_encoder_homing_never_arms(self):
@@ -262,6 +272,62 @@ class TestNeighborEvictDistanceValidation(NeighborTestCase):
         self.assertIn('nfc_neighbor_evict_distance', str(cm.exception))
         # The switch must not land half-applied with a stale, now-unsafe positive distance
         self.assertEqual(self.hh.mmu.mmu_unit(0).p.gate_homing_endstop, 'mmu_shared_exit')
+
+
+class TestSelfVerifyDistanceValidation(NeighborTestCase):
+    """
+    Config validation for nfc_self_verify_distance, and its on_change revalidation - mirrors
+    TestNeighborEvictDistanceValidation exactly, since the validator logic is the same shape,
+    but nfc_self_verify_distance is a genuinely independent parameter (see
+    MmuNfcFieldArbiter._ratify) so it gets its own coverage rather than assuming the other
+    class's tests are enough.
+    """
+
+    def test_zero_disables_and_needs_no_window(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=0')
+        self.assertEqual(self.hh.errors, [])
+
+    def test_forward_jog_rejected_on_shared_endstop(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_shared_exit')
+        self.assertEqual(self.hh.errors, [])
+        with self.assertRaises(Exception) as cm:
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=40')
+        self.assertIn('nfc_self_verify_distance', str(cm.exception))
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance, 0.0)
+
+    def test_backward_jog_accepted_on_shared_endstop(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_shared_exit')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=-40')
+        self.assertEqual(self.hh.errors, [])
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance, -40.0)
+
+    def test_forward_jog_accepted_on_a_per_gate_exit_endstop(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_exit')
+        self.assertEqual(self.hh.errors, [])
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=40')
+        self.assertEqual(self.hh.errors, [])
+
+    def test_out_of_window_distance_is_rejected(self):
+        with self.assertRaises(Exception) as cm:
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=-999')
+        self.assertIn('nfc_gate_jog_scan_window', str(cm.exception))
+
+    def test_switching_to_a_shared_endstop_rechecks_a_stale_self_verify_distance(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_exit')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=40')
+        self.assertEqual(self.hh.errors, [])
+        with self.assertRaises(Exception) as cm:
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_shared_exit')
+        self.assertIn('nfc_self_verify_distance', str(cm.exception))
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.gate_homing_endstop, 'mmu_shared_exit')
+
+    def test_independent_of_neighbor_evict_distance(self):
+        """The two parameters must not interfere with each other's validation or value."""
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_neighbor_evict_distance=-10')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=-40')
+        self.assertEqual(self.hh.errors, [])
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance, -10.0)
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance, -40.0)
 
 
 class TestGateRfidPlumbing(NeighborTestCase):
@@ -396,15 +462,17 @@ class TestArbitrationEndToEnd(NeighborTestCase):
         it, the read taken mid-sweep would already have been committed to the gate map by
         the time this assertion runs, warning or no warning.
 
-        evict_distance is deliberately -10.0, not some larger value: the passive check
-        fails (tag_pos=-80, dead center), and ratification now escalates to a self-jog of
-        -10mm too (tip -110 -> tag_pos -90, |-90-(-80)|=10 <= the 15 tag_window - still
+        nfc_self_verify_distance is deliberately -10.0, not some larger value: the passive
+        check fails (tag_pos=-80, dead center), and ratification now escalates to a self-jog
+        of -10mm too (tip -110 -> tag_pos -90, |-90-(-80)|=10 <= the 15 tag_window - still
         detected). Kept inside the window on purpose, so this test exercises "escalation
         was attempted and still correctly failed to clear", not "escalation never ran at
         all" - see test_provisional_verdict_is_ratified_via_self_jog_when_passive_check_fails_scan
-        for the -40.0 case where the self-jog actually clears it.
+        for the -40.0 case where the self-jog actually clears it. nfc_neighbor_evict_distance
+        is deliberately left at its default 0 - proves self-jog escalation runs on its own,
+        independent of neighbor eviction (see MmuNfcFieldArbiter._ratify).
         """
-        self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = -10.0
+        self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance = -10.0
         self.fil.attach_tag(0, TAG, offset=-20.0)  # unregistered, and never truly clears
         self.hh.mmu.select_gate(0)
         self.hh.place_filament(0)  # normal park position
@@ -426,9 +494,10 @@ class TestArbitrationEndToEnd(NeighborTestCase):
         normal homing path rather than the "already preloaded" shortcut (which would bypass
         arbitration entirely), while still putting the tag in range from the very start (see
         the scan test's docstring for the offset/park/reader arithmetic, and for why
-        evict_distance is -10.0 here too - self-jog escalation must run and still fail).
+        nfc_self_verify_distance is -10.0 here too - self-jog escalation must run and
+        still fail, independent of neighbor eviction which stays at its default 0).
         """
-        self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = -10.0
+        self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance = -10.0
         self.fil.attach_tag(0, TAG, offset=-20.0)
         self.hh.mmu.select_gate(0)
         self.hh.place_filament(0)  # normal park position, exit sensor not yet triggered
@@ -443,15 +512,17 @@ class TestArbitrationEndToEnd(NeighborTestCase):
     def test_provisional_verdict_is_ratified_via_self_jog_when_passive_check_fails_scan(self):
         """
         Same physical setup as the "never ratified" scan test above, but with the ORIGINAL
-        -40.0 evict_distance: the passive check fails exactly the same way (tag_pos=-80,
-        dead center), but escalation's self-jog moves the tip an ADDITIONAL 40mm (tip=-140
-        -> tag_pos=-120, |-120-(-80)|=40 > the 15 tag_window) - clear this time, so the
-        provisional read IS ratified and committed. This is the motivating case from the
-        real captured log this feature was built to fix: a genuinely-owned tag that the
-        passive check alone would discard forever.
+        -40.0 self-verify distance: the passive check fails exactly the same way
+        (tag_pos=-80, dead center), but escalation's self-jog moves the tip an ADDITIONAL
+        40mm (tip=-140 -> tag_pos=-120, |-120-(-80)|=40 > the 15 tag_window) - clear this
+        time, so the provisional read IS ratified and committed. This is the motivating
+        case from the real captured log this feature was built to fix: a genuinely-owned
+        tag that the passive check alone would discard forever. nfc_neighbor_evict_distance
+        is deliberately left at its default 0 here - proves self-jog ratification doesn't
+        need neighbor eviction armed at all.
         """
         self.hh.mmu.p.log_level = 4  # so the self-jog's own log_debug lines are visible
-        self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = -40.0
+        self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance = -40.0
         self.fil.attach_tag(0, TAG, offset=-20.0)
         self.hh.mmu.select_gate(0)
         self.hh.place_filament(0)
@@ -468,7 +539,7 @@ class TestArbitrationEndToEnd(NeighborTestCase):
     def test_provisional_verdict_is_ratified_via_self_jog_when_passive_check_fails_preload(self):
         """Preload's side of the self-jog-succeeds scenario above."""
         self.hh.mmu.p.log_level = 4
-        self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = -40.0
+        self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance = -40.0
         self.fil.attach_tag(0, TAG, offset=-20.0)
         self.hh.mmu.select_gate(0)
         self.hh.place_filament(0)
@@ -484,16 +555,18 @@ class TestArbitrationEndToEnd(NeighborTestCase):
 
     def test_check_only_mode_spends_zero_extra_motion_on_a_never_ratified_read(self):
         """
-        nfc_neighbor_check=1 with nfc_neighbor_evict_distance=0 (check-only mode's own
-        default) must keep its "no motion budget at all" promise even with self-jog
-        escalation added: _ratify's `if distance and ...` guard is false for distance=0,
-        so it falls straight to the unchanged passive-only discard, exactly as before this
-        feature existed. log_level=4 makes _jog_off's own "jogging ... off its park
-        reference" debug line visible if it ran at all - asserting its absence is a direct
-        check that neither neighbor eviction nor the new self-jog spent any motion.
+        nfc_neighbor_check=1 with both nfc_neighbor_evict_distance=0 and
+        nfc_self_verify_distance=0 (both default) must keep the "no motion budget at all"
+        promise even with self-jog escalation added: _ratify's `if distance and ...` guard
+        is false for distance=0, so it falls straight to the unchanged passive-only
+        discard, exactly as before this feature existed. log_level=4 makes _jog_off's own
+        "jogging ... off its park reference" debug line visible if it ran at all -
+        asserting its absence is a direct check that neither neighbor eviction nor the
+        new self-jog spent any motion.
         """
         self.hh.mmu.p.log_level = 4
         self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = 0.0
+        self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance = 0.0
         self.fil.attach_tag(0, TAG, offset=-20.0)
         self.hh.mmu.select_gate(0)
         self.hh.place_filament(0)
@@ -506,7 +579,8 @@ class TestArbitrationEndToEnd(NeighborTestCase):
         console = ' '.join(self.hh.console).lower()
         self.assertIn('no tag found', console)
         self.assertIn('could not confirm this gate', console)
-        self.assertNotIn('jogging', console, 'check-only mode (evict_distance=0) must spend zero motion')
+        self.assertNotIn('jogging', console,
+                        'check-only mode (both distances at 0) must spend zero motion')
 
 
 class TestRatifyDoesNotSelfPoison(NeighborTestCase):

--- a/test/test_mmu_nfc_neighbor.py
+++ b/test/test_mmu_nfc_neighbor.py
@@ -395,8 +395,16 @@ class TestArbitrationEndToEnd(NeighborTestCase):
         to sit at this reader. This is the actual point of the deferred-commit fix: before
         it, the read taken mid-sweep would already have been committed to the gate map by
         the time this assertion runs, warning or no warning.
+
+        evict_distance is deliberately -10.0, not some larger value: the passive check
+        fails (tag_pos=-80, dead center), and ratification now escalates to a self-jog of
+        -10mm too (tip -110 -> tag_pos -90, |-90-(-80)|=10 <= the 15 tag_window - still
+        detected). Kept inside the window on purpose, so this test exercises "escalation
+        was attempted and still correctly failed to clear", not "escalation never ran at
+        all" - see test_provisional_verdict_is_ratified_via_self_jog_when_passive_check_fails_scan
+        for the -40.0 case where the self-jog actually clears it.
         """
-        self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = -40.0
+        self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = -10.0
         self.fil.attach_tag(0, TAG, offset=-20.0)  # unregistered, and never truly clears
         self.hh.mmu.select_gate(0)
         self.hh.place_filament(0)  # normal park position
@@ -417,9 +425,10 @@ class TestArbitrationEndToEnd(NeighborTestCase):
         the reader) - that keeps the per-gate exit sensor unTRIGGERED so preload takes its
         normal homing path rather than the "already preloaded" shortcut (which would bypass
         arbitration entirely), while still putting the tag in range from the very start (see
-        the scan test's docstring for the offset/park/reader arithmetic).
+        the scan test's docstring for the offset/park/reader arithmetic, and for why
+        evict_distance is -10.0 here too - self-jog escalation must run and still fail).
         """
-        self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = -40.0
+        self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = -10.0
         self.fil.attach_tag(0, TAG, offset=-20.0)
         self.hh.mmu.select_gate(0)
         self.hh.place_filament(0)  # normal park position, exit sensor not yet triggered
@@ -430,6 +439,74 @@ class TestArbitrationEndToEnd(NeighborTestCase):
         self.assertEqual(self.hh.mmu.gate_maps.gate_spool_rfid[0], '',
                          "a never-ratified provisional read must never be committed to the gate map")
         self.assertIn('no tag found', ' '.join(self.hh.console).lower())
+
+    def test_provisional_verdict_is_ratified_via_self_jog_when_passive_check_fails_scan(self):
+        """
+        Same physical setup as the "never ratified" scan test above, but with the ORIGINAL
+        -40.0 evict_distance: the passive check fails exactly the same way (tag_pos=-80,
+        dead center), but escalation's self-jog moves the tip an ADDITIONAL 40mm (tip=-140
+        -> tag_pos=-120, |-120-(-80)|=40 > the 15 tag_window) - clear this time, so the
+        provisional read IS ratified and committed. This is the motivating case from the
+        real captured log this feature was built to fix: a genuinely-owned tag that the
+        passive check alone would discard forever.
+        """
+        self.hh.mmu.p.log_level = 4  # so the self-jog's own log_debug lines are visible
+        self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = -40.0
+        self.fil.attach_tag(0, TAG, offset=-20.0)
+        self.hh.mmu.select_gate(0)
+        self.hh.place_filament(0)
+        self.hh.mmu.gate_maps.set_gate_status(0, GATE_AVAILABLE)
+        self.assertIsNotNone(self.fil.tag_detected(0), 'precondition: tag must be in range at rest')
+        self.hh.run_gcode('MMU_NFC_SCAN GATE=0')
+        self.assertEqual(self.hh.errors, [])
+        self.assertEqual(self.hh.mmu.gate_maps.gate_spool_rfid[0], TAG,
+                         "a self-jog-ratified provisional read must be committed to the gate map")
+        console = ' '.join(self.hh.console).lower()
+        self.assertIn('tag read', console)
+        self.assertIn('ratified via a deliberate self-jog', console)
+
+    def test_provisional_verdict_is_ratified_via_self_jog_when_passive_check_fails_preload(self):
+        """Preload's side of the self-jog-succeeds scenario above."""
+        self.hh.mmu.p.log_level = 4
+        self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = -40.0
+        self.fil.attach_tag(0, TAG, offset=-20.0)
+        self.hh.mmu.select_gate(0)
+        self.hh.place_filament(0)
+        self.assertIsNotNone(self.fil.tag_detected(0), 'precondition: tag must be in range at rest')
+        self.hh.run_gcode('MMU_PRELOAD GATE=0')
+        self.assertEqual(self.hh.errors, [])
+        self.assertEqual(self.hh.mmu.gate_status[0], GATE_AVAILABLE)
+        self.assertEqual(self.hh.mmu.gate_maps.gate_spool_rfid[0], TAG,
+                         "a self-jog-ratified provisional read must be committed to the gate map")
+        console = ' '.join(self.hh.console).lower()
+        self.assertIn('tag read', console)
+        self.assertIn('ratified via a deliberate self-jog', console)
+
+    def test_check_only_mode_spends_zero_extra_motion_on_a_never_ratified_read(self):
+        """
+        nfc_neighbor_check=1 with nfc_neighbor_evict_distance=0 (check-only mode's own
+        default) must keep its "no motion budget at all" promise even with self-jog
+        escalation added: _ratify's `if distance and ...` guard is false for distance=0,
+        so it falls straight to the unchanged passive-only discard, exactly as before this
+        feature existed. log_level=4 makes _jog_off's own "jogging ... off its park
+        reference" debug line visible if it ran at all - asserting its absence is a direct
+        check that neither neighbor eviction nor the new self-jog spent any motion.
+        """
+        self.hh.mmu.p.log_level = 4
+        self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = 0.0
+        self.fil.attach_tag(0, TAG, offset=-20.0)
+        self.hh.mmu.select_gate(0)
+        self.hh.place_filament(0)
+        self.hh.mmu.gate_maps.set_gate_status(0, GATE_AVAILABLE)
+        self.assertIsNotNone(self.fil.tag_detected(0), 'precondition: tag must be in range at rest')
+        self.hh.run_gcode('MMU_NFC_SCAN GATE=0')
+        self.assertEqual(self.hh.errors, [])
+        self.assertEqual(self.hh.mmu.gate_maps.gate_spool_rfid[0], '',
+                         "check-only mode must never commit an unconfirmed read")
+        console = ' '.join(self.hh.console).lower()
+        self.assertIn('no tag found', console)
+        self.assertIn('could not confirm this gate', console)
+        self.assertNotIn('jogging', console, 'check-only mode (evict_distance=0) must spend zero motion')
 
 
 class TestRatifyDoesNotSelfPoison(NeighborTestCase):
@@ -455,7 +532,7 @@ class TestRatifyDoesNotSelfPoison(NeighborTestCase):
         # already attributes this exact UID to gate 0, same as _nfc_tag_read would leave it.
         self.hh.mmu.gate_maps.set_gate_rfid(0, TAG)
         self.hh.gcode.console.clear()
-        self.assertFalse(self.arbiter._ratify(0, mgr))
+        self.assertFalse(self.arbiter._ratify(0, mgr, None))
         self.assertTrue(
             any('could not confirm this gate' in c for c in self.hh.console), self.hh.console)
 
@@ -467,7 +544,7 @@ class TestRatifyDoesNotSelfPoison(NeighborTestCase):
         self.hh.place_filament(0, position=self.fil.layout['mmu_nfc'])
         self.hh.mmu.gate_maps.set_gate_rfid(0, TAG) # Map says something else entirely
         self.hh.gcode.console.clear()
-        self.assertFalse(self.arbiter._ratify(0, mgr))
+        self.assertFalse(self.arbiter._ratify(0, mgr, None))
         self.assertTrue(
             any('could not confirm this gate' in c for c in self.hh.console), self.hh.console)
 
@@ -477,7 +554,7 @@ class TestRatifyDoesNotSelfPoison(NeighborTestCase):
         mgr = self.hh.mmu.mmu_unit(0).nfc_manager
         self.hh.mmu.gate_maps.set_gate_rfid(0, TAG)
         self.hh.gcode.console.clear()
-        self.assertTrue(self.arbiter._ratify(0, mgr))
+        self.assertTrue(self.arbiter._ratify(0, mgr, None))
         self.assertFalse(
             any('could not confirm this gate' in c for c in self.hh.console), self.hh.console)
 

--- a/test/test_mmu_nfc_neighbor.py
+++ b/test/test_mmu_nfc_neighbor.py
@@ -198,14 +198,22 @@ class TestFieldArm(NeighborTestCase):
         self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = -40.0
         self.assertIsNotNone(self.hh.mmu._nfc_field_arm(0))
 
-    def test_self_verify_distance_alone_arms(self):
+    def test_gate_clear_distance_alone_arms(self):
         """
-        A machine that only wants the self-jog ratification escalation, with neither
-        neighbor check nor eviction, must still reach clear_field()/_ratify() - otherwise
-        nfc_self_verify_distance would be configured but silently do nothing.
+        A machine that only wants the scan-context self-jog ratification escalation, with
+        neither neighbor check nor eviction nor the preload distance, must still reach
+        clear_field()/_ratify() - otherwise nfc_gate_clear_distance would be configured but
+        silently do nothing.
         """
         self.hh.mmu.mmu_unit(0).p.gate_homing_endstop = 'mmu_exit'
-        self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance = -40.0
+        self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance = -40.0
+        self.assertIsNotNone(self.hh.mmu._nfc_field_arm(0))
+
+    def test_preload_clear_distance_alone_arms(self):
+        """Same as above, but for the independent preload-context distance."""
+        self.hh.mmu.mmu_unit(0).p.gate_homing_endstop = 'mmu_exit'
+        self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance = 0.0
+        self.hh.mmu.mmu_unit(0).p.nfc_preload_clear_distance = -40.0
         self.assertIsNotNone(self.hh.mmu._nfc_field_arm(0))
 
     def test_encoder_homing_never_arms(self):
@@ -274,60 +282,116 @@ class TestNeighborEvictDistanceValidation(NeighborTestCase):
         self.assertEqual(self.hh.mmu.mmu_unit(0).p.gate_homing_endstop, 'mmu_shared_exit')
 
 
-class TestSelfVerifyDistanceValidation(NeighborTestCase):
+class TestClearDistanceValidation(NeighborTestCase):
     """
-    Config validation for nfc_self_verify_distance, and its on_change revalidation - mirrors
-    TestNeighborEvictDistanceValidation exactly, since the validator logic is the same shape,
-    but nfc_self_verify_distance is a genuinely independent parameter (see
-    MmuNfcFieldArbiter._ratify) so it gets its own coverage rather than assuming the other
-    class's tests are enough.
+    Config validation for nfc_gate_clear_distance / nfc_preload_clear_distance, and their
+    on_change revalidation. Unlike nfc_neighbor_evict_distance, these have NO window-fit
+    check at all: the self-jog and its restore are both plain relative moves off the
+    already-established park position (see MmuNfcFieldArbiter._verify_by_self_jog) - there is
+    no re-home involved, so there is no re-homing budget to bound them against. Only the
+    forward-jog-vs-shared-endstop safety rule applies, same shape as
+    TestNeighborEvictDistanceValidation, checked against each parameter's OWN endstop.
     """
 
-    def test_zero_disables_and_needs_no_window(self):
-        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=0')
+    def test_zero_disables(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=0')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_preload_clear_distance=0')
         self.assertEqual(self.hh.errors, [])
 
-    def test_forward_jog_rejected_on_shared_endstop(self):
+    def test_any_magnitude_is_accepted_with_no_window_fit_check(self):
+        """Deliberately left to the user to size sensibly - not bounded against anything."""
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_exit')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=-999')
+        self.assertEqual(self.hh.errors, [])
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance, -999.0)
+
+    def test_gate_forward_jog_rejected_on_shared_endstop(self):
         self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_shared_exit')
         self.assertEqual(self.hh.errors, [])
         with self.assertRaises(Exception) as cm:
-            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=40')
-        self.assertIn('nfc_self_verify_distance', str(cm.exception))
-        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance, 0.0)
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=40')
+        self.assertIn('nfc_gate_clear_distance', str(cm.exception))
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance, 0.0)
 
-    def test_backward_jog_accepted_on_shared_endstop(self):
+    def test_gate_backward_jog_accepted_on_shared_endstop(self):
         self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_shared_exit')
-        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=-40')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=-40')
         self.assertEqual(self.hh.errors, [])
-        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance, -40.0)
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance, -40.0)
 
-    def test_forward_jog_accepted_on_a_per_gate_exit_endstop(self):
+    def test_gate_forward_jog_accepted_on_a_per_gate_exit_endstop(self):
         self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_exit')
         self.assertEqual(self.hh.errors, [])
-        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=40')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=40')
         self.assertEqual(self.hh.errors, [])
 
-    def test_out_of_window_distance_is_rejected(self):
-        with self.assertRaises(Exception) as cm:
-            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=-999')
-        self.assertIn('nfc_gate_jog_scan_window', str(cm.exception))
-
-    def test_switching_to_a_shared_endstop_rechecks_a_stale_self_verify_distance(self):
+    def test_switching_to_a_shared_endstop_rechecks_a_stale_gate_clear_distance(self):
         self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_exit')
-        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=40')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=40')
         self.assertEqual(self.hh.errors, [])
         with self.assertRaises(Exception) as cm:
             self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_shared_exit')
-        self.assertIn('nfc_self_verify_distance', str(cm.exception))
+        self.assertIn('nfc_gate_clear_distance', str(cm.exception))
         self.assertEqual(self.hh.mmu.mmu_unit(0).p.gate_homing_endstop, 'mmu_shared_exit')
 
+    def test_preload_can_diverge_from_gate_including_in_sign(self):
+        """
+        Confirms the two are genuinely independent, not just two names for one value - the
+        motivating case from the user's own request: opposite-signed clear jogs for preload
+        (forward) vs scan (backward), since the two operations can home/park via different
+        endstops. (The "preload defaults to gate" relationship is a boot-time ParamSpec
+        default - like nfc_preload_jog_scan_window's own default - not something a later
+        MMU_TEST_CONFIG change re-derives live, so that half isn't exercised here.)
+        """
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=-40')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=mmu_exit')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_preload_clear_distance=25')
+        self.assertEqual(self.hh.errors, [])
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance, -40.0,
+                         'setting the preload distance must not disturb the gate distance')
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_preload_clear_distance, 25.0)
+
+    def test_preload_forward_jog_rejected_on_its_own_shared_endstop(self):
+        """The preload distance is checked against the PRELOAD endstop, not the gate one."""
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_exit')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=mmu_shared_exit')
+        self.assertEqual(self.hh.errors, [])
+        with self.assertRaises(Exception) as cm:
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_preload_clear_distance=40')
+        self.assertIn('nfc_preload_clear_distance', str(cm.exception))
+
+    def test_preload_endstop_unset_inherits_gate_homing_endstop_for_validation(self):
+        """
+        gate_preload_endstop='' inherits gate_homing_endstop, same as everywhere else - the
+        test profile's own boot-time default already resolves it to a concrete value
+        ('mmu_exit'), so it has to be forced back to '' explicitly to exercise inheritance.
+        """
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_shared_exit')
+        self.assertEqual(self.hh.errors, [])
+        with self.assertRaises(Exception) as cm:
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_preload_clear_distance=40')
+        self.assertIn('nfc_preload_clear_distance', str(cm.exception))
+
+    def test_switching_preload_endstop_rechecks_a_stale_preload_clear_distance(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_homing_endstop=mmu_exit')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=mmu_exit')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_preload_clear_distance=40')
+        self.assertEqual(self.hh.errors, [])
+        with self.assertRaises(Exception) as cm:
+            self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=mmu_shared_exit')
+        self.assertIn('nfc_preload_clear_distance', str(cm.exception))
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.gate_preload_endstop, 'mmu_shared_exit')
+
     def test_independent_of_neighbor_evict_distance(self):
-        """The two parameters must not interfere with each other's validation or value."""
+        """The three parameters must not interfere with each other's validation or value."""
         self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_neighbor_evict_distance=-10')
-        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_self_verify_distance=-40')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_gate_clear_distance=-40')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 nfc_preload_clear_distance=-25')
         self.assertEqual(self.hh.errors, [])
         self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance, -10.0)
-        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance, -40.0)
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance, -40.0)
+        self.assertEqual(self.hh.mmu.mmu_unit(0).p.nfc_preload_clear_distance, -25.0)
 
 
 class TestGateRfidPlumbing(NeighborTestCase):
@@ -462,17 +526,17 @@ class TestArbitrationEndToEnd(NeighborTestCase):
         it, the read taken mid-sweep would already have been committed to the gate map by
         the time this assertion runs, warning or no warning.
 
-        nfc_self_verify_distance is deliberately -10.0, not some larger value: the passive
+        nfc_gate_clear_distance is deliberately -10.0, not some larger value: the passive
         check fails (tag_pos=-80, dead center), and ratification now escalates to a self-jog
         of -10mm too (tip -110 -> tag_pos -90, |-90-(-80)|=10 <= the 15 tag_window - still
-        detected). Kept inside the window on purpose, so this test exercises "escalation
-        was attempted and still correctly failed to clear", not "escalation never ran at
-        all" - see test_provisional_verdict_is_ratified_via_self_jog_when_passive_check_fails_scan
+        detected). Kept small on purpose, so this test exercises "escalation was attempted
+        and still correctly failed to clear", not "escalation never ran at all" - see
+        test_provisional_verdict_is_ratified_via_self_jog_when_passive_check_fails_scan
         for the -40.0 case where the self-jog actually clears it. nfc_neighbor_evict_distance
         is deliberately left at its default 0 - proves self-jog escalation runs on its own,
         independent of neighbor eviction (see MmuNfcFieldArbiter._ratify).
         """
-        self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance = -10.0
+        self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance = -10.0
         self.fil.attach_tag(0, TAG, offset=-20.0)  # unregistered, and never truly clears
         self.hh.mmu.select_gate(0)
         self.hh.place_filament(0)  # normal park position
@@ -494,10 +558,10 @@ class TestArbitrationEndToEnd(NeighborTestCase):
         normal homing path rather than the "already preloaded" shortcut (which would bypass
         arbitration entirely), while still putting the tag in range from the very start (see
         the scan test's docstring for the offset/park/reader arithmetic, and for why
-        nfc_self_verify_distance is -10.0 here too - self-jog escalation must run and
+        nfc_preload_clear_distance is -10.0 here too - self-jog escalation must run and
         still fail, independent of neighbor eviction which stays at its default 0).
         """
-        self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance = -10.0
+        self.hh.mmu.mmu_unit(0).p.nfc_preload_clear_distance = -10.0
         self.fil.attach_tag(0, TAG, offset=-20.0)
         self.hh.mmu.select_gate(0)
         self.hh.place_filament(0)  # normal park position, exit sensor not yet triggered
@@ -522,7 +586,7 @@ class TestArbitrationEndToEnd(NeighborTestCase):
         need neighbor eviction armed at all.
         """
         self.hh.mmu.p.log_level = 4  # so the self-jog's own log_debug lines are visible
-        self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance = -40.0
+        self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance = -40.0
         self.fil.attach_tag(0, TAG, offset=-20.0)
         self.hh.mmu.select_gate(0)
         self.hh.place_filament(0)
@@ -539,7 +603,7 @@ class TestArbitrationEndToEnd(NeighborTestCase):
     def test_provisional_verdict_is_ratified_via_self_jog_when_passive_check_fails_preload(self):
         """Preload's side of the self-jog-succeeds scenario above."""
         self.hh.mmu.p.log_level = 4
-        self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance = -40.0
+        self.hh.mmu.mmu_unit(0).p.nfc_preload_clear_distance = -40.0
         self.fil.attach_tag(0, TAG, offset=-20.0)
         self.hh.mmu.select_gate(0)
         self.hh.place_filament(0)
@@ -555,10 +619,10 @@ class TestArbitrationEndToEnd(NeighborTestCase):
 
     def test_check_only_mode_spends_zero_extra_motion_on_a_never_ratified_read(self):
         """
-        nfc_neighbor_check=1 with both nfc_neighbor_evict_distance=0 and
-        nfc_self_verify_distance=0 (both default) must keep the "no motion budget at all"
-        promise even with self-jog escalation added: _ratify's `if distance and ...` guard
-        is false for distance=0, so it falls straight to the unchanged passive-only
+        nfc_neighbor_check=1 with nfc_neighbor_evict_distance=0 and both nfc_gate_clear_distance
+        and nfc_preload_clear_distance=0 (all default) must keep the "no motion budget at
+        all" promise even with self-jog escalation added: _ratify's `if distance and ...`
+        guard is false for distance=0, so it falls straight to the unchanged passive-only
         discard, exactly as before this feature existed. log_level=4 makes _jog_off's own
         "jogging ... off its park reference" debug line visible if it ran at all -
         asserting its absence is a direct check that neither neighbor eviction nor the
@@ -566,7 +630,7 @@ class TestArbitrationEndToEnd(NeighborTestCase):
         """
         self.hh.mmu.p.log_level = 4
         self.hh.mmu.mmu_unit(0).p.nfc_neighbor_evict_distance = 0.0
-        self.hh.mmu.mmu_unit(0).p.nfc_self_verify_distance = 0.0
+        self.hh.mmu.mmu_unit(0).p.nfc_gate_clear_distance = 0.0
         self.fil.attach_tag(0, TAG, offset=-20.0)
         self.hh.mmu.select_gate(0)
         self.hh.place_filament(0)


### PR DESCRIPTION
## Summary

- Fixes provisional NFC attribution for a gate's own tag when the tag remains in range at the normal park position: ratification can now perform a deliberate self-jog, re-probe, and return to park.
- Adds independent, park-relative `nfc_gate_clear_distance` (`MMU_NFC_SCAN`) and `nfc_preload_clear_distance` (`MMU_PRELOAD`) settings. Both default to `0`/off; preload defaults to the gate value but can be configured independently, including with a different sign.
- Keeps operation arming isolated: a preload-only clear distance does not arm or alter `MMU_NFC_SCAN`, and a scan-only clear distance does not arm or alter `MMU_PRELOAD`.
- Bounds each clear jog by its matching homing profile. The jog magnitude cannot exceed the homing maximum, and the park offset plus a backward jog cannot reach beyond that recovery range.
- Revalidates clear-jog safety when homing endstops, parking distances, or homing maxima change live. Ratification repeats the reach and shared-endstop checks at runtime so stale/direct state cannot execute unsafe motion.
- Reuses the existing symmetric `_jog_off` primitive and keeps neighbor eviction independent under `nfc_neighbor_evict_distance`.

## Isolation / compatibility

All arbitration controls remain off by default. With `nfc_neighbor_check=0`, `nfc_neighbor_evict_distance=0`, and both clear distances at `0`, `_nfc_field_arm()` returns `None`; `clear_field()` is an inert passthrough with no extra reader I/O or motion, preserving the previous scan/preload paths.

The new self-jog runs only for an unregistered/provisional tag that remains visible after the operation's normal movement, and only for the operation whose clear distance is enabled.

## Test plan

- [x] Focused NFC suites: 140 tests pass (`test_mmu_nfc_neighbor.py`, `test_mmu_nfc_scan.py`, `test_mmu_nfc.py`)
- [x] Full suite: 1,146 tests pass (`skipped=1`, `expected failures=4`)
- [x] Regression: preload-only clear distance leaves `MMU_NFC_SCAN` on its zero-motion fast path
- [x] Regression: oversized jog magnitude and park-relative backward target are rejected
- [x] Regression: live parking/homing/endstop changes revalidate dependent clear distances
- [x] Runtime guard: stale out-of-reach values cannot execute a self-jog
- [x] Existing scan and preload self-jog success/failure cases remain covered

## Hardware note

The harness validates sequencing, attribution, configuration, and simulated filament position. Genuine cross-reader RF crosstalk, step generation, drive slip, and physical reader coupling still require hardware verification.

🤖 Generated with Codex
