### PR TITLE
Reject NFC scan of the currently loaded gate

### DIFF
--- a/extras/mmu/commands/mmu_nfc_scan.py
+++ b/extras/mmu/commands/mmu_nfc_scan.py
@@ -83,6 +83,12 @@ class MmuNfcScanCommand(BaseCommand):
         filament_pos = mmu.filament_pos
         is_unloaded = filament_pos == FILAMENT_POS_UNLOADED
 
+        # Crossloading only permits operating on another gate while filament is loaded.
+        # Jogging the filament in the gate that owns the active load would disturb the
+        # path to the extruder, regardless of whether this MMU can crossload.
+        if gate == current_gate and self.check_if_loaded():
+            return
+
         # Selecting a different gate with filament loaded requires a crossload-capable MMU -
         # and, if the gate endstop is a per-unit SHARED resource (mmu_shared_exit, extruder
         # entry, or the encoder), can_crossload alone isn't enough: it says the selector won't

--- a/test/test_mmu_nfc_scan.py
+++ b/test/test_mmu_nfc_scan.py
@@ -133,6 +133,32 @@ class TestJogScanFindsTag(NfcScanTestCase):
         self.assertIn('tag read', ' '.join(self.hh.console).lower())
         self.assertEqual(self.hh.errors, [])
 
+    def test_scan_refuses_the_current_gate_when_its_filament_is_loaded(self):
+        """Crossload capability must not permit jogging the gate owning the active load."""
+        self.preload(0)
+        self.hh.mmu.select_gate(0)
+        self.hh.mmu.filament_pos = FILAMENT_POS_LOADED
+        self.fil.history.clear()
+
+        self.hh.run_gcode('MMU_NFC_SCAN GATE=0')
+
+        self.assertEqual(self.fil.history, [], 'the currently loaded gate must not move')
+        self.assertTrue(any('filament is loaded' in e.lower() for e in self.hh.errors),
+                        self.hh.errors)
+
+    def test_preload_refuses_the_current_gate_when_its_filament_is_loaded(self):
+        """MMU_PRELOAD has the same invariant, including on a crossload-capable MMU."""
+        self.preload(0)
+        self.hh.mmu.select_gate(0)
+        self.hh.mmu.filament_pos = FILAMENT_POS_LOADED
+        self.fil.history.clear()
+
+        self.hh.run_gcode('MMU_PRELOAD GATE=0')
+
+        self.assertEqual(self.fil.history, [], 'preload must not move the currently loaded gate')
+        self.assertTrue(any('filament is loaded' in e.lower() for e in self.hh.errors),
+                        self.hh.errors)
+
     def test_backward_jog_finds_the_tag(self):
         """
         THE BACKWARD PATH. MmuNfcEndstop.home_start pins triggered=True because tag


### PR DESCRIPTION
## Summary

- reject `MMU_NFC_SCAN` when the target is the currently selected loaded gate
- keep crossload support limited to operating on other gates
- add regression coverage for both `MMU_NFC_SCAN` and the existing `MMU_PRELOAD` loaded-gate guard

## Testing

- `./venv/bin/python -m unittest test.test_mmu_nfc_scan` (53 tests)