### PR TITLE
Make selector homing refuse loaded filament

### DIFF
--- a/config/macros/mmu_misc.cfg
+++ b/config/macros/mmu_misc.cfg
@@ -231,8 +231,7 @@ gcode: MMU_EJECT
 [gcode_macro MMU__HOME]
 gcode:
     {% set tool = params.TOOL|default(0)|int %}
-    {% set force_unload = params.FORCE_UNLOAD|default(0)|int %}
-    MMU_HOME UNIT=ALL TOOL={tool} FORCE_UNLOAD={force_unload}
+    MMU_HOME UNIT=ALL TOOL={tool}
 
 [gcode_macro MMU__STATUS]
 gcode: MMU_STATUS

--- a/extras/mmu/commands/mmu_home.py
+++ b/extras/mmu/commands/mmu_home.py
@@ -28,7 +28,6 @@ class MmuHomeCommand(BaseCommand):
         f"{CMD}: {HELP_BRIEF}\n"
         + "UNIT         = #(int)|_name_|ALL Specify unit by name, number or all-units (optional if single unit)\n"
         + "TOOL         = #(int) Optionally select tool number after homing\n"
-        + "FORCE_UNLOAD = [0|1]  Omit to unload when needed; 1 forces recovery; 0 homes without unloading\n"
         + "SKIP_HOMED   = [0|1]  Skip homing of units that are already homed\n"
         + "(no parameters: home selector on single unit setup and select T0)\n"
     )
@@ -36,7 +35,7 @@ class MmuHomeCommand(BaseCommand):
         "Examples:\n"
         + f"{CMD} UNIT=ALL              ...Home all mmu units with selector kinimatics\n"
         + f"{CMD} UNIT=ALL SKIP_HOMED=1 ...Home only units that are not already homed\n"
-        + f"{CMD} UNIT=1 FORCE_UNLOAD=1 ...Home unit 1 unloading filament if necessary\n"
+        + f"{CMD} UNIT=1              ...Home unit 1\n"
     )
 
     def __init__(self, mmu):
@@ -61,10 +60,8 @@ class MmuHomeCommand(BaseCommand):
         if self.check_if_not_calibrated(CALIBRATED_SELECTOR, mmu_unit=mmu_unit):
             mmu.log_always("Not calibrated. Will attempt to home to endstop")
             tool = -1
-            force_unload = 0
         else:
             tool = gcmd.get_int('TOOL', mmu.tool_selected, minval=0, maxval=mmu.num_gates - 1)
-            force_unload = gcmd.get_int('FORCE_UNLOAD', None, minval=0, maxval=1)
         skip_homed = gcmd.get_int('SKIP_HOMED', 0, minval=0, maxval=1)
 
         # With UNIT=ALL this handler is called once per unit. Defer the tool selection
@@ -79,7 +76,7 @@ class MmuHomeCommand(BaseCommand):
                 if skip_homed and mmu_unit.selector.is_homed:
                     mmu.log_always("Skipped homing %s (not necessary / already homed)" % mmu_unit.name if all_units else "Skipped homing (not necessary / already homed)")
                 else:
-                    mmu.home_unit(mmu_unit, force_unload=force_unload, reselect=False)
+                    mmu.home_unit(mmu_unit, reselect=False)
                     mmu.log_always("Homed %s" % mmu_unit.name if all_units else "Homed")
 
                 # Always select gate for chosen tool (just once, at the end, if UNIT=ALL)

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -402,18 +402,12 @@ class MmuController(MmuFilamentMovement):
                     continue
 
                 if u.p.startup_home_selector:
-                    unit_loaded = (
-                        self.filament_pos != FILAMENT_POS_UNLOADED and
-                        (self.gate_selected == TOOL_GATE_UNKNOWN or
-                         self._unit_owns_selection(u, self.gate_selected))
-                    )
-
-                    if unit_loaded:
+                    if self._unit_may_have_filament(u):
                         self.log_warning(f"Skipping autohome of {u.name} because it may have filament loaded (or filament state could not be confirmed)")
                         continue
 
                     try:
-                        self.home_unit(u, force_unload=False) # Startup never initiates filament movement
+                        self.home_unit(u)
 
                     except Exception as e:
                         # This is recoverable so just report errors
@@ -3125,45 +3119,35 @@ class MmuController(MmuFilamentMovement):
         return False
 
 
