### PR TITLE
Reject blank NFC reads as Bambu tags

### DIFF
--- a/extras/mmu/unit/nfc/tag_parser.py
+++ b/extras/mmu/unit/nfc/tag_parser.py
@@ -519,8 +519,8 @@ def _detect_bambu(raw: bytes) -> bool:
     authentication (see ``_bambu_derive_keys`` and the module docstring).
 
     Detection is unreliable from raw bytes alone; we flag a candidate only when
-    the raw dump is exactly a multiple of 64 bytes (MIFARE Classic sector size)
-    with no readable NDEF and no known filament keywords.
+    the raw dump is exactly a multiple of 64 bytes (MIFARE Classic sector size),
+    contains varied data, and has no readable NDEF or known filament keywords.
     This is a best-effort heuristic only.
     """
     if len(raw) == 0:
@@ -530,6 +530,12 @@ def _detect_bambu(raw: bytes) -> bool:
     # 64 bytes is one MIFARE Classic 1K sector (4 blocks × 16 bytes).
     # A full card dump is 1024 bytes (16 sectors × 4 blocks × 16 bytes).
     if len(raw) % 64 != 0 and len(raw) != 1024:
+        return False
+    # Blank, erased, or failed reads are commonly returned as a uniform buffer of
+    # 0x00 or 0xFF.  Encrypted Bambu data must contain variation; rejecting every
+    # uniform payload also covers other reader fill bytes without guessing which
+    # value a particular device uses.
+    if len(set(raw)) < 2:
         return False
     # If we can find an NDEF TLV, it's not a Bambu tag.
     if _find_ndef_tlv(raw) is not None:

--- a/test/README.md
+++ b/test/README.md
@@ -92,7 +92,7 @@ make BOOTSTRAP_PY=python3.9 VENV=venv39 test
 Expect to see:
 
 ```
-OK (skipped=1, expected failures=2)
+OK (skipped=1, expected failures=1)
 ```
 
 `skipped` and `expected failures` are normal and explained in §6. Anything else — `FAILED
@@ -1004,7 +1004,7 @@ this wrong makes Happy Hare look broken when it is being right about an impossib
 ## 6. Skips and expected failures
 
 ```
-OK (skipped=1, expected failures=2)
+OK (skipped=1, expected failures=1)
 ```
 
 **`expected failures`** are known bugs, written as tests of what *should* happen and
@@ -1017,7 +1017,6 @@ Currently:
 
 | Where | Bug |
 |---|---|
-| `test_mmu_tag_parser.py` | a blank tag is reported as a Bambu Lab tag |
 | `test_mmu_motion.py` | a `synced` (print-time) move does not advance the filament model — unlike the other three drive modes it never reaches `MmuStepper._submit_move`, so `motion_queuing`'s trapq hook never fires. A HARNESS gap rather than a Happy Hare bug, which is the one entry here that will not be fixed by changing `extras/` |
 
 **`skipped`** is `test/installer/test_build.py` — legacy installer tests that can't run

--- a/test/test_mmu_tag_parser.py
+++ b/test/test_mmu_tag_parser.py
@@ -301,61 +301,33 @@ if __name__ == '__main__':
     unittest.main()
 
 
-class TestBlankTagMisdetectedAsBambu(TagParserTestCase):
+class TestBlankTagBambuRejection(TagParserTestCase):
     """
