### PR TITLE
Fix v4 encoder runout timing

### DIFF
--- a/extras/mmu/commands/mmu_encoder_runout.py
+++ b/extras/mmu/commands/mmu_encoder_runout.py
@@ -29,6 +29,8 @@ class MmuEncoderRunoutCommand(BaseCommand):
     HELP_BRIEF = "Internal encoder filament runout handler"
     HELP_PARAMS = (
         f"{CMD}: {HELP_BRIEF}\n"
+        + "EVENTTIME  = #(float)\n"
+        + "GENERATION = #(int)\n"
     )
     HELP_SUPPLEMENT = ""  # Internal callback command
 
@@ -53,6 +55,33 @@ class MmuEncoderRunoutCommand(BaseCommand):
             return
 
         mmu.fix_started_state()
+
+        eventtime = gcmd.get_float('EVENTTIME', mmu.reactor.monotonic())
+        generation = gcmd.get_int('GENERATION', None)
+        encoder = mmu.encoder() if mmu.has_encoder() else None
+
+        # Encoder runout is inferred state, so re-enabling starts a new observation
+        # epoch. Never deliver an event queued against an earlier epoch after a load,
+        # unload, toolchange, pause, or other monitoring suspension has reset it.
+        stale = (
+            encoder is None
+            or not encoder.active
+            or not encoder.is_flowguard_enabled()
+            or generation is None
+            or generation != encoder.get_flowguard_generation()
+            or eventtime < mmu.runout_last_handled_time
+        )
+        if stale:
+            mmu.log_debug(
+                "Stale encoder runout event ignored "
+                "(event=%.3f generation=%s current_generation=%s now=%.3f)"
+                % (eventtime, generation,
+                   encoder.get_flowguard_generation() if encoder else None,
+                   mmu.reactor.monotonic())
+            )
+            # Undo what encoder runout event handling did before waiting on gcode.
+            mmu.pause_resume.send_resume_command()
+            return
 
         try:
             with mmu.wrap_sync_gear_to_extruder():

--- a/extras/mmu/unit/mmu_encoder.py
+++ b/extras/mmu/unit/mmu_encoder.py
@@ -54,8 +54,9 @@ class MmuEncoder:
         counter.setup_callback(self._counter_callback)
 
         # For FlowGuard runout/clog/tangle functionality...
-        self.active = True                    # Active when in a print
+        self.active = False                   # Active only while in a print
         self._flowguard_enabled = False       # FlowGuard Runout/Clog/Tangle functionality
+        self._flowguard_generation = 0        # Invalidates callbacks queued before a disable/re-enable
 
         # The runout headroom that MMU will attempt to maintain (closest MMU comes to triggering runout)
         self.desired_headroom = config.getfloat('desired_headroom', 6., above=0.)
@@ -182,16 +183,22 @@ class MmuEncoder:
 
         self._reset_filament_runout_params()
         self._flowguard_enabled = (mode != 0)
+        self._flowguard_generation += 1
         return self._flowguard_enabled # Success if mode is not "off"
 
 
     def disable_flowguard(self):
         self._flowguard_enabled = False
+        self._flowguard_generation += 1
         return (self.detection_mode != 0) # Success if mode is not "off"
 
 
     def is_flowguard_enabled(self):
         return self._flowguard_enabled
+
+
+    def get_flowguard_generation(self):
+        return self._flowguard_generation
 
 
     def _get_extruder_pos(self, eventtime=None):
@@ -271,6 +278,10 @@ class MmuEncoder:
 
     # Called periodically to tune the automatic clog detection length
     def _update_detection_length(self, increase_only=False):
+        # Match v3: suspended monitoring must not consume or alter the measurement
+        # accumulated during the preceding print interval.
+        if not self._flowguard_enabled:
+            return
         if self.detection_mode != ENCODER_RUNOUT_AUTOMATIC:
             return
 
@@ -306,6 +317,10 @@ class MmuEncoder:
             if self.active_mmu_unit:
                 self.active_mmu_unit.calibrator.update_clog_detection_length(round(self.detection_length, 1))
 
+            # Match v3 set_clog_detection_length(): after a material autotune change,
+            # rebase at the live extruder position and grant startup headroom.
+            self._reset_filament_runout_params()
+
 
     # Called to see if state update requires callback notification
     def _handle_filament_event(self, filament_detected):