-    def home_unit(self, mmu_unit, force_unload=None, reselect=True):
+    def _unit_may_have_filament(self, mmu_unit):
+        """Whether selector motion on mmu_unit may be obstructed by filament."""
+        return (
+            self.filament_pos != FILAMENT_POS_UNLOADED and
+            (self.gate_selected == TOOL_GATE_UNKNOWN or
+             self._unit_owns_selection(mmu_unit, self.gate_selected))
+        )
+
+
+    def home_unit(self, mmu_unit, reselect=True):
         """
         Home the specific mmu unit
         Params:
-          force_unload - whether to unload current gate
-            None  - intelligently unload if necessary (default)
-            True  - always force an unload regardless of filament position state (safety)
-            False - never unload; explicit override when gate ownership is unknown
           reselect - whether to reselect gate (default is True)
         """
         selector = mmu_unit.selector
         if not selector.requires_homing: return # Class-B and other non-physical selectors
-        if force_unload is not None:
-            force_unload = bool(force_unload) # G-Code supplies 0/1 integers
 
         prev_gate = self.gate_selected
         owns_selection = self._unit_owns_selection(mmu_unit, prev_gate)
 
-        # With no gate identity there is no safe drive or unit to unload. In particular,
-        # manages_gate(UNKNOWN) is true for every unit, so never use it to infer ownership.
-        if (
-            prev_gate == TOOL_GATE_UNKNOWN and
-            self.filament_pos != FILAMENT_POS_UNLOADED and
-            force_unload is not False
-        ):
-            raise MmuError(
-                "Cannot home %s because filament state or gate ownership is unknown. "
-                "Use MMU_RECOVER GATE=xx first, or FORCE_UNLOAD=0 to home without unloading" % mmu_unit.name)
-
-        # Filament policy belongs here, while the real gate still identifies its unit and
-        # drive. selector.home() is deliberately mechanical and must not infer ownership.
-        if owns_selection:
-            if force_unload is False:
-                if self.filament_pos not in [FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN]:
-                    raise MmuError("Cannot home %s because it has filament loaded" % mmu_unit.name)
-            elif force_unload is True:
-                self.unload_sequence(check_state=True)
-            elif self.filament_pos != FILAMENT_POS_UNLOADED:
-                self.unload_sequence()
+        # Selector homing never moves filament. Refuse unless the target unit is definitely
+        # empty; an unrelated unit may still home without disturbing the active filament.
+        if self._unit_may_have_filament(mmu_unit):
+            if prev_gate == TOOL_GATE_UNKNOWN:
+                raise MmuError(
+                    "Cannot home %s because filament state or gate ownership is unknown. "
+                    "Use MMU_RECOVER GATE=xx first" % mmu_unit.name)
+            raise MmuError("Cannot home %s because it may have filament loaded. Unload filament first" % mmu_unit.name)
 
         # An unrelated unit can home without disturbing the active gate. For the owning unit
         # (or an empty, as-yet-unselected machine), invalidate the logical selection before the

--- a/extras/mmu/unit/selectors/mmu_base_selectors.py
+++ b/extras/mmu/unit/selectors/mmu_base_selectors.py
@@ -93,7 +93,7 @@ class BaseSelector:
         pass
 
 
-    def home(self, force_unload = None):
+    def home(self):
         pass
 
 
@@ -330,13 +330,12 @@ class PhysicalSelector(BaseSelector, object):
         self.var_manager.write() # One flush, so the pair can never land separately
 
 
-    def home(self, force_unload = None):
+    def home(self):
         """
         Home the physical selector mechanism.
 
-        Filament unload policy is owned by MmuController.home_unit(), which can
-        make the decision while the selected gate still identifies the correct
-        unit and drive. The argument remains for selector interface compatibility.
+        MmuController.home_unit() verifies that selector motion cannot be
+        obstructed by filament before calling this mechanical operation.
         """
         if not self.requires_homing: return
         if self.check_if_unit_bypass(): return
@@ -375,10 +374,8 @@ class PhysicalSelector(BaseSelector, object):
         """
         Similar to MMU controller check but localized to specific selector
         """
-        if not self.mmu_unit.manages_gate(self.mmu.gate_selected):
-            return False
-        if self.mmu.filament_pos not in [FILAMENT_POS_UNLOADED, FILAMENT_POS_UNKNOWN]:
-            self.mmu.log_error("Operation not possible. Filament is loaded")
+        if self.mmu._unit_may_have_filament(self.mmu_unit):
+            self.mmu.log_error("Operation not possible. Filament may be loaded or its state is unknown")
             return True
         return False
 
