### PR TITLE
Fix proportional buffer virtual sensor thresholds

### DIFF
--- a/extras/mmu/unit/mmu_buffer.py
+++ b/extras/mmu/unit/mmu_buffer.py
@@ -204,9 +204,15 @@ class MmuProportionalSensor:
         self.value = 0.0     # In [-1.0, 1.0]
 
         # Virtual sensor setup
-        h = abs(self.analog_sensor_threshold) * self._vsensor_hysteresis
-        self._vsensor_threshold_low = self.analog_sensor_threshold - h
-        self._vsensor_threshold_high = self.analog_sensor_threshold + h
+        threshold = self.analog_sensor_threshold
+        h = threshold * self._vsensor_hysteresis
+        # The configured threshold is where an extreme state is asserted.  Release it
+        # inside that boundary so noise around the threshold cannot chatter the virtual
+        # sensors.  This makes the stable neutral range symmetric around zero.
+        self._vsensor_tension_trigger = -threshold
+        self._vsensor_tension_release = -threshold + h
+        self._vsensor_compression_release = threshold - h
+        self._vsensor_compression_trigger = threshold
         self._vsensor_state = None
 
         # Setup ADC
@@ -277,20 +283,27 @@ class MmuProportionalSensor:
 
         prev_state = self._vsensor_state
 
-        # Apply hysteresis before calling trigger and initilize on first call
-        if self._vsensor_state is None:
-            if self.value > self._vsensor_threshold_high:
+        # Apply state-dependent hysteresis before calling trigger.  The configured
+        # threshold is the assertion point; an asserted state releases only after the
+        # value has moved inward by the hysteresis amount.  Check the opposite extreme
+        # first so a reading may jump directly from tension to compression or vice versa.
+        if self._vsensor_state == -1:
+            if self.value >= self._vsensor_compression_trigger:
                 self._vsensor_state = 1
-            elif self.value < self._vsensor_threshold_low:
+            elif self.value >= self._vsensor_tension_release:
+                self._vsensor_state = 0
+        elif self._vsensor_state == 1:
+            if self.value <= self._vsensor_tension_trigger:
                 self._vsensor_state = -1
+            elif self.value <= self._vsensor_compression_release:
+                self._vsensor_state = 0
+        else:  # Initial or neutral state
+            if self.value <= self._vsensor_tension_trigger:
+                self._vsensor_state = -1
+            elif self.value >= self._vsensor_compression_trigger:
+                self._vsensor_state = 1
             else:
                 self._vsensor_state = 0
-        elif self.value > self._vsensor_threshold_high:
-            self._vsensor_state = 1
-        elif self.value < self._vsensor_threshold_low:
-            self._vsensor_state = -1
-        elif self._vsensor_threshold_low <= self.value <= self._vsensor_threshold_high:
-            self._vsensor_state = 0
 
         # Service virtual endstop sensors only if hysteresis state changes...
         if self._vsensor_state != prev_state:

--- a/test/README.md
+++ b/test/README.md
@@ -92,7 +92,7 @@ make BOOTSTRAP_PY=python3.9 VENV=venv39 test
 Expect to see:
 
 ```
-OK (skipped=1, expected failures=4)
+OK (skipped=1, expected failures=2)
 ```
 
 `skipped` and `expected failures` are normal and explained in §6. Anything else — `FAILED
@@ -1004,7 +1004,7 @@ this wrong makes Happy Hare look broken when it is being right about an impossib
 ## 6. Skips and expected failures
 
 ```