@@ -330,16 +345,24 @@ class MmuEncoder:
                 # Runout detected
                 self.min_event_systime = self.reactor.NEVER
                 self.mmu.log_info(f"MMU: Encoder Sensor {self.name}: runout event detected, Time {eventtime:.2f}")
-                self.reactor.register_callback(self._runout_event_handler)
+                generation = self._flowguard_generation
+                self.reactor.register_callback(
+                    lambda reh, et=eventtime, gen=generation: self._runout_event_handler(reh, et, gen))
 
 
-    def _runout_event_handler(self, eventtime):
+    def _runout_event_handler(self, reactor_eventtime, eventtime, generation):
+        # Avoid issuing even a transient PAUSE when the callback was invalidated before
+        # it began. The command repeats this check after acquiring the gcode mutex.
+        if not self.active or not self._flowguard_enabled or generation != self._flowguard_generation:
+            self.min_event_systime = self.reactor.monotonic() + self.event_delay
+            return
+
         # Pausing from inside an event requires that the pause portion of pause_resume execute immediately.
         pause_resume = self.printer.lookup_object('pause_resume')
         pause_resume.send_pause_command()
         if self.pause_delay:
-            self.printer.get_reactor().pause(eventtime + self.pause_delay)
-        self._exec_gcode(self.runout_gcode)
+            self.printer.get_reactor().pause(reactor_eventtime + self.pause_delay)
+        self._exec_gcode(f"{self.runout_gcode} EVENTTIME={eventtime:.6f} GENERATION={generation}")
 
 
     def _insert_event_handler(self, eventtime):
@@ -416,9 +439,14 @@ class MmuEncoder:
 
             new_counts = count - self._last_count
             self._counts += new_counts
-            self._movement = new_counts > 0
+            movement = new_counts > 0
 
-            if self._movement:
+            # FlowGuard samples less often than the MCU counter. Latch movement until
+            # _extruder_pos_update_event() consumes it; an intervening empty counter
+            # sample must not erase a real pulse.
+            self._movement = self._movement or movement
+
+            if movement:
                 self._no_movement_count = 0
 
                 if not self._endstop_triggered:
@@ -431,7 +459,6 @@ class MmuEncoder:
         else:
             # No counts since last sample
             self._last_count_time = print_time
-            self._movement = False
             self._no_movement_count += 1
 
         if (self._endstop_triggered and self._no_movement_count >= self.no_movement_samples):

--- a/extras/mmu/unit/mmu_extruder_monitor.py
+++ b/extras/mmu/unit/mmu_extruder_monitor.py
@@ -54,8 +54,9 @@ class ExtruderMonitor:
         """
         Enable monitoring and start the watchdog immediately.
         """
-        self.mmu.reactor.update_timer(self._timer, self.mmu.reactor.NOW)
         self.active = True
+        self._rebase_extruder_position(eventtime)
+        self.mmu.reactor.update_timer(self._timer, self.mmu.reactor.NOW)
 
 
     def _handle_not_printing(self, eventtime):
@@ -64,14 +65,19 @@ class ExtruderMonitor:
         """
         self.mmu.reactor.update_timer(self._timer, self.mmu.reactor.NEVER)
         self.active = False
+        self._last_pos = None
 
 
     def enable(self):
+        if self.enabled:
+            return
         self.enabled = True
+        self._rebase_extruder_position()
 
 
     def disable(self):
         self.enabled = False
+        self._last_pos = None
 
 
     def register_callback(self, cb, movement_threshold):
@@ -90,7 +96,10 @@ class ExtruderMonitor:
         if movement_threshold is None or movement_threshold <= 0:
             raise ValueError("movement_threshold must be a positive float")
 
+        first_callback = not self._callbacks
         self._callbacks[cb] = {"threshold": float(movement_threshold), "accum": 0.0}
+        if first_callback:
+            self._rebase_extruder_position()
 
 
     def remove_callback(self, cb):
@@ -98,6 +107,8 @@ class ExtruderMonitor:
         Unregister a previously registered callback. Silently ignores unknown cbs.
         """
         self._callbacks.pop(cb, None)
+        if not self._callbacks:
+            self._last_pos = None
 
 
     def get_and_reset_accumulated(self, cb):
@@ -141,6 +152,21 @@ class ExtruderMonitor:
 
     # Internal Implementation ----------------------------------------
 
