### PR TITLE
Add startup NFC receiver gain configuration

### DIFF
--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -592,6 +592,7 @@ ven_pin               : [[PARAM_NFC_READER_VEN_PIN]]
 irq_pin               : [[PARAM_NFC_READER_IRQ_PIN]]
 [% endif %]
 [% endif %]
+rx_gain               : [[PARAM_NFC_READER_RX_GAIN]]	# 0=chip default; valid dB values depend on reader_type
 debug                 : 0		# Allows for debugging: 0=off, 4=trace
 
 [% endif %]
@@ -631,6 +632,7 @@ ven_pin               : [[ (PARAM_NFC_READER_VEN_PIN_|d)[i] ]]
 irq_pin               : [[ (PARAM_NFC_READER_IRQ_PIN_|d)[i] ]]
 [% endif %]
 [% endif %]
+rx_gain               : [[ (PARAM_NFC_READER_RX_GAIN_|d)[i] ]]	# 0=chip default; valid dB values depend on reader_type
 debug                 : 0		# Allows for debugging: 0=off, 4=trace
 [% endif %]
 

--- a/extras/mmu/unit/nfc/mmu_nfc_reader.py
+++ b/extras/mmu/unit/nfc/mmu_nfc_reader.py
@@ -22,6 +22,7 @@
 #   #transceive_delay: 0.250        # pn532/pn7160 tag-wait (min 0.050)
 #   #crc_delay: 0.050               # pn532 InRelease wait
 #   #tag_max_pages: 16              # NTAG/Type-5 pages read during a deep read (4..135)
+#   #rx_gain: 0                      # 0=chip default; valid dB values depend on reader_type
 #
 # [mmu_nfc_reader gate0]            # one reader instance; name = "gate0"
 #   reader_type: rc522              # pn532 | pn5180 | pn7160 | rc522 (overrides default)
@@ -214,6 +215,7 @@ class MmuNfcReaderDefaults:
         self.transceive_delay = config.getfloat('transceive_delay', 0.250, minval=0.050, maxval=2.0)
         self.crc_delay = config.getfloat('crc_delay', 0.050, minval=0.005, maxval=1.0)
         self.tag_max_pages = config.getint('tag_max_pages', 16, minval=4, maxval=135)
+        self.rx_gain = config.getint('rx_gain', 0, minval=0)
         self.low_level_debug = pn532_driver.get_low_level_debug(config)
 
 
@@ -253,8 +255,16 @@ class MmuNfcReader:
         self.tag_max_pages = config.getint('tag_max_pages',
                                            self._defaults.tag_max_pages if self._defaults else 16,
                                            minval=4, maxval=135)
-        low_level_debug = pn532_driver.get_low_level_debug(config,
-                                                           self._defaults.low_level_debug if self._defaults else False)
+        self.rx_gain = reader_factory.rx_gain_from_config(
+            config, self.reader_type,
+            default=self._defaults.rx_gain if self._defaults else 0)
+        low_level_debug = pn532_driver.get_low_level_debug(
+            config, self._defaults.low_level_debug if self._defaults else False)
+        if self.rx_gain and low_level_debug:
+            raise config.error(
+                "[mmu_nfc_reader %s]: rx_gain cannot be used with low_level_debug; "
+                "low_level_debug deliberately suppresses all driver-initiated chip traffic"
+                % self.name)
 
         # The driver labels its own log lines with this section's name, which it
         # derives from config itself - nothing to pass in or patch later.
@@ -328,8 +338,20 @@ class MmuNfcReader:
         self.last_target_info = None
         self.present = False
         self.reader.init()
+        self._apply_rx_gain()
         self.alive = bool(self.reader.is_alive())
         return self.alive
+
+
+    def _apply_rx_gain(self):
+        """Apply the static startup gain after the driver's reset/init sequence."""
+        if not self.rx_gain:
+            return
+        set_rx_gain = getattr(self.reader, 'set_rx_gain', None)
+        if set_rx_gain is None or not set_rx_gain(self.rx_gain):
+            reader_log.warning(
+                "[mmu_nfc_reader %s] rx_gain=%ddB was not applied by %s",
+                self.name, self.rx_gain, self.reader_type)
 
 
     def read(self, timeout=0.5):