@@ -505,7 +502,7 @@ class MmuSoaktestSelectorCommand(BaseCommand):
                     gate = random.randint(min_gate, max_gate)
 
                     if random.randint(0, 10) == 0 and home:
-                        mmu.home_unit(mmu_unit, force_unload=False)
+                        mmu.home_unit(mmu_unit)
 
                     if random.randint(0, 10) == 0 and mmu_unit.selector.has_bypass():
                         mmu.log_always("Testing loop %d / %d. Selecting bypass..." % (l + 1, loops))

--- a/extras/mmu/unit/selectors/mmu_indexed_selector.py
+++ b/extras/mmu/unit/selectors/mmu_indexed_selector.py
@@ -499,6 +499,8 @@ class MmuCalibrateSelectorIndexesCommand(BaseCommand):
             mmu.log_always(f"Reset selector index calibration on {mmu_unit.name}")
             return
 
+        if selector.check_if_unit_loaded(): return
+
         mmu.log_always(f"Calibrating selector indexes on {mmu_unit.name}...")
 
         try:

--- a/extras/mmu/unit/selectors/mmu_linear_selector.py
+++ b/extras/mmu/unit/selectors/mmu_linear_selector.py
@@ -786,6 +786,8 @@ class MmuCalibrateSelectorCommand(BaseCommand):
             selector.calibrator.mark_not_calibrated(CALIBRATED_SELECTOR)
             return
 
+        if selector.check_if_unit_loaded(): return
+
         if gate is not None and not mmu_unit.manages_gate(gate):
             raise gcmd.error("Gate %d is not managed by %s (range=%d-%d)" % (gate, mmu_unit.name, min_gate, max_gate))
 

--- a/extras/mmu/unit/selectors/mmu_rotary_selector.py
+++ b/extras/mmu/unit/selectors/mmu_rotary_selector.py
@@ -552,6 +552,8 @@ class MmuCalibrateRotarySelectorCommand(BaseCommand):
             self.mmu.log_error("Operation not possible on this selector type (RotarySelector only)")
             return
 
+        if selector.check_if_unit_loaded(): return
+
         save = gcmd.get_int('SAVE', 1, minval=0, maxval=1)
         single = gcmd.get_int('SINGLE', 0, minval=0, maxval=1)
         quick = gcmd.get_int('QUICK', 0, minval=0, maxval=1)

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -1177,12 +1177,16 @@ class Session:
         Named per unit because MMU_HOME insists on it once more than one is configured
         (mmu_base_command.py:198). No-op on a VirtualSelector machine.
         """
+        # Unlike production code, the harness owns the complete physical model and knows the
+        # active path is empty. Publish that fact explicitly: MMU_HOME deliberately no longer
+        # accepts an override that homes through an unresolved filament state.
+        from extras.mmu.mmu_constants import FILAMENT_POS_UNLOADED
+        self.mmu.set_filament_pos_state(FILAMENT_POS_UNLOADED, silent=True)
+
         homed = []
         for index, unit in enumerate(self.mmu.mmu_machine.units):
             if getattr(unit.selector, 'selector_stepper', None) is not None:
-                # The harness knows its freshly-created selector paths are empty even when
-                # preloaded gate sensors make the machine-wide filament state ambiguous.
-                self.gcode.run_script('MMU_HOME UNIT=%d FORCE_UNLOAD=0' % index)
+                self.gcode.run_script('MMU_HOME UNIT=%d' % index)
                 homed.append(unit.name)
         return homed
 

--- a/test/test_mmu_selector.py
+++ b/test/test_mmu_selector.py
@@ -471,6 +471,18 @@ class TestRotarySelectorOnALaterUnit(SelectorTestCase):
                           % self.UNIT1_FIRST_GATE)
         self.assertEqual(self.hh.errors, [])
 
+    def test_rotary_calibration_refuses_filament_on_its_own_unit(self):
+        gate = self.UNIT1_FIRST_GATE
+        before = list(self.selector('unit1').selector_offsets)
+        self.hh.run_gcode('MMU_SELECT GATE=%d' % gate)
+        self.hh.mmu.set_filament_pos_state(FILAMENT_POS_LOADED, silent=True)
+
+        self.hh.run_gcode('MMU_CALIBRATE_ROTARY_SELECTOR UNIT=1 GATE=%d QUICK=1 SAVE=0'
+                          % gate)
+
+        self.assertEqual(self.selector('unit1').selector_offsets, before)
+        self.assertTrue(any('Filament may be loaded' in error for error in self.hh.errors))
+
 
 class TestSelectorCalibration(unittest.TestCase):
     """