+    def _get_extruder_position(self, eventtime=None):
+        if eventtime is None:
+            eventtime = self.mmu.reactor.monotonic()
+        mcu = self.mmu.printer.lookup_object('mcu')
+        est_print_time = mcu.estimated_print_time(eventtime)
+        return self.extruder_wrapper.extruder_stepper_obj().find_past_position(est_print_time)
+
+
+    def _rebase_extruder_position(self, eventtime=None):
+        """Start a fresh movement epoch without waiting for the next monitor tick."""
+        if self.enabled and self.active and self._callbacks:
+            self._last_pos = self._get_extruder_position(eventtime)
+        else:
+            self._last_pos = None
+
     def _check_extruder_movement(self, eventtime):
         """
         Reactor timer entrypoint. Returns the next wakeup time.
@@ -148,9 +174,7 @@ class ExtruderMonitor:
         if not self.enabled or not self.active or not self._callbacks:
             return eventtime + self.CHECK_INTERVAL
 
-        mcu = self.mmu.printer.lookup_object('mcu')
-        est_print_time = mcu.estimated_print_time(eventtime)
-        pos = self.extruder_wrapper.extruder_stepper_obj().find_past_position(est_print_time)
+        pos = self._get_extruder_position(eventtime)
 
         # Initialize last position on first successful read
         if self._last_pos is None:

--- a/test/test_mmu_encoder.py
+++ b/test/test_mmu_encoder.py
@@ -106,6 +106,16 @@ class TestEncoderProfile(EncoderTestCase):
         self.assertEqual(blank, [], 'unpopulated keys in [%s]' % section)
         self.assertGreater(self.encoder.resolution, 0)
 
+    def test_runout_watchdog_is_active_only_during_printing(self):
+        self.assertFalse(self.encoder.active)
+
+        now = self.hh.reactor.monotonic()
+        self.hh.printer.send_event('mmu:printing', now)
+        self.assertTrue(self.encoder.active)
+
+        self.hh.printer.send_event('mmu:not_printing', now)
+        self.assertFalse(self.encoder.active)
+
 
 class TestEncoderMeasuresTravel(EncoderTestCase):
     """
@@ -158,6 +168,22 @@ class TestEncoderMeasuresTravel(EncoderTestCase):
         self.assertFalse(self.hh.sensor('unit0:encoder').present)
         self.preload()
         self.assertTrue(self.hh.sensor('unit0:encoder').present)
+
+    def test_movement_stays_latched_until_flowguard_consumes_it(self):
+        """
+        MCU counter reports arrive every 100ms, while FlowGuard samples every 250ms.
+        An empty counter report between a real pulse and the FlowGuard tick must not erase
+        the pulse. v3 latched this flag; the virtual-endstop work accidentally stopped doing
+        so in v4.
+        """
+        counter = self.hh.printer.harness_counters[ENCODER_PIN]
+        self.encoder._movement = False
+
+        counter.pulse(1)
+        self.assertTrue(self.encoder._movement, 'real pulse did not set the movement latch')
+
+        counter.pulse(0)
+        self.assertTrue(self.encoder._movement, 'empty MCU sample erased unconsumed movement')
 
 
 class TestGateHomingByMotion(EncoderTestCase):
@@ -447,6 +473,109 @@ class TestClogDetectionLength(EncoderTestCase):
         # Averaging down lands on a long float; only 1dp reaches mmu_vars.cfg
         self.assertEqual(self.calibrator.get_clog_detection_length(),
                          round(self.encoder.get_clog_detection_length(), 1))