-    A blank tag is reported as a Bambu Lab tag, in the DEFAULT configuration.
-
-    _detect_bambu is explicitly a heuristic - its own docstring says "Detection is
-    unreliable from raw bytes alone ... best-effort heuristic only". It flags a candidate
-    when the dump is a multiple of 64 bytes, contains no NDEF TLV, and holds none of the
-    ASCII keywords PLA/ABS/PETG/TPU/spoolman_id/openspool. An all-zeros buffer satisfies
-    all three.
-
-    That is reachable with shipped defaults, not a contrived length: tag_max_pages
-    defaults to 16 (extras/mmu/unit/nfc/mmu_nfc_reader.py:119), so an NTAG deep read
-    returns 16 pages x 4 bytes = exactly 64 bytes. Scan a blank or non-filament NTAG and
-    the user is told:
-
-        "Detected Bambu Lab tag but decryption/authentication not available;
-         see README for hardware requirements"
-
-    BLAST RADIUS IS MESSAGING ONLY, and worth being precise about: the result is a parse
-    ERROR dict, is_parse_error() is True, and MmuNfcReader._read_tag_metadata therefore
-    returns None - so no incorrect filament data reaches the gate map. The cost is a
-    misleading diagnostic pointing the user at Bambu hardware requirements they do not
-    need.
-
-    A cheap tightening would be to require at least some non-zero entropy before
-    claiming an encrypted tag.
+    Sector-sized blank reads must not satisfy the best-effort Bambu heuristic.  Uniform
+    buffers carry no evidence of encrypted data, whether a reader fills them with 0x00,
+    0xFF, or another byte.  Non-uniform binary data remains eligible so this guard does
+    not turn into a speculative entropy threshold for real Bambu tags.
     """
 
     BLANK_NTAG_READ = bytes(64)     # 16 pages x 4 bytes, the shipped default
 
-    def test_blank_tag_is_currently_claimed_as_bambu(self):
-        """Pins today's behaviour so a fix shows up as a change here."""
-        info = self.parse(self.BLANK_NTAG_READ)
-        self.assertIsNotNone(info)
-        self.assertEqual(info.get('tag_format'), 'bambu')
-        self.assertIn('Bambu', info.get('error', ''))
+    def test_blank_tag_is_unrecognised_not_bambu(self):
+        self.assertFalse(tag_parser._detect_bambu(self.BLANK_NTAG_READ))
+        self.assertIsNone(self.parse(self.BLANK_NTAG_READ))
 
-    def test_the_misdetection_is_contained_to_messaging(self):
-        """No wrong filament data escapes: it is an error dict, so metadata is dropped."""
-        info = self.parse(self.BLANK_NTAG_READ)
-        self.assertTrue(tag_parser.is_parse_error(info))
-        self.assertNotIn('material', info)
+    def test_erased_tag_is_unrecognised_not_bambu(self):
+        erased = b'\xFF' * 64
+        self.assertFalse(tag_parser._detect_bambu(erased))
+        self.assertIsNone(self.parse(erased))
 
     def test_default_page_count_produces_exactly_the_trigger_length(self):
         """Documents WHY this is the default path rather than an edge case."""
         self.assertEqual(len(self.BLANK_NTAG_READ) % 64, 0)
         self.assertEqual(16 * 4, 64)
 
-    @unittest.expectedFailure
-    def test_blank_tag_should_not_be_claimed_as_bambu(self):
-        """
-        What should happen. Flips green if the heuristic gains an entropy check; delete
-        this and invert test_blank_tag_is_currently_claimed_as_bambu then.
-        """
-        self.assertFalse(tag_parser._detect_bambu(self.BLANK_NTAG_READ))
+    def test_nonuniform_binary_data_remains_a_bambu_candidate(self):
+        candidate = b'\xA5\x5A' * 32
+        self.assertTrue(tag_parser._detect_bambu(candidate))
 
     def test_a_written_ndef_tag_is_never_mistaken_for_bambu(self):
         """The NDEF escape hatch works, which is what keeps real tags safe."""


### PR DESCRIPTION
## Summary
- reject uniform sector-sized NFC buffers from the best-effort Bambu heuristic
- cover blank 0x00 and erased 0xFF reads while retaining varied binary Bambu candidates
- replace the known expected failure with passing regression tests
- update the documented expected-failure count

## User impact
Blank, erased, or failed NFC reads no longer produce a misleading Bambu Lab authentication warning. They are reported as unrecognized tags instead.

## Testing
- make UT=test_mmu_tag_parser.py test (36 tests passed)
- make ALL=1 test (1182 tests passed; skipped=1, expected failures=1)