@@ -549,6 +561,17 @@ class TestSelectorCalibration(unittest.TestCase):
         # handle_ready seeds the variable with -1 per gate, which IS the uncalibrated value
         self.assertEqual(self.saved_offsets(), [-1] * self.hh.mmu.num_gates,
                          'a bogus measurement was saved')
+
+    def test_linear_calibration_refuses_filament_before_selector_motion(self):
+        before = self.axis.carriage
+        self.hh.mmu._set_gate_selected(0)
+        self.hh.mmu.set_filament_pos_state(FILAMENT_POS_LOADED, silent=True)
+
+        self.hh.run_gcode('MMU_CALIBRATE_SELECTOR UNIT=0 GATE=0')
+
+        self.assertEqual(self.axis.carriage, before)
+        self.assertEqual(self.saved_offsets(), [-1] * self.hh.mmu.num_gates)
+        self.assertTrue(any('Filament may be loaded' in error for error in self.hh.errors))
 
 
 class TestStepperPositionSemantics(unittest.TestCase):
@@ -644,6 +667,18 @@ class TestMultiUnitSelectors(SelectorTestCase):
         self.assertEqual(self.hh.mmu.gate_selected, 12, self.hh.errors)
         self.assertEqual(self.selector('unit1').lgate_selected, 3)
         self.assertEqual(self.hh.errors, [])
+
+    def test_index_calibration_refuses_filament_before_selector_motion(self):
+        gate = 10
+        axis = self.axis('unit1')
+        self.hh.run_gcode('MMU_SELECT GATE=%d' % gate)
+        self.hh.mmu.set_filament_pos_state(FILAMENT_POS_LOADED, silent=True)
+        before = axis.carriage
+
+        self.hh.run_gcode('MMU_CALIBRATE_SELECTOR_INDEXES UNIT=1 SAVE=0')
+
+        self.assertEqual(axis.carriage, before)
+        self.assertTrue(any('Filament may be loaded' in error for error in self.hh.errors))
 
     def test_unit0_loads_and_unloads(self):
         """
@@ -964,14 +999,14 @@ class TestPersistedPositionRestore(unittest.TestCase):
         persisted state - anything that leaves cmd_MMU_BOOTUP's own recovery attempt short of a
         definite answer) must not be treated as "safe to auto-home". Before the fix,
         FILAMENT_POS_UNKNOWN was explicitly exempted from the boot skip-check, so bootup would
-        proceed into home_unit() -> PhysicalSelector.home(), whose "automatic unload case" branch
-        then runs a real unload_sequence() - which can heat the extruder - based on nothing more
-        than an ambiguous read. The fix (mmu_controller.py's autohoming loop) must skip and warn
-        instead, leaving the unload untouched.
+        proceed into selector homing based on nothing more than an ambiguous read. The startup
+        loop must skip and warn instead, leaving both filament and selector untouched.
 
         No gate is seeded here: an unresolved filament_pos is most likely exactly when no gate
         has ever been selected either (a fresh install), and that combination is what let the old
-        check's `gate_selected != TOOL_GATE_UNKNOWN` clause slip past it too.
+        check's `gate_selected != TOOL_GATE_UNKNOWN` clause slip past it too. Selector homing
+        now never unloads, but this remains the startup guard against moving a carriage when
+        filament presence cannot be ruled out.
 
         Not using self.boot(): a genuinely unresolved state legitimately produces two
         informational errors of its own (the rigged sensor failure itself, and
@@ -1009,9 +1044,9 @@ class TestPersistedPositionRestore(unittest.TestCase):
         is machine-wide, not per-unit, so on a multi-unit machine it reflects whichever gate is
         currently selected - here, one that belongs to unit0, not unit1.
 
-        home_unit() now owns all unload policy and checks real ownership before changing
-        gate_selected. PhysicalSelector.home() is mechanical only, so an unrelated unit never
-        gets a second opportunity to infer ownership from the machine-wide UNKNOWN sentinel.
+        home_unit() checks real ownership before changing gate_selected. PhysicalSelector.home()
+        is mechanical only, so an unrelated unit never gets a second opportunity to infer
+        ownership from the machine-wide UNKNOWN sentinel.
         This test pins that by construction: unit0 genuinely owns gate 3 with a real (not
         ambiguous) FILAMENT_POS_LOADED, and both units ask for startup homing at once.
         """