+
+    def test_autotuning_does_not_run_while_flowguard_is_suspended(self):
+        """Match v3: toolchange/load suspension must not consume the print measurement."""
+        self.hh.run_gcode('MMU_TEST_CONFIG flowguard_encoder_mode=2')
+        self.calibrator.update_clog_detection_length(20.0, push=True)
+        self.encoder.enable_flowguard(self.unit)
+        self.encoder.min_headroom = 0.
+        before = self.encoder.get_clog_detection_length()
+
+        self.encoder.disable_flowguard()
+        self.encoder.note_clog_detection_length()
+
+        self.assertEqual(self.encoder.get_clog_detection_length(), before)
+
+    def test_material_autotune_change_restores_startup_headroom(self):
+        """v3 rebased significant changes with detection length plus desired headroom."""
+        self.hh.run_gcode('MMU_TEST_CONFIG flowguard_encoder_mode=2')
+        self.calibrator.update_clog_detection_length(20.0, push=True)
+        self.encoder.enable_flowguard(self.unit)
+        self.encoder.min_headroom = 0.
+
+        self.encoder._update_detection_length()
+
+        available = self.encoder.filament_runout_pos - self.encoder.last_extruder_pos
+        expected = self.encoder.detection_length + self.encoder.desired_headroom
+        self.assertAlmostEqual(available, expected)
+
+
+class TestEncoderRunoutEpoch(EncoderTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.mmu = self.hh.mmu
+        self.unit = self.mmu.mmu_unit(0)
+        self.pause_resume = self.hh.printer.lookup_object('pause_resume')
+        self.hh.run_gcode('MMU_TEST_CONFIG flowguard_encoder_mode=2')
+        self.mmu._enable_filament_monitoring()
+
+    def test_runout_queued_before_reactivation_is_ignored(self):
+        """
+        Encoder runout is inferred state. A load/unload suspension resets that state, so a
+        callback queued against the previous observation epoch must not run afterward.
+        """
+        self.hh.settle(1.0)
+        eventtime = self.hh.reactor.monotonic()
+        old_generation = self.encoder.get_flowguard_generation()
+
+        self.mmu._disable_filament_monitoring()
+        self.hh.settle(1.0)
+        self.mmu._enable_filament_monitoring()
+        self.assertNotEqual(old_generation, self.encoder.get_flowguard_generation())
+
+        runouts = []
+        self.mmu._runout = lambda **kwargs: runouts.append(kwargs)
+        self.pause_resume.send_pause_command() # What the queued encoder callback did
+        self.hh.run_gcode(
+            '__MMU_ENCODER_RUNOUT EVENTTIME=%.6f GENERATION=%d'
+            % (eventtime, old_generation)
+        )
+
+        self.assertEqual(runouts, [], 'stale encoder event reached runout handling')
+        self.assertFalse(self.pause_resume.is_paused, 'stale callback left PAUSE asserted')
+
+
+class TestExtruderMonitorRebase(EncoderTestCase):
+
+    def test_enable_and_first_active_subscription_rebase_position_immediately(self):
+        monitor = self.hh.mmu.mmu_unit(0).extruder_monitor()
+        callback = lambda eventtime, movement: None
+
+        monitor.disable()
+        monitor.active = True
+        monitor.register_callback(callback, 1.)
+        self.assertIsNone(monitor._last_pos, 'disabled monitor should not sample')
+
+        monitor.enable()
+        self.assertEqual(monitor._last_pos, monitor._get_extruder_position())
+
+        monitor.remove_callback(callback)
+        self.assertIsNone(monitor._last_pos)
+
+        monitor.register_callback(callback, 1.)
+        self.assertEqual(monitor._last_pos, monitor._get_extruder_position())
+
+        monitor._last_pos = 123.
+        monitor.enable()
+        self.assertEqual(monitor._last_pos, 123., 'redundant enable discarded an active interval')
+
+    def test_disable_and_last_unsubscribe_clear_position(self):
+        monitor = self.hh.mmu.mmu_unit(0).extruder_monitor()
+        callback = lambda eventtime, movement: None
+        monitor.active = True
+        monitor.enabled = True
+        monitor.register_callback(callback, 1.)
+
+        monitor._last_pos = 123.
+        monitor.disable()
+        self.assertIsNone(monitor._last_pos)
+
+        monitor.enable()
+        monitor._last_pos = 999.
+        monitor.remove_callback(callback)
+        self.assertIsNone(monitor._last_pos)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- latch encoder movement until the FlowGuard watchdog consumes it, preventing empty MCU samples from erasing valid pulses
- restore v3-compatible automatic detection-length behavior while monitoring is suspended and after material autotune changes
- restrict encoder runout monitoring to printing and invalidate callbacks queued across disable/re-enable cycles
- immediately rebase ExtruderMonitor from the live extruder position for sync-feedback and eSpooler subscribers
- add regression coverage for encoder timing, runout lifecycle, stale callbacks, autotune headroom, and monitor rebasing

## Testing

- Full suite: 1,190 tests passed
- Focused encoder/runout/sync-feedback/toolchange suite after final changes: 150 tests passed
- `git diff --check` passed
