### PR TITLE
Model synchronized toolhead filament movement

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -92,11 +92,11 @@ make BOOTSTRAP_PY=python3.9 VENV=venv39 test
 Expect to see:
 
 ```
-OK (skipped=1, expected failures=1)
+OK (skipped=1)
 ```
 
-`skipped` and `expected failures` are normal and explained in §6. Anything else — `FAILED
-(failures=…)` or `(errors=…)` — is a genuine problem.
+The skip is normal and explained in §6. Anything else — `FAILED (failures=…)` or
+`(errors=…)` — is a genuine problem.
 
 A minute and a half is still too long to sit through on every change, which is why `make
 test` opens a file picker first rather than starting straight away.
@@ -1004,7 +1004,7 @@ this wrong makes Happy Hare look broken when it is being right about an impossib
 ## 6. Skips and expected failures
 
 ```
-OK (skipped=1, expected failures=1)
+OK (skipped=1)
 ```
 
 **`expected failures`** are known bugs, written as tests of what *should* happen and
@@ -1013,11 +1013,7 @@ unexpected success as a *failure*, so the moment someone fixes the bug the suite
 and tells you to delete the marker. If a test you didn't touch suddenly fails that way,
 you probably fixed something — check, then remove the marker and its comment.
 
-Currently:
-
-| Where | Bug |
-|---|---|
-| `test_mmu_motion.py` | a `synced` (print-time) move does not advance the filament model — unlike the other three drive modes it never reaches `MmuStepper._submit_move`, so `motion_queuing`'s trapq hook never fires. A HARNESS gap rather than a Happy Hare bug, which is the one entry here that will not be fixed by changing `extras/` |
+There are currently no expected failures.
 
 **`skipped`** is `test/installer/test_build.py` — legacy installer tests that can't run
 (the functions they call no longer exist). Its header explains what restoring it needs.

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -505,9 +505,8 @@ class Session:
         long as the extruder and the filament model move by the SAME amount, HH's conclusion is
         self-consistent with the machine the harness is presenting.
 
-        Both halves are done explicitly rather than through a trapq append, because the model's
-        move observer is filtered to the gear stepper and tip forming is an extruder move; see
-        the CANDIDATE IMPROVEMENT note on _on_manual_move.
+        Both halves are done explicitly because the harness macro body does not emit either a
+        manual trapq move or a toolhead extrusion for the motion observers to see.
         """
         vars_macro = self.printer.lookup_object('gcode_macro %s_VARS' % macro.alias, None)
         variables = dict(getattr(macro, 'variables', {}) or {})
@@ -705,20 +704,22 @@ class Session:
         Advance the filament model for a plain (non-homing) move.
 
         Filtered to the trapq of whichever stepper is currently DRIVING the filament - HH's own
-        notion (MmuDrive.driving_stepper), and exactly one stepper drives in each of the four
-        sync modes (mmu_constants.py:169-172):
+        notion (MmuDrive.driving_stepper).  The three manual move modes use these trapqs:
 
             gear / gear+extruder  -> the gear stepper drives
-            extruder / synced     -> the extruder stepper drives
+            extruder              -> the extruder stepper drives
+
+        The fourth mode, gear synced to extruder, is a toolhead move and is handled separately
+        by _on_toolhead_move because it never reaches an MmuStepper manual trapq.
 
         A gear+extruder move appends to BOTH trapqs for ONE physical movement, so something has
         to pick just one; keying off the DRIVER counts it exactly once without having to reason
-        about append order, and without dropping the two modes where the gear is not the driver.
+        about append order, and without dropping extruder-only movement.
 
         This used to watch the gear stepper unconditionally, which silently discarded every
-        motor="extruder" and motor="synced" move - the model just did not follow the filament.
-        Invisible on a machine with no encoder; on one with an encoder it means no pulses are
-        generated and HH concludes the filament is stuck. test_mmu_motion's
+        motor="extruder" move.  Synced moves were also dropped because no toolhead observer
+        existed.  Invisible on a machine with no encoder; on one with an encoder either gap
+        means no pulses are generated and HH concludes the filament is stuck. test_mmu_motion's
         TestEveryDriveModeMovesFilament pins all four modes to the exact distance, so a
         regression to either the dropped-move or the double-counted kind fails loudly.
 
@@ -770,14 +771,28 @@ class Session:
 
     def _install_move_observer(self):
         """
-        Watch every plain (non-homing) move. Needed by BOTH the filament model and the
-        selector axes, so it is installed independently of either - a selector can move
-        before anything has asked for the filament model, and filament() is lazy.
+        Watch every plain (non-homing) manual move and toolhead extrusion.  Needed by the
+        filament model and selector axes, so it is installed independently of either - a
+        selector can move before anything has asked for the filament model, and filament()
+        is lazy.
         """
         mq = self.printer.lookup_object('motion_queuing', None)
         if mq is not None:
             mq.move_observer = self._on_manual_move
+            mq.toolhead_move_observer = self._on_toolhead_move
         return self
+
+    def _on_toolhead_move(self, distance):
+        """Advance filament when the gear is following a toolhead extrusion move."""
+        model = getattr(self.printer, 'harness_filament', None)
+        gate = self.mmu.gate_selected
+        if model is None or gate is None or gate < 0:
+            return
+
+        from extras.mmu.mmu_constants import DRIVE_GEAR_SYNCED_TO_EXTRUDER
+        if self.mmu.drive(gate).get_sync_mode() != DRIVE_GEAR_SYNCED_TO_EXTRUDER:
+            return
+        model.advance(gate, distance, 'toolhead extrusion')
 
     def _driving_stepper(self, gate):
         """