@@ -1041,9 +1076,40 @@ class TestPersistedPositionRestore(unittest.TestCase):
                          "unit1's homing must not disturb unit0's gate selection")
         self.assertEqual(hh.errors, [])
 
+    def test_startup_home_failure_does_not_stop_other_units_or_bootup(self):
+        """A failed physical home is local and must not truncate delayed initialization."""
+        later_home_calls = []
+        downstream_calls = []
 
-class TestHomeUnitUnloadPolicy(unittest.TestCase):
-    """Controller owns filament policy; selector.home() owns only selector motion."""
+        def rig_first_unit_failure():
+            hh = self.hh
+            hh.run_gcode('MMU_TEST_CONFIG UNIT=0 startup_home_selector=1')
+            hh.run_gcode('MMU_TEST_CONFIG UNIT=1 startup_home_selector=1')
+            units = hh.mmu.mmu_machine.units
+
+            def fail_home():
+                raise Exception('harness: startup selector jammed')
+
+            units[0].selector.selector_stepper.do_home_rail = fail_home
+            units[1].selector._home_selector = lambda: later_home_calls.append(True)
+            hh.mmu._spoolman_sync = lambda: downstream_calls.append('spoolman')
+            hh.mmu._moonraker_sync_lane_data = lambda: downstream_calls.append('lanes')
+
+        self.hh = session('ercf_vvd')
+        self.hh.boot(calibrate=True, pre_bootup=rig_first_unit_failure)
+        hh = self.hh
+
+        self.assertEqual(later_home_calls, [True],
+                         'the first unit failure stopped startup homing of the next unit')
+        self.assertEqual(downstream_calls, ['spoolman', 'lanes'])
+        self.assertEqual(hh.mmu.psm.print_state, 'initialized')
+        self.assertTrue(hh.fired('mmu:bootup'))
+        self.assertTrue(any('startup selector jammed' in error for error in hh.errors))
+        self.assertFalse(any('Error booting up MMU' in error for error in hh.errors), hh.errors)
+
+
+class TestHomeUnitFilamentGuard(unittest.TestCase):
+    """Selector homing never moves filament and requires the target unit to be empty."""
 
     GATE = 3
 
@@ -1064,130 +1130,80 @@ class TestHomeUnitUnloadPolicy(unittest.TestCase):
         self.hh.run_gcode('MMU_SELECT GATE=%d' % self.GATE)
         self.mmu.set_filament_pos_state(state, silent=True)
 
-    def _record_successful_unload(self):
+    def _record_unload_attempts(self):
         calls = []
 
         def unload(*args, **kwargs):
             calls.append((self.mmu.gate_selected, args, kwargs))
-            self.mmu.set_filament_pos_state(FILAMENT_POS_UNLOADED, silent=True)
 
         self.mmu.unload_sequence = unload
         return calls
 
-    def test_automatic_policy_unloads_before_forgetting_the_owning_gate(self):
+    def test_home_unit_refuses_loaded_filament_without_motion(self):
         self._select_loaded_gate()
-        calls = self._record_successful_unload()
+        unload_calls = self._record_unload_attempts()
+        home_calls = []
+        self.selector._home_selector = lambda: home_calls.append(True)
 
-        self.mmu.home_unit(self.unit, force_unload=None, reselect=False)
+        with self.assertRaisesRegex(Exception, 'Unload filament first'):
+            self.mmu.home_unit(self.unit, reselect=False)
 