--- a/extras/mmu/unit/nfc/pn5180_driver.py
+++ b/extras/mmu/unit/nfc/pn5180_driver.py
@@ -34,6 +34,7 @@
 #   instance built without one is still reactor-friendly.
 
 from .log import logger
+from .rx_gain import RX_GAIN_CODES
 
 
 SYSTEM_CONFIG = 0x00
@@ -43,6 +44,7 @@ CRC_RX_CONFIG = 0x12
 RX_STATUS = 0x13
 CRC_TX_CONFIG = 0x19
 RF_STATUS = 0x1D
+RF_CONTROL_RX = 0x22
 
 PRODUCT_VERSION = 0x10
 FIRMWARE_VERSION = 0x12
@@ -120,6 +122,7 @@ class PN5180Core:
         self.spi = spi
         self.mcu = spi.get_mcu()
         self.debug = debug
+        self.rx_gain_code = None
         self._sleep_fn = sleep_fn or self._default_sleep
 
         self.rf_timeout = config.getfloat(
@@ -224,6 +227,20 @@ class PN5180Core:
 
     def load_rf_config(self, tx_conf, rx_conf):
         self._transceive_command([CMD_LOAD_RF_CONFIG, tx_conf, rx_conf])
+        # LOAD_RF_CONFIG replaces RF_CONTROL_RX, so a static override must be
+        # restored for every protocol profile (Type A and ISO15693), not merely
+        # after the initial hardware reset.
+        if self.rx_gain_code is not None:
+            self._write_rx_gain(self.rx_gain_code)
+
+    def _write_rx_gain(self, code):
+        value = (self.read_register(RF_CONTROL_RX) & ~0x03) | code
+        self.write_register(RF_CONTROL_RX, value)
+        return value
+
+    def set_rx_gain(self, code):
+        self.rx_gain_code = code
+        return self._write_rx_gain(code)
 
     def _wait_irq(self, mask, timeout=None, raise_on_error=True):
         deadline = self._now() + (self.rf_timeout if timeout is None else timeout)
@@ -633,6 +650,16 @@ class PN5180Driver:
 
     def is_alive(self):
         return self._core.initialized and self._core.is_alive()
+
+    def set_rx_gain(self, db):
+        """Set and retain RF_CONTROL_RX.RX_GAIN across protocol loads."""
+        code = RX_GAIN_CODES['pn5180'].get(db)
+        if code is None:
+            return False
+        value = self._core.set_rx_gain(code)
+        logger.info('[%s pn5180] rx_gain set to %d dB (RF_CONTROL_RX=0x%08X)',
+                    self._name, db, value)
+        return True
 
     def _clear_current_card(self):
         self.current_target_info = None

--- a/extras/mmu/unit/nfc/pn532_driver.py
+++ b/extras/mmu/unit/nfc/pn532_driver.py
@@ -105,6 +105,7 @@ import time
 import traceback
 
 from .log import logger
+from .rx_gain import RX_GAIN_CODES
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PN532 frame constants
@@ -115,6 +116,7 @@ _TFI_PN532_TO_HOST = 0xD5
 
 # PN532 command codes, mirrored from HH_code/pn532.py.
 PN532_COMMAND_GETFIRMWAREVERSION = 0x02
+PN532_COMMAND_WRITEREGISTER = 0x08
 PN532_COMMAND_SAMCONFIGURATION = 0x14
 PN532_COMMAND_RFCONFIGURATION = 0x32
 PN532_COMMAND_INLISTPASSIVETARGET = 0x4A
@@ -131,6 +133,7 @@ PN532_ACK = [0x00, 0x00, 0xFF, 0x00, 0xFF, 0x00]
 
 # Internal aliases retained for the existing driver implementation.
 _CMD_GETFIRMWAREVERSION = PN532_COMMAND_GETFIRMWAREVERSION
+_CMD_WRITEREGISTER = PN532_COMMAND_WRITEREGISTER
 _CMD_SAMCONFIGURATION = PN532_COMMAND_SAMCONFIGURATION
 _CMD_RFCONFIGURATION = PN532_COMMAND_RFCONFIGURATION
 _CMD_INLISTPASSIVETARGET = PN532_COMMAND_INLISTPASSIVETARGET
@@ -373,6 +376,22 @@ class _PN532Base:
                 logger.info("[%s %s] probe_stop: release failed: %s",
                             self._name, self._transport_name, e)
             return False
+        return True
+
+    def set_rx_gain(self, db):
+        """Set CIU_RFCfg.RxGain for every PN532 transport."""
+        code = RX_GAIN_CODES['pn532'].get(db)
+        if code is None:
+            return False
+        # CIU_RFCfg (0x6316): bits 6:4 are RxGain. Preserve the documented
+        # power-on RFLevel value (bits 3:0 = 8); bit 7 is reserved zero.
+        payload = self._transceive(
+            [_CMD_WRITEREGISTER, 0x63, 0x16, (code << 4) | 0x08],
+            _CMD_WRITEREGISTER + 1, read_len=12, timeout=0.200)
+        if payload is None:
+            return False
+        logger.info("[%s %s] rx_gain set to %d dB",
+                    self._name, self._transport_name, db)
         return True
 
     # ─────────────────────────────────────────────────────────────────────────

--- a/extras/mmu/unit/nfc/pn7160_driver.py
+++ b/extras/mmu/unit/nfc/pn7160_driver.py
@@ -9,6 +9,7 @@
 # Spoolman lookups, and Happy Hare side effects.
 
 from .log import logger
+from .rx_gain import RX_GAIN_CODES
 
 
 PN7160_I2C_ADDRESS = 0x28
@@ -58,6 +59,14 @@ NCI_CORE_GET_TOTAL_DURATION_CMD = [
     0x20, 0x03, 0x02,       # CORE_GET_CONFIG, 2 payload octets
     0x01, 0x00,             # one parameter: TOTAL_DURATION
 ]
+
+# Proprietary RF configuration entries used by this driver. Both receive paths
+# it enables need the same configured gain: NFC-A/106 and ISO15693. Register
+# 0x44 is CLIF_ANA_RX_REG; RX_GAIN_I is bits 2:0 and RX_GAIN_Q bits 6:4.
+PN7160_RX_TRANSITIONS = (
+    (0x3C, 0x0A),  # RF_CLIF_CFG_BR_106_I_RXA_P; default HPCF = 2
+    (0x20, 0x0A),  # RF_CLIF_CFG_TECHNO_I_RX15693; default HPCF = 2
+)
 
 NCI_GID_CORE = 0x00
 NCI_GID_RF = 0x01
@@ -1138,6 +1147,22 @@ class PN7160Handler:
         return [rsp] + extra
 
 
+    def configure_rx_gain(self, code, db):
+        """Set both I/Q BBA gains in the enabled reader-mode RF profiles."""
+        gain_byte = code | (code << 4)
+        frames = []
+        for transition, hpcf_byte in PN7160_RX_TRANSITIONS:
+            # CORE_SET_CONFIG, one proprietary A0 0D parameter containing one
+            # RF transition/register/value tuple. The 32-bit register value is LE.
+            cmd = [0x20, 0x02, 0x0A, 0x01, 0xA0, 0x0D, 0x06,
+                   transition, 0x44, gain_byte, hpcf_byte, 0x00, 0x00]
+            rsp, extra = self.command(cmd, NCI_GID_CORE, 0x02, timeout=1.0)
+            frames.extend([rsp] + extra)
+        logger.info('[%s pn7160] rx_gain set to %d dB for NFC-A and ISO15693',
+                    self._name, db)
+        return frames
+
+
     def start_discovery(self):
         rsp, extra = self.command(
             NCI_RF_DISCOVER_NFCA_NFCV_CMD, NCI_GID_RF, 0x03, timeout=1.0,
@@ -1345,6 +1370,7 @@ class PN7160Driver:
         self._probe_active = False
         self._probe_errors = 0
         self._probe_transport_errors = 0
+        self._rx_gain = None
 
         # Advanced PN7160 tuning options are intentionally hidden from the
         # default config templates.  Users can still override them in a specific
@@ -1412,6 +1438,16 @@ class PN7160Driver:
         return bool(self._alive and self._handler.initialized)
 
 
+    def set_rx_gain(self, db):
+        """Set and retain PN7160 reader-mode I/Q gain across full NCI resets."""
+        code = RX_GAIN_CODES['pn7160'].get(db)
+        if code is None:
+            return False
+        self._rx_gain = (code, db)
+        self._handler.configure_rx_gain(code, db)
+        return True
+
+
     def _setup_for_read(self, full=None):
         """
         Prepare PN7160 for one read operation.
@@ -1432,6 +1468,8 @@ class PN7160Driver:
             # probe_start()'s keep-config path is the homing critical path, and a
             # keep-config reset preserves the value anyway.
             self._handler.configure_total_duration()
+            if self._rx_gain is not None:
+                self._handler.configure_rx_gain(*self._rx_gain)
             self._handler.configure_discovery_map()
         else:
             self._handler.connect_nci(reset=False, keep_config=True)

--- a/extras/mmu/unit/nfc/rc522_driver.py
+++ b/extras/mmu/unit/nfc/rc522_driver.py
@@ -49,6 +49,7 @@ import time
 import traceback
 
 from .log import logger
+from .rx_gain import RX_GAIN_CODES
 
 # ─────────────────────────────────────────────────────────────────────────────
 # RC522 register addresses
@@ -69,6 +70,7 @@ _TxControlReg   = 0x14
 _TxASKReg       = 0x15
 _CRCResultRegH  = 0x21
 _CRCResultRegL  = 0x22
+_RFCfgReg       = 0x26   # bits 6:4 = RxGain
 _TModeReg       = 0x2A
 _TPrescalerReg  = 0x2B
 _TReloadRegH    = 0x2C
@@ -204,6 +206,17 @@ class RC522Driver:
 
     _INIT_ATTEMPTS = 3          # As PN532's _wake_pn532; a soft reset per attempt
     _INIT_RETRY_DELAY = 0.050
+
+    def set_rx_gain(self, db):
+        """Set RFCfgReg.RxGain while preserving the other register fields."""
+        code = RX_GAIN_CODES['rc522'].get(db)
+        if code is None:
+            return False
+        value = (self._read(_RFCfgReg) & ~0x70) | (code << 4)
+        self._write(_RFCfgReg, value)
+        logger.info("[%s rc522] rx_gain set to %d dB (RFCfg=0x%02X)",
+                    self._name, db, value)
+        return True
 
     def init(self):
         """

--- a/extras/mmu/unit/nfc/reader_factory.py
+++ b/extras/mmu/unit/nfc/reader_factory.py
@@ -17,6 +17,7 @@ from .pn532_uart_driver import PN532UARTDriver, DEFAULT_BAUD
 from .pn5180_driver import PN5180Driver
 from .pn7160_driver import PN7160Driver
 from .rc522_driver import RC522Driver
+from .rx_gain import RX_GAIN_DB
 
 SUPPORTED_READER_TYPES = ('pn532', 'pn5180', 'pn7160', 'rc522')
 DEFAULT_READER_TYPE = 'pn532'
@@ -46,7 +47,6 @@ DEFAULT_SPI_SPEED = {
     'rc522': 1000000,
 }
 PN7160_I2C_ADDRESSES = (0x28, 0x29, 0x2A, 0x2B)
-
 
 _UNSET = object()   # "caller passed no default", distinct from an explicit None
 
@@ -100,6 +100,24 @@ def reader_type_from_config(config, default=DEFAULT_READER_TYPE):
             % (config.get_name().split()[-1], reader_type,
                ', '.join(SUPPORTED_READER_TYPES)))
     return reader_type
+
+
+def rx_gain_from_config(config, reader_type, default=0):
+    """Return a validated, static receiver-gain selection in dB.
+
+    Zero means that no register/configuration write is made, preserving the
+    chip's protocol-specific startup default. All non-zero values must be an
+    exact member of the selected reader's hardware gain table.
+    """
+    gain = config.getint('rx_gain', default, minval=0)
+    allowed = RX_GAIN_DB[reader_type]
+    if gain and gain not in allowed:
+        raise config.error(
+            "[mmu_nfc_reader %s]: rx_gain for %s must be 0 (chip default) or "
+            "one of %s dB; got %d"
+            % (config.get_name().split()[-1], reader_type,
+               ', '.join(str(value) for value in allowed), gain))
+    return gain
 
 
 def default_interface(reader_type):

--- a/extras/mmu/unit/nfc/rx_gain.py
+++ b/extras/mmu/unit/nfc/rx_gain.py
@@ -1,0 +1,27 @@
+"""Discrete receiver-gain tables shared by NFC config and chip drivers."""
+
+# Values are dB -> the chip register encoding. Zero is intentionally absent:
+# at the config layer it means "do not write a gain; retain the chip/profile
+# default", not a hardware gain code.
+RX_GAIN_CODES = {
+    'pn532': {
+        18: 0b010, 23: 0b011, 33: 0b100,
+        38: 0b101, 43: 0b110, 48: 0b111,
+    },
+    'pn5180': {
+        33: 0b00, 40: 0b01, 50: 0b10, 57: 0b11,
+    },
+    'pn7160': {
+        18: 0b000, 26: 0b001, 32: 0b010, 39: 0b011,
+        44: 0b100, 51: 0b101, 53: 0b110, 60: 0b111,
+    },
+    'rc522': {
+        18: 0b010, 23: 0b011, 33: 0b100,
+        38: 0b101, 43: 0b110, 48: 0b111,
+    },
+}
+
+RX_GAIN_DB = {
+    reader_type: tuple(sorted(codes))
+    for reader_type, codes in RX_GAIN_CODES.items()
+}

--- a/installer/Kconfig.nfc_reader
+++ b/installer/Kconfig.nfc_reader
@@ -45,6 +45,7 @@
 #
 #   PARAM_NFC_READER_VEN_PIN     (if pn7160 type)
 #   PARAM_NFC_READER_IRQ_PIN     (if pn7160 type)
+#   PARAM_NFC_READER_RX_GAIN     (0 = chip/profile default)
 #
 # Per-gate:
 #   PARAM_NFC_READER_X
@@ -331,6 +332,19 @@ if MMU_HAS_NFC_READER
             Optional IRQ pin for the PN7160 reader.
             Don't forget to prefix with mcu name. E.g. mmu:PG13
       endif
+
+      config PARAM_NFC_READER_RX_GAIN
+        int "Receiver gain (dB)"
+        default 0
+        range 0 60
+        help
+          Static startup gain; 0 keeps the chip/RF-profile default.
+          Valid dB values (effective default in parentheses):
+            RC522/PN532: 18, 23, 33, 38, 43, 48 (33)
+            PN5180: 33, 40, 50, 57 (50)
+            PN7160: 18, 26, 32, 39, 44, 51, 53, 60
+            PN7160 defaults: NFC-A 106=53; ISO15693=51
+          Bench-tuning option for the antenna and receive path.
     endif
 
 
@@ -579,7 +593,20 @@ if MMU_HAS_NFC_READER
                   Optional IRQ pin for this gate's PN7160 reader.
                   Don't forget to prefix with mcu name. E.g. mmu:PG13
             endif
-          endif
+
+            config PARAM_NFC_READER_RX_GAIN_$(i)
+              int "Gate $(i) receiver gain (dB)"
+              default 0
+              range 0 60
+              help
+                Static startup gain; 0 keeps the chip/RF-profile default.
+                Valid dB values (effective default in parentheses):
+                  RC522/PN532: 18, 23, 33, 38, 43, 48 (33)
+                  PN5180: 33, 40, 50, 57 (50)
+                  PN7160: 18, 26, 32, 39, 44, 51, 53, 60
+                  PN7160 defaults: NFC-A 106=53; ISO15693=51
+                Bench-tuning option for the antenna and receive path.
+           endif
         endif
       @endrepeat@
 

--- a/installer/Kconfig.nfc_reader
+++ b/installer/Kconfig.nfc_reader
@@ -340,10 +340,10 @@ if MMU_HAS_NFC_READER
         help
           Static startup gain; 0 keeps the chip/RF-profile default.
           Valid dB values (effective default in parentheses):
-            RC522/PN532: 18, 23, 33, 38, 43, 48 (33)
-            PN5180: 33, 40, 50, 57 (50)
-            PN7160: 18, 26, 32, 39, 44, 51, 53, 60
-            PN7160 defaults: NFC-A 106=53; ISO15693=51
+            RC522/PN532: 18, 23, (33), 38, 43, 48
+            PN5180: 33, 40, (50), 57
+            PN7160: 18, 26, 32, 39, 44, (51), (53), 60
+              PN7160 defaults: NFC-A 106=53; ISO15693=51
           Bench-tuning option for the antenna and receive path.
     endif
 

--- a/test/test_mmu_nfc_gain.py
+++ b/test/test_mmu_nfc_gain.py
@@ -1,0 +1,185 @@
+# Happy Hare test harness - static NFC receiver-gain configuration.
+
+import unittest
+
+from test.hh.bootstrap import install
+from test.hh import cfg, profiles
+
+install()
+
+from extras.mmu.unit.nfc import pn5180_driver, pn7160_driver, rc522_driver
+from extras.mmu.unit.nfc.pn532_driver import _PN532Base
+from extras.mmu.unit.nfc.reader_factory import rx_gain_from_config
+from extras.mmu.unit.nfc.rx_gain import RX_GAIN_DB
+
+
+class ConfigError(Exception):
+    pass
+
+
+class FakeConfig:
+    error = ConfigError
+
+    def __init__(self, gain):
+        self.gain = gain
+
+    def getint(self, _name, default=None, minval=None):
+        value = default if self.gain is None else self.gain
+        if minval is not None and value < minval:
+            raise self.error('below minimum')
+        return value
+
+    def get_name(self):
+        return 'mmu_nfc_reader gate0'
+
+
+class TestGainValidation(unittest.TestCase):
+
+    def test_every_documented_hardware_value_is_accepted(self):
+        for reader_type, gains in RX_GAIN_DB.items():
+            for gain in (0,) + gains:
+                self.assertEqual(
+                    rx_gain_from_config(FakeConfig(gain), reader_type), gain)
+
+    def test_value_from_another_chip_is_rejected(self):
+        with self.assertRaises(ConfigError) as caught:
+            rx_gain_from_config(FakeConfig(60), 'pn5180')
+        self.assertIn('33, 40, 50, 57', str(caught.exception))
+        self.assertIn('pn5180', str(caught.exception))
+
+
+class TestGainTemplate(unittest.TestCase):
+
+    def reader_gain(self, base, symbol, gain, reader):
+        profile = profiles.get(base).derive(
+            base + '_rx_gain_test', syms={symbol: gain})
+        parser = cfg.assemble(cfg.render(profile))
+        return dict(parser.items('mmu_nfc_reader ' + reader))['rx_gain']
+
+    def test_common_reader_gain_is_rendered(self):
+        self.assertEqual(
+            self.reader_gain('nfc_pn5180', 'PARAM_NFC_READER_RX_GAIN',
+                             40, 'unit0_nfc'),
+            '40')
+
+    def test_per_gate_reader_gain_is_rendered(self):
+        self.assertEqual(
+            self.reader_gain('nfc_per_gate', 'PARAM_NFC_READER_RX_GAIN_0',
+                             38, 'unit0_nfc0'),
+            '38')
+
+
+class FakeSpi:
+    def __init__(self, register_value=0):
+        self.register_value = register_value
+        self.writes = []
+
+    def spi_transfer(self, _data):
+        return {'response': [0, self.register_value]}
+
+    def spi_send(self, data):
+        self.writes.append(list(data))
+
+
+class TestMfrcGainWrites(unittest.TestCase):
+
+    def test_rc522_preserves_non_gain_register_bits(self):
+        spi = FakeSpi(register_value=0x8B)
+        driver = rc522_driver.RC522Driver(
+            spi, 'gate0', debug=0, sleep_fn=lambda _seconds: None)
+        self.assertTrue(driver.set_rx_gain(43))
+        self.assertEqual(
+            spi.writes[-1],
+            [((rc522_driver._RFCfgReg << 1) & 0x7E), 0xEB])
+
+    def test_pn532_all_transport_base_emits_write_register(self):
+        driver = _PN532Base(
+            'gate0', 0.250, 0.050, 0, False,
+            sleep_fn=lambda _seconds: None, time_fn=lambda: 0.0)
+        driver._transport_name = 'pn532/test'
+        calls = []
+        driver._transceive = lambda *args, **kwargs: calls.append((args, kwargs)) or []
+        self.assertTrue(driver.set_rx_gain(38))
+        self.assertEqual(calls[0][0][0], [0x08, 0x63, 0x16, 0x58])
+        self.assertEqual(calls[0][0][1], 0x09)
+
+
+class TestPn5180GainWrites(unittest.TestCase):
+
+    def core(self, register_value=0xA4):
+        core = pn5180_driver.PN5180Core.__new__(pn5180_driver.PN5180Core)
+        core.rx_gain_code = None
+        core.commands = []
+        core.writes = []
+        core._transceive_command = lambda data: core.commands.append(list(data)) or []
+        core.read_register = lambda reg: register_value
+        core.write_register = lambda reg, value: core.writes.append((reg, value))
+        return core
+
+    def test_gain_maps_to_rf_control_rx(self):
+        core = self.core()
+        driver = pn5180_driver.PN5180Driver.__new__(pn5180_driver.PN5180Driver)
+        driver._name = 'gate0'
+        driver._core = core
+        self.assertTrue(driver.set_rx_gain(50))
+        self.assertEqual(core.rx_gain_code, 2)
+        self.assertEqual(core.writes[-1], (pn5180_driver.RF_CONTROL_RX, 0xA6))
+
+    def test_protocol_load_reapplies_static_gain(self):
+        core = self.core()
+        core.rx_gain_code = 3
+        core.load_rf_config(0x0D, 0x8D)
+        self.assertEqual(
+            core.commands, [[pn5180_driver.CMD_LOAD_RF_CONFIG, 0x0D, 0x8D]])
+        self.assertEqual(core.writes[-1], (pn5180_driver.RF_CONTROL_RX, 0xA7))
+
+
+class FakePn7160Handler:
+    def __init__(self):
+        self.commands = []
+        self.events = []
+
+    def command(self, frame, expected_gid, expected_oid, timeout=1.0):
+        self.commands.append((list(frame), expected_gid, expected_oid, timeout))
+        return [0x40, 0x02, 0x01, 0x00], []
+
+    def connect_nci(self, reset, keep_config):
+        self.events.append(('connect', reset, keep_config))
+
+    def configure_total_duration(self):
+        self.events.append(('duration',))
+
+    def configure_rx_gain(self, code, db):
+        self.events.append(('gain', code, db))
+
+    def configure_discovery_map(self):
+        self.events.append(('map',))
+
+
+class TestPn7160GainWrites(unittest.TestCase):
+
+    def test_both_enabled_rf_profiles_receive_i_and_q_gain(self):
+        handler = FakePn7160Handler()
+        handler._name = 'gate0'
+        pn7160_driver.PN7160Handler.configure_rx_gain(handler, 6, 53)
+        self.assertEqual(len(handler.commands), 2)
+        frames = [call[0] for call in handler.commands]
+        self.assertEqual([frame[7] for frame in frames], [0x3C, 0x20])
+        for frame in frames:
+            self.assertEqual(frame[:7], [0x20, 0x02, 0x0A, 0x01, 0xA0, 0x0D, 0x06])
+            self.assertEqual(frame[8:], [0x44, 0x66, 0x0A, 0x00, 0x00])
+
+    def test_full_setup_reapplies_gain_after_clear_config_reset(self):
+        handler = FakePn7160Handler()
+        driver = pn7160_driver.PN7160Driver.__new__(pn7160_driver.PN7160Driver)
+        driver._handler = handler
+        driver._rx_gain = (4, 44)
+        driver._alive = False
+        driver._needs_full_setup = True
+        driver._setup_for_read(full=True)
+        self.assertEqual(handler.events, [
+            ('connect', True, False), ('duration',), ('gain', 4, 44), ('map',)])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add startup-only rx_gain configuration with chip-specific validation
- support PN532, RC522, PN5180, and PN7160, preserving the override across PN5180 RF profile loads and PN7160 full NCI resets
- expose common and per-gate settings through Kconfig and generated hardware configuration
- document valid values and effective chip/profile defaults

## Testing
- venv/bin/python -m unittest test.test_mmu_nfc test.test_mmu_nfc_gain test.test_mmu_nfc_i2c test.test_mmu_nfc_neighbor test.test_mmu_nfc_probe test.test_mmu_nfc_scan test.test_mmu_nfc_uart test.test_mmu_tag_parser
- 347 tests passed (1 expected failure)
- git diff --check