--- a/test/hh/klippy_root/extras/motion_queuing.py
+++ b/test/hh/klippy_root/extras/motion_queuing.py
@@ -43,6 +43,11 @@ class PrinterMotionQueuing:
         # Set by the harness (test/hh/bootstrap.py) to observe plain filament moves.
         # callable(trapq, signed_distance_mm)
         self.move_observer = None
+        # Toolhead extrusion does not use an MmuStepper manual trapq.  The fake
+        # toolhead reports its E-axis delta here so the harness can model a gear
+        # synchronized to the extruder without conflating it with manual moves.
+        # callable(signed_distance_mm)
+        self.toolhead_move_observer = None
 
     def allocate_trapq(self):
         tq = Trapq(len(self.trapqs))
@@ -145,6 +150,10 @@ class PrinterMotionQueuing:
         # MmuGenericRail.home DOES appear, and should.
         if self.move_observer is not None and distance:
             self.move_observer(trapq, distance)
+
+    def note_toolhead_move(self, distance):
+        if self.toolhead_move_observer is not None and distance:
+            self.toolhead_move_observer(distance)
 
     def _pace_factor(self):
         """

--- a/test/hh/klippy_root/toolhead.py
+++ b/test/hh/klippy_root/toolhead.py
@@ -94,7 +94,14 @@ class ToolHead:
 
     def move(self, newpos, speed):
         self.moves.append((list(newpos), speed))
+        old_extruder_pos = self.commanded_pos[3]
         self.commanded_pos = list(newpos)
+        distance = self.commanded_pos[3] - old_extruder_pos
+        mq = self.printer.lookup_object('motion_queuing', None)
+        if mq is not None:
+            note_move = getattr(mq, 'note_toolhead_move', None)
+            if note_move is not None:
+                note_move(distance)
 
     def manual_move(self, coord, speed):
         newpos = list(self.commanded_pos)

--- a/test/test_mmu_motion.py
+++ b/test/test_mmu_motion.py
@@ -5,12 +5,14 @@
 # what is under test is the sequencing and the position arithmetic, not Klipper's
 # motion planner.
 #
-# Two integration points make this work, both in the fake layer with no monkeypatching
+# Three integration points make this work, all in the fake layer with no monkeypatching
 # of Happy Hare:
 #   - HOMING moves: the fake HomingMove asks the model which endstop trips first and
 #     how far the move gets (test/hh/klippy_root/extras/homing.py).
 #   - PLAIN moves (notably the final park): observed via the fake motion_queuing's
 #     trapq_append, from which the signed distance is exactly recoverable.
+#   - TOOLHEAD extrusion: its E-axis delta advances filament only while the MMU gear is
+#     synchronized to the extruder, matching print-time movement.
 #
 # Geometry is the model's DEFAULT_LAYOUT: park -100, entry -50, gate/exit 0. The entry
 # switch sits BETWEEN the park point and the gate sensor, so a parked filament leaves it
@@ -291,23 +293,15 @@ class TestEveryDriveModeMovesFilament(MotionTestCase):
     def test_extruder_only(self):
         self.assertAlmostEqual(self._moved('extruder'), self.MOVE, places=3)
 
-    @unittest.expectedFailure
     def test_gear_synced_to_extruder(self):
-        """
-        KNOWN GAP, and a different one from the three above - not fixable at this hook.
-
-        In 'synced' mode (DRIVE_GEAR_SYNCED_TO_EXTRUDER, the print-time mode where the gear
-        follows the extruder) the move never reaches MmuStepper._submit_move at all: it goes
-        through the toolhead's own extruder motion, so motion_queuing's trapq_append - the only
-        thing _on_manual_move can observe - is never called. Verified by spying on the observer:
-        for MOTOR=synced it sees nothing whatsoever, where MOTOR=extruder sees one append.
-
-        Closing it means observing toolhead extruder moves, which is a bigger change than the
-        driving-stepper accounting this class otherwise pins. Kept as an expected failure rather
-        than deleted so the gap is visible in the suite instead of only in a comment; it flips
-        green on its own once toolhead motion is observed.
-        """
         self.assertAlmostEqual(self._moved('synced'), self.MOVE, places=3)
+
+    def test_unsynced_toolhead_extrusion_does_not_move_the_model(self):
+        before = self.fil.tip[0]
+        pos = self.hh.mmu.toolhead.get_position()
+        pos[3] += self.MOVE
+        self.hh.mmu.toolhead.move(pos, 25.)
+        self.assertAlmostEqual(self.fil.tip[0] - before, 0., places=3)
 
 
 class TestQuietPlacement(MotionTestCase):


### PR DESCRIPTION
## Summary
- report fake toolhead E-axis deltas through the harness motion observer
- advance the filament model only while the MMU gear is synchronized to the extruder
- preserve manual trapq handling for the other drive modes without double counting
- replace the final expected failure with passing synchronized and unsynchronized coverage

## Scope
This is a test-harness-only change; no Happy Hare production code is modified.

## Testing
- make UT=test_mmu_motion.py test (45 tests passed)
- make ALL=1 test (1183 tests passed; skipped=1)