-        self.assertEqual(calls, [(self.GATE, (), {})])
-        self.assertEqual(self.mmu.gate_selected, TOOL_GATE_UNKNOWN)
-        self.assertTrue(self.selector.is_homed)
-
-    def test_automatic_policy_can_recover_unknown_filament_when_gate_is_known(self):
-        self._select_loaded_gate(FILAMENT_POS_UNKNOWN)
-        calls = self._record_successful_unload()
-
-        self.mmu.home_unit(self.unit, force_unload=None, reselect=False)
-
-        self.assertEqual(calls, [(self.GATE, (), {})])
-        self.assertEqual(self.mmu.gate_selected, TOOL_GATE_UNKNOWN)
-
-    def test_forced_policy_preserves_gate_identity_during_state_recovery(self):
-        self._select_loaded_gate(FILAMENT_POS_UNKNOWN)
-        calls = self._record_successful_unload()
-
-        self.mmu.home_unit(self.unit, force_unload=True, reselect=False)
-
-        self.assertEqual(calls, [(self.GATE, (), {'check_state': True})])
-        self.assertEqual(self.mmu.gate_selected, TOOL_GATE_UNKNOWN)
-
-    def test_gcode_force_unload_one_uses_forced_policy(self):
-        self._select_loaded_gate()
-        calls = self._record_successful_unload()
-
-        self.hh.run_gcode('MMU_HOME UNIT=0 FORCE_UNLOAD=1')
-
-        self.assertEqual(calls, [(self.GATE, (), {'check_state': True})])
-        self.assertEqual(self.hh.errors, [])
-
-    def test_gcode_force_unload_zero_never_unloads(self):
-        self._select_loaded_gate()
-        calls = self._record_successful_unload()
-
-        self.hh.run_gcode('MMU_HOME UNIT=0 FORCE_UNLOAD=0')
-
-        self.assertEqual(calls, [])
+        self.assertEqual(unload_calls, [])
+        self.assertEqual(home_calls, [])
         self.assertEqual(self.mmu.gate_selected, self.GATE)
-        self.assertTrue(any('has filament loaded' in error for error in self.hh.errors))
 
-    def test_default_gcode_home_performs_a_real_automatic_unload(self):
-        self.hh.place_filament(self.GATE, position=TIP_AT_GATE)
-        self.hh.run_gcode('MMU_PRELOAD GATE=%d' % self.GATE)
-        self.hh.run_gcode('MMU_SELECT GATE=%d' % self.GATE)
-        self.hh.run_gcode('MMU_LOAD')
-        self.assertEqual(self.mmu.filament_pos, FILAMENT_POS_LOADED)
+    def test_gcode_home_reports_loaded_filament_without_unloading(self):
+        self._select_loaded_gate()
+        unload_calls = self._record_unload_attempts()
 
         self.hh.run_gcode('MMU_HOME UNIT=0')
 
-        self.assertEqual(self.mmu.filament_pos, FILAMENT_POS_UNLOADED)
-        self.assertTrue(self.selector.is_homed)
-        self.assertEqual(self.hh.errors, [])
-
-    def test_failed_unload_keeps_the_owning_gate_for_recovery(self):
-        self._select_loaded_gate()
-        calls = []
-
-        def fail_unload(*args, **kwargs):
-            calls.append(self.mmu.gate_selected)
-            from extras.mmu.mmu_utils import MmuError
-            raise MmuError('simulated unload failure')
-
-        self.mmu.unload_sequence = fail_unload
-
-        with self.assertRaisesRegex(Exception, 'simulated unload failure'):
-            self.mmu.home_unit(self.unit, force_unload=None, reselect=False)
-
-        self.assertEqual(calls, [self.GATE])
+        self.assertEqual(unload_calls, [])
         self.assertEqual(self.mmu.gate_selected, self.GATE)
+        self.assertTrue(any('Unload filament first' in error for error in self.hh.errors))
 
-    def test_autohome_unload_failure_also_keeps_the_owning_gate(self):
+    def test_select_gate_autohome_refuses_loaded_filament(self):
         self._select_loaded_gate()
         self.selector.is_homed = False
+        unload_calls = self._record_unload_attempts()
 
-        def fail_unload(*args, **kwargs):
-            from extras.mmu.mmu_utils import MmuError
-            raise MmuError('simulated autohome unload failure')
-
-        self.mmu.unload_sequence = fail_unload
-
-        with self.assertRaisesRegex(Exception, 'simulated autohome unload failure'):
+        with self.assertRaisesRegex(Exception, 'Unload filament first'):
             self.mmu.select_gate(self.GATE + 1)
 