-OK (skipped=1, expected failures=4)
+OK (skipped=1, expected failures=2)
 ```
 
 **`expected failures`** are known bugs, written as tests of what *should* happen and
@@ -1017,7 +1017,6 @@ Currently:
 
 | Where | Bug |
 |---|---|
-| `test_mmu_profiles.py` ×2 | the proportional buffer reports TENSION almost always — its low threshold is computed positive when the config help says it should be about −0.9 |
 | `test_mmu_tag_parser.py` | a blank tag is reported as a Bambu Lab tag |
 | `test_mmu_motion.py` | a `synced` (print-time) move does not advance the filament model — unlike the other three drive modes it never reaches `MmuStepper._submit_move`, so `motion_queuing`'s trapq hook never fires. A HARNESS gap rather than a Happy Hare bug, which is the one entry here that will not be fixed by changing `extras/` |
 

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -401,41 +401,11 @@ class TestProportionalBufferSensor(unittest.TestCase):
         self.assertEqual(self.hh.sensor('mmu_entry_0').kind, 'switch')
 
 
-class TestTensionThresholdSignError(unittest.TestCase):
+class TestProportionalVirtualSensorThresholds(unittest.TestCase):
     """
-    A REAL BUG: a proportional buffer sensor reports TENSION almost all the time.
-
-    The config help for analog_sensor_threshold states the intent unambiguously
-    (installer/Kconfig.sync_feedback_buffer:208-215):
-
-        a setting of 0.9 means:
-          the virtual filament_compression sensor will trigger at 0.9
-          the virtual filament_tension sensor will trigger at -0.9
-
-    But the thresholds are computed without the negation
-    (extras/mmu/unit/mmu_buffer.py:207-209):
-
-        h = abs(self.analog_sensor_threshold) * self._vsensor_hysteresis
-        self._vsensor_threshold_low  = self.analog_sensor_threshold - h    # +0.864
-        self._vsensor_threshold_high = self.analog_sensor_threshold + h    # +0.936
-
-    so with the default threshold of 0.9 the bands are:
-
-        value > +0.936            -> compression
-        +0.864 .. +0.936          -> neutral
-        anything below +0.864     -> TENSION      <-- includes 0.0 and every -ve value
-
-    The consequences: there is effectively no neutral state (it is a 0.072-wide sliver at
-    the top of the compression range), and the virtual tension sensor is asserted for
-    essentially every reading a real sensor produces - including a perfectly centred
-    filament. Sync-feedback gear compensation reads permanent tension.
-
-    `low` should be negative: -(threshold - h) = -0.864, or -(threshold + h) = -0.936
-    depending on which side hysteresis is meant to widen. That choice is a design call,
-    which is why this is reported rather than fixed here.
-
-    Reachable with shipped defaults on any machine with an analog buffer sensor - EMU
-    ships one.
+    The configured threshold is the assertion point on both sides of zero.  Once asserted,
+    each virtual sensor releases one hysteresis interval inward, producing a stable neutral
+    core and preventing chatter at the assertion boundary.
     """
 
     def setUp(self):
@@ -454,48 +424,46 @@ class TestTensionThresholdSignError(unittest.TestCase):
         self.prop.feed(self.sensor._neutral_point + value * span)
         return self.sensor.value
 
-    def test_both_thresholds_are_currently_positive(self):
-        """The mechanism, pinned directly - this is the whole bug in one assertion."""
-        self.assertGreater(self.sensor._vsensor_threshold_low, 0.0,
-                           'the tension threshold should be negative')
-        self.assertAlmostEqual(self.sensor._vsensor_threshold_low, 0.864, places=3)
-        self.assertAlmostEqual(self.sensor._vsensor_threshold_high, 0.936, places=3)
+    def test_thresholds_are_symmetric_with_an_inward_release_band(self):
+        self.assertAlmostEqual(self.sensor._vsensor_tension_trigger, -0.900, places=3)
+        self.assertAlmostEqual(self.sensor._vsensor_tension_release, -0.864, places=3)
+        self.assertAlmostEqual(self.sensor._vsensor_compression_release, 0.864, places=3)
+        self.assertAlmostEqual(self.sensor._vsensor_compression_trigger, 0.900, places=3)
 
-    def test_a_centred_filament_currently_reports_tension(self):
-        """Documents today's behaviour so a fix shows up as a change here."""
-        self.feed_normalised(0.0)
-        self.assertTrue(self.sm.check_sensor('filament_tension'),
-                        'precondition for the bug: 0.0 < +0.864 so it reads as tension')
-        self.assertFalse(self.sm.check_sensor('filament_compression'))
-
-    def test_the_neutral_band_is_a_sliver_at_the_top(self):
-        self.feed_normalised(0.90)      # inside +0.864..+0.936
-        self.assertFalse(self.sm.check_sensor('filament_tension'))
-        self.assertFalse(self.sm.check_sensor('filament_compression'))
-
-    @unittest.expectedFailure
-    def test_a_centred_filament_should_read_neither(self):
-        """
-        What the config help promises. Flips green when the sign is corrected; delete this
-        and invert test_a_centred_filament_currently_reports_tension then.
-        """
+    def test_a_centred_filament_reads_neither(self):
         self.feed_normalised(0.0)
         self.assertFalse(self.sm.check_sensor('filament_tension'))
         self.assertFalse(self.sm.check_sensor('filament_compression'))
 
-    @unittest.expectedFailure
-    def test_tension_should_trigger_near_minus_one(self):
-        """Tension at -1.0 and nothing at -0.5, per the documented -0.9 trigger point."""
-        self.feed_normalised(-1.0)
-        self.assertTrue(self.sm.check_sensor('filament_tension'))
+    def test_moderate_tension_is_neutral(self):
         self.feed_normalised(-0.5)
         self.assertFalse(self.sm.check_sensor('filament_tension'))
+        self.assertFalse(self.sm.check_sensor('filament_compression'))
 
-    def test_compression_end_is_unaffected(self):
-        """The positive side works; only the tension threshold has the wrong sign."""
-        self.feed_normalised(1.0)
-        self.assertTrue(self.sm.check_sensor('filament_compression'))
+    def test_tension_uses_state_dependent_hysteresis(self):
+        self.feed_normalised(-0.91)
+        self.assertTrue(self.sm.check_sensor('filament_tension'))
+        self.feed_normalised(-0.88)
+        self.assertTrue(self.sm.check_sensor('filament_tension'),
+                        'tension should remain asserted inside its hysteresis band')
+        self.feed_normalised(-0.86)
         self.assertFalse(self.sm.check_sensor('filament_tension'))
+
+    def test_compression_uses_state_dependent_hysteresis(self):
+        self.feed_normalised(0.91)
+        self.assertTrue(self.sm.check_sensor('filament_compression'))
+        self.feed_normalised(0.88)
+        self.assertTrue(self.sm.check_sensor('filament_compression'),
+                        'compression should remain asserted inside its hysteresis band')
+        self.feed_normalised(0.86)
+        self.assertFalse(self.sm.check_sensor('filament_compression'))
+
+    def test_can_jump_directly_between_extremes(self):
+        self.feed_normalised(-1.0)
+        self.assertTrue(self.sm.check_sensor('filament_tension'))
+        self.feed_normalised(1.0)
+        self.assertFalse(self.sm.check_sensor('filament_tension'))
+        self.assertTrue(self.sm.check_sensor('filament_compression'))
 
 
 class TestAdcCompatMatrixOnRealMachine(unittest.TestCase):


### PR DESCRIPTION
## Summary
- assert virtual tension and compression sensors symmetrically at the configured negative and positive thresholds
- release each sensor one hysteresis interval toward neutral to prevent chatter
- replace the two expected failures with passing state-transition coverage
- update the documented expected-failure count

## User impact
A centered proportional buffer no longer reports tension continuously. With the default threshold of 0.9, tension asserts at -0.9 and compression at +0.9; they release at -0.864 and +0.864 respectively.

## Testing
- make UT=test_mmu_profiles.py test (33 tests passed)
- make ALL=1 test (1182 tests passed; skipped=1, expected failures=2)