### PR TITLE
Fix extruder homing without toolhead sensor

### DIFF
--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -294,8 +294,8 @@ extruder_homing_max               : [[PARAM_EXTRUDER_HOMING_MAX]]		# Maximum dis
 extruder_collision_homing_current : [[PARAM_EXTRUDER_COLLISION_HOMING_CURRENT]]		# % gear stepper current (10%-100%)
 
 [% if MMU_HAS_SENSOR_TOOLHEAD %]
-# By default, for not calibrating loads, Happy Hare will not home to the extruder if a toolhead sensor is fitted
-# (because homing point is inside the extruder). However the extruder homing can be forced by setting this option.
+# By default, for non calibrating loads, Happy Hare will not home to the extruder if a toolhead sensor is fitted
+# (because best homing point is inside the extruder). However the extruder homing can be forced by setting this option.
 extruder_force_homing             : [[PARAM_EXTRUDER_FORCE_HOMING]]
 
 [% endif %]

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -1534,20 +1534,14 @@ class MmuFilamentMovement:
         if u.p.extruder_homing_endstop == SENSOR_EXTRUDER_NONE:
             return False
 
-        force_homing = u.p.extruder_force_homing
-
         # Homing to extruder is not really necessary with toolhead sensor because we
         # always home to that, however it can be forced.
         if self.sensor_manager.has_sensor(SENSOR_TOOLHEAD):
-            return force_homing
+            return bool(u.p.extruder_force_homing)
 
-        # With good calibration it is often better just to move the full length, but give user the choice
-        has_inccurate_endstop = u.p.extruder_homing_endstop in (SENSOR_EXTRUDER_ENCODER, SENSOR_GEAR_TOUCH)
-        if has_inccurate_endstop:
-            return force_homing
-
-        # Default is up to the user
-        return force_homing
+        # Without a toolhead sensor, the configured extruder endstop is the only
+        # precise reference point for the final extruder load.
+        return True
 
 
     def _home_to_extruder(self, extra_homing=0.):


### PR DESCRIPTION
## Summary
- home to a configured extruder endstop when no toolhead sensor is available
- retain extruder_force_homing behavior when a toolhead sensor is present
- clarify the extruder homing configuration comments

## Problem
A calibrated load with extruder_homing_endstop configured could skip extruder homing when extruder_force_homing was left at its default. The fast Bowden move then consumed the full remaining distance and the non-homing branch issued a 0 mm slow move.

## Testing
- verified the fix against the reported load sequence
- python3 -m py_compile extras/mmu/mmu_filament_movement.py
- ./venv/bin/python -m unittest -v test.test_mmu_import (12 tests passed)
- git diff --check