+        self.assertEqual(unload_calls, [])
+        self.assertEqual(self.mmu.gate_selected, self.GATE)
+
+    def test_unknown_filament_state_on_known_gate_is_refused(self):
+        self._select_loaded_gate(FILAMENT_POS_UNKNOWN)
+        home_calls = []
+        self.selector._home_selector = lambda: home_calls.append(True)
+
+        with self.assertRaisesRegex(Exception, 'may have filament loaded'):
+            self.mmu.home_unit(self.unit, reselect=False)
+
+        self.assertEqual(home_calls, [])
         self.assertEqual(self.mmu.gate_selected, self.GATE)
 
     def test_unknown_gate_with_unresolved_filament_requires_recovery(self):
         self.mmu.unselect_gate()
         self.mmu.set_filament_pos_state(FILAMENT_POS_UNKNOWN, silent=True)
-        unload_calls = self._record_successful_unload()
+        unload_calls = self._record_unload_attempts()
         home_calls = []
         self.selector._home_selector = lambda: home_calls.append(True)
 
         with self.assertRaisesRegex(Exception, 'MMU_RECOVER GATE'):
-            self.mmu.home_unit(self.unit, force_unload=None, reselect=False)
+            self.mmu.home_unit(self.unit, reselect=False)
 
         self.assertEqual(unload_calls, [])
         self.assertEqual(home_calls, [])
         self.assertEqual(self.mmu.gate_selected, TOOL_GATE_UNKNOWN)
 
-    def test_explicit_never_unload_can_home_with_unknown_ownership(self):
-        self.mmu.unselect_gate()
-        self.mmu.set_filament_pos_state(FILAMENT_POS_UNKNOWN, silent=True)
-        unload_calls = self._record_successful_unload()
+    def test_empty_unit_homes_without_calling_unload(self):
+        unload_calls = self._record_unload_attempts()
         home_calls = []
         self.selector._home_selector = lambda: home_calls.append(True)
 
-        self.mmu.home_unit(self.unit, force_unload=False, reselect=False)
+        self.mmu.home_unit(self.unit, reselect=False)
 
         self.assertEqual(unload_calls, [])
         self.assertEqual(home_calls, [True])
@@ -1195,7 +1211,7 @@ class TestHomeUnitUnloadPolicy(unittest.TestCase):
 
     def test_selector_home_is_mechanical_and_never_infers_filament_ownership(self):
         self._select_loaded_gate()
-        unload_calls = self._record_successful_unload()
+        unload_calls = self._record_unload_attempts()
         home_calls = []
         self.selector._home_selector = lambda: home_calls.append(self.mmu.gate_selected)
 
@@ -1205,7 +1221,7 @@ class TestHomeUnitUnloadPolicy(unittest.TestCase):
         self.assertEqual(home_calls, [self.GATE])
         self.assertEqual(self.mmu.gate_selected, self.GATE)
 
-    def test_homing_another_unit_never_unloads_the_active_units_gate(self):
+    def test_homing_another_unit_is_allowed_while_the_active_unit_is_loaded(self):
         self.hh.close()
         self.hh = session('ercf_vvd')
         self.hh.boot()
@@ -1214,10 +1230,10 @@ class TestHomeUnitUnloadPolicy(unittest.TestCase):
         self.hh.run_gcode('MMU_HOME UNIT=0')
         self.hh.run_gcode('MMU_SELECT GATE=3')
         self.mmu.set_filament_pos_state(FILAMENT_POS_LOADED, silent=True)
-        unload_calls = self._record_successful_unload()
+        unload_calls = self._record_unload_attempts()
         sibling = self.mmu.mmu_machine.units[1]
 
-        self.mmu.home_unit(sibling, force_unload=True, reselect=False)
+        self.mmu.home_unit(sibling, reselect=False)
 
         self.assertEqual(unload_calls, [])
         self.assertEqual(self.mmu.gate_selected, self.GATE)


### PR DESCRIPTION
## Summary
- remove the `FORCE_UNLOAD` option from `MMU_HOME` and its underlying selector-homing API
- refuse homing when the target unit may contain filament, while still allowing an independent sibling unit to home
- guard linear, indexed, and rotary selector calibration paths that home or move the selector directly
- keep startup homing failures local so later units and the rest of delayed boot initialization continue
- update the console harness to publish its known-empty filament state instead of bypassing the production guard

## Safety behavior
Selector homing no longer initiates an unload or heats the extruder. Loaded and unresolved states are rejected before selector motion. Unknown ownership requires `MMU_RECOVER GATE=xx`; a known occupied unit requires unloading first.

## Tests
- `make ALL=1 test`
- 1123 tests passed (1 skipped, 4 expected failures)
- focused selector and shared-gate occupancy tests passed after final review