### PR TITLE
Preserve real Klipper home for test-mode CAN discovery

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -543,6 +543,15 @@ if [ "${F_MENUCONFIG}" ] && [ "${F_UNINSTALL}" ]; then
 fi
 
 if [ "${TESTDIR}" ]; then
+    # Test mode redirects installation into a synthetic Klipper tree. Preserve the
+    # operational Klipper checkout so menuconfig can still run its CAN discovery tool.
+    if [ -n "${CONFIG_KLIPPER_HOME:-}" ]; then
+        export REAL_KLIPPER_HOME="${CONFIG_KLIPPER_HOME}"
+    elif [ -d "/usr/share/klipper" ]; then
+        export REAL_KLIPPER_HOME="/usr/share/klipper"
+    else
+        export REAL_KLIPPER_HOME="${HOME}/klipper"
+    fi
     export CONFIG_KLIPPER_HOME="${TESTDIR}/klipper"
     export CONFIG_KLIPPER_CONFIG_HOME="${TESTDIR}/printer_data/config"
     export CONFIG_MOONRAKER_HOME="${TESTDIR}/moonraker"

--- a/installer/Kconfig
+++ b/installer/Kconfig
@@ -129,7 +129,8 @@ buffer_serial_config = $(shell, basename '$(serial_device,$(1),$(2))' | sed 's/-
 
 # Grab UUIDs that are not in use by Klipper from all available CAN interfaces.
 # Keep each interface attached to its UUID, e.g. "can0:43a8... vlan1:25ff...".
-canbus_query        := $(shell, echo "$(KLIPPER_HOME)/../klippy-env/bin/python $(KLIPPER_HOME)/scripts/canbus_query.py")
+real_klipper_home   := $(shell, if [ -n "$(REAL_KLIPPER_HOME)" ]; then printf '%s' "$(REAL_KLIPPER_HOME)"; else printf '%s' "$(KLIPPER_HOME)"; fi)
+canbus_query        := $(shell, echo "$(real_klipper_home)/../klippy-env/bin/python $(real_klipper_home)/scripts/canbus_query.py")
 canbus_interfaces   := $(shell, (ip -o link show type can | awk -F': ' '{print $2}') 2>/dev/null || true)
 canbus_connections  := $(shell, (for interface in $(canbus_interfaces); do $(canbus_query) "$interface" | sed -n 's/.*canbus_uuid=\([0-9a-fA-F][0-9a-fA-F]*\).*/\1/p' | while IFS= read -r uuid; do printf '%s:%s\n' "$interface" "$uuid"; done; done) 2>/dev/null || true)
 canbus_uuid_count   := $(count, $(canbus_connections))

--- a/test/test_mmu_config.py
+++ b/test/test_mmu_config.py
@@ -472,6 +472,42 @@ esac
         self.assertEqual(kc.syms['PARAM_MMU_CANBUS_INTERFACE'].str_value,
                          'vlan-1')
 
+    def test_canbus_discovery_uses_real_klipper_home_override(self):
+        install_home = os.path.join(self.tmpdir.name, 'test-install', 'klipper')
+        real_home = os.path.join(self.tmpdir.name, 'real', 'klipper')
+        python_path = os.path.join(self.tmpdir.name, 'real', 'klippy-env',
+                                   'bin', 'python')
+        mock_bin = os.path.join(self.tmpdir.name, 'bin')
+        os.makedirs(install_home)
+        os.makedirs(os.path.dirname(python_path))
+        os.makedirs(os.path.join(real_home, 'scripts'))
+        os.makedirs(mock_bin)
+
+        query_path = os.path.join(real_home, 'scripts', 'canbus_query.py')
+        with open(query_path, 'w') as f:
+            f.write('# mock canbus query\n')
+        ip_path = os.path.join(mock_bin, 'ip')
+        with open(ip_path, 'w') as f:
+            f.write('#!/bin/sh\necho "2: can0: <NOARP,UP> mtu 16"\n')
+        os.chmod(ip_path, 0o755)
+        with open(python_path, 'w') as f:
+            f.write('#!/bin/sh\n'
+                    'echo "Found canbus_uuid=abc123abc123"\n')
+        os.chmod(python_path, 0o755)
+
+        syms = dict(profiles.get('boxturtle').syms)
+        syms['CHOICE_MMU_CONNECTION_TYPE_SERIAL'] = False
+        syms['CHOICE_MMU_CONNECTION_TYPE_CANBUS'] = True
+        with cfg._env({'KLIPPER_HOME': install_home,
+                       'REAL_KLIPPER_HOME': real_home,
+                       'PATH': mock_bin + os.pathsep + os.environ['PATH']}):
+            kc = cfg._kconfig('real-klipper-home-canbus-discovery', syms)
+
+        choice = kc.named_choices['CHOICE_MMU_CANBUS_CONNECTION']
+        prompts = [node.prompt[0] for symbol in choice.syms
+                   for node in symbol.nodes if node.prompt]
+        self.assertIn('can0:abc123abc123', prompts)
+
     def test_failed_canbus_queries_produce_no_discovered_choices(self):
         klipper_home = os.path.join(self.tmpdir.name, 'klipper')
         python_path = os.path.join(self.tmpdir.name, 'klippy-env', 'bin', 'python')


### PR DESCRIPTION
## Summary

- preserve the operational Klipper checkout before test mode redirects installation into `/tmp/mmu_test`
- make `REAL_KLIPPER_HOME` default to the existing `KLIPPER_HOME` in Kconfig
- use the real checkout for CAN UUID discovery without probing the host filesystem
- add regression coverage for a separate test destination and real Klipper checkout

This addresses the intent of #1098 while keeping the existing CAN discovery fixtures isolated and deterministic.

## Testing

- `make ALL=1 test` — 1124 tests passed (`skipped=1`, `expected failures=4`)
- `sh -n install.sh`
- `git diff --check`