### PR TITLE
Add sensorless gate preload mode

### DIFF
--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -185,18 +185,18 @@ gear_short_move_threshold   : [[PARAM_GEAR_SHORT_MOVE_THRESHOLD]]		# Move distan
 #   mmu_exit        - Use individual per-gate endstop (type-B MMU's)
 #   extruder        - Use extruder entry sensor (Only for some type-B designs, see [mmu_machine] require_bowden_move setting)
 #
-# The 'preload_endstop' and associated parameters typically would be the same as 'gate_home_endstop' or '' which means the same,
-# However it can be useful on type-B MMU's when preloading filament to the gate specific 'mmu_exit' sensor even if the gate
-# endstop is something else.
+# The 'preload_endstop' and associated parameters typically would be the same as 'gate_home_endstop' or '' which means the same.
+# It can also be the gate-specific 'mmu_exit' sensor on type-B MMU's, or 'none' for an unverified fixed-distance preload.
+# With 'none', preload_homing_max is the exact forward move, attempts and preload NFC motion are ignored, and the gate remains UNKNOWN.
 #
 gate_homing_endstop           : [[PARAM_GATE_HOMING_ENDSTOP]]	# Name of gate endstop used for filament parking
 gate_homing_max               : [[PARAM_GATE_HOMING_MAX]]		# Maximum extra move distance to home (or actual move distance if encoder endstop)
 gate_parking_distance         : [[PARAM_GATE_PARKING_DISTANCE]]		# ⚠️  Parking position relative to homing endstop. -ve=retraction, +ve=forward. Must be a retraction (<=0) unless endstop is mmu_exit
 
-gate_preload_endstop          : [[PARAM_GATE_PRELOAD_ENDSTOP]]		# Name of endstop used when preloading (if not set will default to gate_homing_endstop)
-gate_preload_homing_max       : [[PARAM_GATE_PRELOAD_HOMING_MAX]]		# Maximum homing distance to the mmu_exit endstop (if MMU is fitted with one)
+gate_preload_endstop          : [[PARAM_GATE_PRELOAD_ENDSTOP]]		# Name of endstop used when preloading; blank inherits gate_homing_endstop, none uses a fixed move
+gate_preload_homing_max       : [[PARAM_GATE_PRELOAD_HOMING_MAX]]		# Maximum homing distance, or exact fixed move distance when preload endstop is none
 gate_preload_parking_distance : [[PARAM_GATE_PRELOAD_PARKING_DISTANCE]]		# Parking position relative to preload endstop. -ve=retraction, +ve=forward. Must be a retraction (<=0) unless preload endstop is mmu_exit
-gate_preload_attempts         : [[PARAM_GATE_PRELOAD_ATTEMPTS]]		# How many attempts are made to pick up the filament with preload feature
+gate_preload_attempts         : [[PARAM_GATE_PRELOAD_ATTEMPTS]]		# How many attempts are made to pick up filament; ignored when preload endstop is none
 
 [% if MMU_HAS_ENCODER %]
 gate_endstop_to_encoder       : [[PARAM_GATE_ENDSTOP_TO_ENCODER]]		# Distance between gate endstop and encoder (IF both fitted. +ve if encoder after endstop)

--- a/config/base/mmu_parameters.cfg
+++ b/config/base/mmu_parameters.cfg
@@ -187,7 +187,7 @@ gear_short_move_threshold   : [[PARAM_GEAR_SHORT_MOVE_THRESHOLD]]		# Move distan
 #
 # The 'preload_endstop' and associated parameters typically would be the same as 'gate_home_endstop' or '' which means the same.
 # It can also be the gate-specific 'mmu_exit' sensor on type-B MMU's, or 'none' for an unverified fixed-distance preload.
-# With 'none', preload_homing_max is the exact forward move, attempts and preload NFC motion are ignored, and the gate remains UNKNOWN.
+# With 'none', preload_homing_max is the exact forward move; attempts, parking, and preload NFC motion are ignored, and the gate remains UNKNOWN.
 #
 gate_homing_endstop           : [[PARAM_GATE_HOMING_ENDSTOP]]	# Name of gate endstop used for filament parking
 gate_homing_max               : [[PARAM_GATE_HOMING_MAX]]		# Maximum extra move distance to home (or actual move distance if encoder endstop)
@@ -195,7 +195,7 @@ gate_parking_distance         : [[PARAM_GATE_PARKING_DISTANCE]]		# ⚠️  Parki
 
 gate_preload_endstop          : [[PARAM_GATE_PRELOAD_ENDSTOP]]		# Name of endstop used when preloading; blank inherits gate_homing_endstop, none uses a fixed move
 gate_preload_homing_max       : [[PARAM_GATE_PRELOAD_HOMING_MAX]]		# Maximum homing distance, or exact fixed move distance when preload endstop is none
-gate_preload_parking_distance : [[PARAM_GATE_PRELOAD_PARKING_DISTANCE]]		# Parking position relative to preload endstop. -ve=retraction, +ve=forward. Must be a retraction (<=0) unless preload endstop is mmu_exit
+gate_preload_parking_distance : [[PARAM_GATE_PRELOAD_PARKING_DISTANCE]]		# Parking position relative to preload endstop. Ignored with none; otherwise -ve=retraction, +ve=forward, and must be <=0 unless using mmu_exit
 gate_preload_attempts         : [[PARAM_GATE_PRELOAD_ATTEMPTS]]		# How many attempts are made to pick up filament; ignored when preload endstop is none
 
 [% if MMU_HAS_ENCODER %]

--- a/extras/mmu/commands/mmu_preload.py
+++ b/extras/mmu/commands/mmu_preload.py
@@ -97,6 +97,7 @@ class MmuPreloadCommand(BaseCommand):
 
         can_preload = (
             filament_pos == FILAMENT_POS_UNLOADED
+            or preload_endstop == SENSOR_GATE_NONE
             or mmu.sensor_manager.has_gate_sensor(SENSOR_EXIT_PREFIX, gate)
             or (
                    not is_unloaded

--- a/extras/mmu/mmu_constants.py
+++ b/extras/mmu/mmu_constants.py
@@ -145,6 +145,7 @@ MACRO_FORM_TIP  = "_MMU_FORM_TIP"
 SENSOR_ENCODER           = "encoder"               # Fake Gate endstop using encoder
 SENSOR_SHARED_EXIT       = "mmu_shared_exit"
 SENSOR_EXIT_PREFIX       = "mmu_exit"
+SENSOR_GATE_NONE         = "none"                  # Sensorless gate preload using a fixed move
 
 SENSOR_EXTRUDER_NONE     = "none"                  # Fake Extruder endstop aka don't attempt home
 SENSOR_EXTRUDER_ENCODER  = "encoder"               # Fake Extruder endstop (uses encoder to detect collision)

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -86,7 +86,8 @@ class MmuFilamentMovement:
             endstop=u.p.gate_preload_endstop,
             homing_max=u.p.gate_preload_homing_max,
             parking_distance=u.p.gate_preload_parking_distance,
-            attempts=u.p.gate_preload_attempts,
+            attempts=(1 if u.p.gate_preload_endstop == SENSOR_GATE_NONE
+                      else u.p.gate_preload_attempts),
             jog_scan_window=u.p.nfc_preload_jog_scan_window,
             clear_distance=u.p.nfc_preload_clear_distance,
         )
@@ -152,6 +153,30 @@ class MmuFilamentMovement:
                     # Ensure expected sync/grip state before macro
                     self.reset_sync_gear_to_extruder(False, force_grip=True)
                     self.wrap_gcode_command(self.p.post_preload_macro, exception=True, wait=True)
+
+        # Explicitly sensorless preload is an open-loop operation. Keep it separate from the
+        # established homing/NFC path below: there is no datum to validate, retry, scan from,
+        # or use for a verified AVAILABLE result. A completed motor sequence is still a
+        # completed preload command, but filament presence remains unknown by definition.
+        if self.mmu_unit().p.gate_preload_endstop == SENSOR_GATE_NONE:
+            profile = self._preload_profile()
+            self.log_always("Preloading gate %d with fixed move..." % gate)
+            self.gate_maps.set_gate_status(gate, GATE_UNKNOWN)
+            with self.wrap_suspend_filament_monitoring(), self.wrap_suspend_insert_events():
+                self.set_filament_direction(DIRECTION_LOAD)
+                self.move_filament("Fixed preload move", profile.homing_max)
+                self.set_filament_direction(DIRECTION_UNLOAD)
+                self.move_filament("Final parking", profile.parking_distance)
+                self.set_filament_pos_state(FILAMENT_POS_UNLOADED)
+
+            self.gate_maps.set_gate_status(gate, GATE_UNKNOWN)
+            self.last_preloaded_gate = gate
+            self._check_pending_filament(gate, pending=pending)
+            self.log_always(
+                "Fixed preload move complete for gate %d; filament presence was not verified"
+                % gate)
+            run_post_preload_macro()
+            return
 
         # Already preloaded? (a per-gate mmu_exit sensor that already reads filament present)
         if self.sensor_manager.check_gate_sensor(SENSOR_EXIT_PREFIX, gate):

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -156,7 +156,7 @@ class MmuFilamentMovement:
 
         # Explicitly sensorless preload is an open-loop operation. Keep it separate from the
         # established homing/NFC path below: there is no datum to validate, retry, scan from,
-        # or use for a verified AVAILABLE result. A completed motor sequence is still a
+        # or use for a verified AVAILABLE result. A completed fixed move is still a
         # completed preload command, but filament presence remains unknown by definition.
         if self.mmu_unit().p.gate_preload_endstop == SENSOR_GATE_NONE:
             profile = self._preload_profile()
@@ -165,8 +165,6 @@ class MmuFilamentMovement:
             with self.wrap_suspend_filament_monitoring(), self.wrap_suspend_insert_events():
                 self.set_filament_direction(DIRECTION_LOAD)
                 self.move_filament("Fixed preload move", profile.homing_max)
-                self.set_filament_direction(DIRECTION_UNLOAD)
-                self.move_filament("Final parking", profile.parking_distance)
                 self.set_filament_pos_state(FILAMENT_POS_UNLOADED)
 
             self.gate_maps.set_gate_status(gate, GATE_UNKNOWN)

--- a/extras/mmu/unit/mmu_unit_parameters.py
+++ b/extras/mmu/unit/mmu_unit_parameters.py
@@ -82,6 +82,7 @@ class MmuUnitParameters(TunableParametersBase):
         if new != old:
             self._validate_gate_preload_parking_distance(self.gate_preload_parking_distance)
             self._validate_nfc_preload_clear_distance(self.nfc_preload_clear_distance)
+            self._validate_sensorless_preload_profile()
 
     def _on_gate_homing_max(self, old, new):
         if new != old:
@@ -94,10 +95,12 @@ class MmuUnitParameters(TunableParametersBase):
     def _on_gate_preload_homing_max(self, old, new):
         if new != old:
             self._validate_nfc_preload_clear_distance(self.nfc_preload_clear_distance)
+            self._validate_sensorless_preload_profile()
 
     def _on_gate_preload_parking_distance(self, old, new):
         if new != old:
             self._validate_nfc_preload_clear_distance(self.nfc_preload_clear_distance)
+            self._validate_sensorless_preload_profile()
 
     def _on_flowguard_tuning_change(self, old, new):
         # Push live FlowGuard tuning (relief) to a running controller
@@ -130,7 +133,8 @@ class MmuUnitParameters(TunableParametersBase):
 
     def _validate_nfc_preload_jog_scan_window(self, value):
         # empty disables scan-on-miss during MMU_PRELOAD; datum-relative like the gate window
-        if not value:
+        endstop = self.gate_preload_endstop or self.gate_homing_endstop # '' inherits gate_homing_endstop
+        if endstop == SENSOR_GATE_NONE or not value:
             return
         if len(value) != 2:
             raise ValueError("nfc_preload_jog_scan_window must be two values (neg, pos), e.g. 0,480")
@@ -185,12 +189,12 @@ class MmuUnitParameters(TunableParametersBase):
 
     def _validate_nfc_preload_clear_distance(self, value):
         # 0 disables; independent of nfc_gate_clear_distance, can differ including in sign
-        if not value:
+        endstop = self.gate_preload_endstop or self.gate_homing_endstop # '' inherits gate_homing_endstop
+        if endstop == SENSOR_GATE_NONE or not value:
             return
         self._validate_nfc_clear_reach(
             'nfc_preload_clear_distance', value, self.gate_preload_parking_distance,
             self.gate_preload_homing_max)
-        endstop = self.gate_preload_endstop or self.gate_homing_endstop # '' inherits gate_homing_endstop
         if value > 0 and endstop in SHARED_GATE_ENDSTOPS:
             raise ValueError(
                 "nfc_preload_clear_distance must be a backward jog (< 0) unless the preload "
@@ -231,6 +235,15 @@ class MmuUnitParameters(TunableParametersBase):
                 "endstop is '%s' (got %.1f with endstop '%s')"
                 % (SENSOR_EXIT_PREFIX, value, endstop))
 
+    def _validate_sensorless_preload_profile(self):
+        endstop = self.gate_preload_endstop or self.gate_homing_endstop # '' inherits gate_homing_endstop
+        if endstop != SENSOR_GATE_NONE:
+            return
+        if self.gate_preload_homing_max <= 0:
+            raise ValueError(
+                "gate_preload_homing_max must be greater than 0 when gate_preload_endstop "
+                "is '%s' (got %.1f)" % (SENSOR_GATE_NONE, self.gate_preload_homing_max))
+
 
     # ---- Specs ----
 
@@ -242,7 +255,7 @@ class MmuUnitParameters(TunableParametersBase):
         ParamSpec('gate_load_attempts',               'int',       1, section="GATE HOMING", limits=dict(minval=1, maxval=20)),
 
         # Gate preloading
-        ParamSpec('gate_preload_endstop',             'choice',   '', section="GATE HOMING", choices={o: o for o in (GATE_ENDSTOPS + [''])}, on_change=_on_gate_preload_endstop),
+        ParamSpec('gate_preload_endstop',             'choice',   '', section="GATE HOMING", choices={o: o for o in (GATE_ENDSTOPS + [SENSOR_GATE_NONE, ''])}, on_change=_on_gate_preload_endstop),
         ParamSpec('gate_preload_homing_max',          'float', lambda self: self.gate_homing_max, section="GATE HOMING", on_change=_on_gate_preload_homing_max),
         ParamSpec('gate_preload_parking_distance',    'float', -10.0, section="GATE HOMING", validator=_validate_gate_preload_parking_distance, on_change=_on_gate_preload_parking_distance),
         ParamSpec('gate_preload_attempts',            'int',       2, section="GATE HOMING", limits=dict(minval=1, maxval=20)),
@@ -377,6 +390,7 @@ class MmuUnitParameters(TunableParametersBase):
     def _post_load_fixups(self):
         # gate_preload_endstop: if blank, inherit gate_homing_endstop
         self.gate_preload_endstop = self.gate_preload_endstop or self.gate_homing_endstop
+        self._validate_sensorless_preload_profile()
 
         # filament_always_gripped: forces sync flags on
         if self._mmu_unit.filament_always_gripped:

--- a/extras/mmu/unit/mmu_unit_parameters.py
+++ b/extras/mmu/unit/mmu_unit_parameters.py
@@ -229,7 +229,7 @@ class MmuUnitParameters(TunableParametersBase):
 
     def _validate_gate_preload_parking_distance(self, value):
         endstop = self.gate_preload_endstop or self.gate_homing_endstop # '' inherits gate_homing_endstop
-        if value > 0 and endstop != SENSOR_EXIT_PREFIX:
+        if value > 0 and endstop not in [SENSOR_EXIT_PREFIX, SENSOR_GATE_NONE]:
             raise ValueError(
                 "gate_preload_parking_distance must be a retraction (<= 0) unless the preload "
                 "endstop is '%s' (got %.1f with endstop '%s')"

--- a/installer/Kconfig.preload_eject
+++ b/installer/Kconfig.preload_eject
@@ -32,12 +32,24 @@ menu "Filament preloading and ejection"
         Use individual per-gate exit sensor (often implemented as the per-gate hub entry sensor)
         This can be useful on type-B MMU's when preloading filament while another gate has filament
         loaded and the gate endstop is shared.
+
+    config CHOICE_GATE_PRELOAD_ENDSTOP_NONE
+      bool "No sensor / fixed move"
+      help
+        Perform one fixed forward preload move followed by the configured parking move.
+        Filament presence cannot be verified, so the gate will remain marked unknown.
+        Per-gate NFC preload scanning and its associated clear/jog moves are not used.
+
+        When crossloading, the configured distance must remain inside the target gate's
+        independent filament path. Crossload capability alone does not guarantee that a
+        shared hub or downstream filament path is clear.
   endchoice
 
   # Create no-prompt param from choice
   config PARAM_GATE_PRELOAD_ENDSTOP
     string
     default "mmu_exit" if CHOICE_GATE_PRELOAD_ENDSTOP_EXIT
+    default "none"     if CHOICE_GATE_PRELOAD_ENDSTOP_NONE
     default ""         # Defaults to gate homing endstop
 
 
@@ -49,7 +61,9 @@ menu "Filament preloading and ejection"
     float "Preload homing distance     "
     default PARAM_GATE_HOMING_MAX
     help
-      Maximum homing distance (mm) to the mmu_exit endstop
+      Maximum homing distance (mm) to the configured preload endstop.
+
+      With no preload sensor this becomes the exact fixed forward move distance.
 
       Usually this is the same as gate homing distance
 
@@ -59,6 +73,7 @@ menu "Filament preloading and ejection"
     help
       Filament parking distance (mm) after homing to configured gate homing sensor
       or per-gate "mmu_exit" sensor if available.
+      With no preload sensor this is a fixed move relative to the end of the forward move.
       Usually this is the same as gate parking distance
 
       Negative values for movement in the retract direction (back off sensor)
@@ -72,10 +87,14 @@ menu "Filament preloading and ejection"
       If mmu entry sensor fitted this controls the automatic loading of the gate
 
   config PARAM_GATE_PRELOAD_ATTEMPTS
-    int "Number of preload attempts  "
+    int
+    prompt "Number of preload attempts  " if !CHOICE_GATE_PRELOAD_ENDSTOP_NONE
+    default 1 if CHOICE_GATE_PRELOAD_ENDSTOP_NONE
     default 2
     help
       Number of attempts to make at loading the filament after preload is issued.
+
+      Fixed at one when no preload sensor is selected.
 
   comment "_"
 

--- a/installer/Kconfig.preload_eject
+++ b/installer/Kconfig.preload_eject
@@ -36,7 +36,7 @@ menu "Filament preloading and ejection"
     config CHOICE_GATE_PRELOAD_ENDSTOP_NONE
       bool "No sensor / fixed move"
       help
-        Perform one fixed forward preload move followed by the configured parking move.
+        Perform one fixed forward preload move. The configured parking distance is ignored.
         Filament presence cannot be verified, so the gate will remain marked unknown.
         Per-gate NFC preload scanning and its associated clear/jog moves are not used.
 
@@ -68,12 +68,13 @@ menu "Filament preloading and ejection"
       Usually this is the same as gate homing distance
 
   config PARAM_GATE_PRELOAD_PARKING_DISTANCE
-    float "Preload parking distance    "
+    float
+    prompt "Preload parking distance    " if !CHOICE_GATE_PRELOAD_ENDSTOP_NONE
     default PARAM_GATE_PARKING_DISTANCE
     help
       Filament parking distance (mm) after homing to configured gate homing sensor
       or per-gate "mmu_exit" sensor if available.
-      With no preload sensor this is a fixed move relative to the end of the forward move.
+      This setting is ignored when no preload sensor is selected.
       Usually this is the same as gate parking distance
 
       Negative values for movement in the retract direction (back off sensor)

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -337,6 +337,17 @@ MMX = Profile(
           'MMU_HAS_SENSOR_SHARED_EXIT': True},
     description='MMX 1.0 - 4 gates, ServoSelector with vendor gate angles')
 
+# KMS with its ordinary defaults. OPTION_KMS_BUFFER is deliberately not set here: the
+# machine type implies it, and that default enables the four per-gate mmu_exit sensors.
+# Keeping gate/preload symbols out of the profile makes this useful for console experiments
+# that switch gate_preload_endstop to none at runtime with MMU_TEST_CONFIG. Jabberwocky is
+# simply the randomly selected toolhead requested for this fixture.
+KMS = Profile(
+    'kms',
+    syms={'MMU_TYPE_KMS_1_0': True,
+          'TOOLHEAD_TYPE_JABBERWOCKY': True},
+    description='KMS 1.0 defaults - 4 gates, exit sensors, Jabberwocky toolhead')
+
 # EMU: 5 gates, and the only shipped profile that brings a PROPORTIONAL (analog) buffer
 # sensor with it. That makes it the profile that exercises MmuAdcHelper's ADC compat shim
 # for real, and the virtual compression/tension sensors derived from an analog reading
@@ -350,8 +361,8 @@ EMU = Profile(
     syms={'MMU_TYPE_EMU_1_0': True},
     description='EMU 1.0 - 5 gates, proportional (analog) buffer sensor')
 
-# BoxTurtle plus an encoder, homing to it instead of to the gate switch. None of the
-# three shipped machine profiles ships an encoder, and _home_to_gate's encoder branch
+# BoxTurtle plus an encoder, homing to it instead of to the gate switch. KMS also ships an
+# encoder, but its exit sensors win the default homing choice, so _home_to_gate's encoder branch
 # (extras/mmu/mmu_filament_movement.py:206-231) is a completely different algorithm from
 # the endstop branch: it does not home at all, it makes a fixed-length move and asks
 # whether the filament MOVED. Nothing else covers it.
@@ -567,7 +578,7 @@ run_current: 0.6
 # also the startup picker's source, so its list and the accepted profile objects stay one
 # thing. The buffered and dual-extruder ERCF variants below are registered for tests but are
 # deliberately absent: one is synthetic and the other needs EXTRA_EXTRUDER_STUB.
-CONSOLE_PROFILES = (ERCF_VVD, BOXTURTLE, TRADRACK, CHAMELEON, PICO_MMU, MMX, EMU, ENCODER,
+CONSOLE_PROFILES = (ERCF_VVD, BOXTURTLE, TRADRACK, CHAMELEON, PICO_MMU, MMX, KMS, EMU, ENCODER,
                     NFC_SINGLE, NFC_PER_GATE, NFC_NEIGHBOR_CHECK, NFC_NEIGHBOR_EVICT,
                     NFC_GATE_CLEAR,
                     NFC_PN5180, NFC_PN5180_PER_GATE, NFC_PN532, NFC_PN532_SW_I2C,

--- a/test/test_mmu_config.py
+++ b/test/test_mmu_config.py
@@ -74,6 +74,18 @@ class TestBoxTurtleRender(unittest.TestCase):
                          'gcode_macro _MMU_SEQUENCE_VARS'):
             self.assertIn(expected, secs)
 
+    def test_sensorless_preload_choice_renders_none_and_one_attempt(self):
+        profile = profiles.get('boxturtle').derive(
+            'boxturtle_sensorless_preload',
+            syms={'CHOICE_GATE_PRELOAD_ENDSTOP_NONE': True})
+        rendered = cfg.render(profile)
+        parser = cfg.assemble(rendered)
+        params = dict(parser.items('mmu_unit_parameters unit0'))
+
+        self.assertEqual(params['gate_preload_endstop'], 'none')
+        # The prompt is hidden in this mode, but the typed symbol retains an explicit value.
+        self.assertEqual(params['gate_preload_attempts'], '1')
+
     def test_every_rendered_macro_variable_is_a_valid_klipper_literal(self):
         """Real Klipper rejects the entire config if any variable is not a Python literal."""
         parser = cfg.assemble(self.rendered, macros=False)

--- a/test/test_mmu_motion.py
+++ b/test/test_mmu_motion.py
@@ -45,6 +45,8 @@ logging.getLogger().setLevel(logging.CRITICAL)
 
 FILAMENT_POS_UNLOADED = 0
 FILAMENT_POS_HOMED_GATE = 1
+FILAMENT_POS_LOADED = 10
+GATE_UNKNOWN = -1
 GATE_EMPTY = 0
 GATE_AVAILABLE = 1
 
@@ -560,6 +562,144 @@ class TestPreload(MotionTestCase):
         self.hh.place_filament(1, position=TIP_AT_GATE)
         self.hh.run_gcode('MMU_PRELOAD GATE=1')
         self.assertAlmostEqual(self.fil.tip[0], TIP_PARKED, places=3)
+
+
+class TestSensorlessPreload(MotionTestCase):
+    """gate_preload_endstop=none is open-loop and must not disturb normal preload."""
+
+    FIXED_MOVE = 120.0
+    PARKING_MOVE = -20.0
+
+    def setUp(self):
+        super().setUp()
+        # Apply dependent values in an order that keeps every intermediate runtime profile
+        # valid. MMU_TEST_CONFIG deliberately applies each command immediately.
+        self.hh.run_gcode(
+            'MMU_TEST_CONFIG UNIT=0 gate_preload_parking_distance=%.1f'
+            % self.PARKING_MOVE)
+        self.hh.run_gcode(
+            'MMU_TEST_CONFIG UNIT=0 gate_preload_homing_max=%.1f'
+            % self.FIXED_MOVE)
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=none')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_attempts=9')
+        self.assertEqual(self.hh.errors, [], 'sensorless preload setup was not clean')
+
+    def test_fixed_preload_is_one_plain_move_then_parking(self):
+        self.hh.place_filament(1, position=TIP_AT_GATE)
+        self.fil.history.clear()
+
+        self.hh.run_gcode('MMU_PRELOAD GATE=1')
+
+        legs = [(distance, reason) for gate, distance, reason in self.fil.history
+                if gate == 1]
+        self.assertEqual(len(legs), 2, legs)
+        self.assertAlmostEqual(legs[0][0], self.FIXED_MOVE)
+        self.assertAlmostEqual(legs[1][0], self.PARKING_MOVE)
+        self.assertFalse(any('homing' in reason.lower() for _distance, reason in legs), legs)
+        self.assertAlmostEqual(
+            self.fil.tip[1], TIP_AT_GATE + self.FIXED_MOVE + self.PARKING_MOVE)
+
+    def test_attempts_are_forced_to_one_and_gate_remains_unknown(self):
+        self.hh.place_filament(1, position=TIP_AT_GATE)
+        self.hh.run_gcode('MMU_PRELOAD GATE=1')
+
+        profile = self.hh.mmu._preload_profile()
+        self.assertEqual(profile.attempts, 1)
+        self.assertEqual(self.hh.mmu.gate_status[1], GATE_UNKNOWN)
+        self.assertEqual(self.hh.mmu.filament_pos, FILAMENT_POS_UNLOADED)
+        self.assertEqual(self.hh.mmu.last_preloaded_gate, 1)
+        self.assertIn('presence was not verified', ' '.join(self.hh.console))
+        self.assertNotIn('Filament detected and loaded in gate 1', self.hh.console)
+        self.assertEqual(self.hh.errors, [])
+
+    def test_runtime_endstop_change_only_forces_attempts_while_none_is_active(self):
+        unit = self.hh.mmu.mmu_unit(0)
+        self.assertEqual(unit.p.gate_preload_attempts, 9)
+        self.assertEqual(self.hh.mmu._preload_profile().attempts, 1)
+
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=mmu_exit')
+        profile = self.hh.mmu._preload_profile()
+        self.assertEqual(profile.endstop, 'mmu_exit')
+        self.assertEqual(profile.attempts, 9)
+
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=none')
+        profile = self.hh.mmu._preload_profile()
+        self.assertEqual(profile.endstop, 'none')
+        self.assertEqual(profile.attempts, 1)
+        self.assertEqual(self.hh.errors, [])
+
+    def test_runtime_can_apply_complete_sensorless_profile_in_one_command(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=mmu_exit')
+        self.hh.run_gcode(
+            'MMU_TEST_CONFIG UNIT=0 gate_preload_attempts=7 '
+            'gate_preload_endstop=none gate_preload_homing_max=60 '
+            'gate_preload_parking_distance=-20 nfc_preload_clear_distance=-500 '
+            'nfc_preload_jog_scan_window=-500,500')
+
+        unit = self.hh.mmu.mmu_unit(0)
+        profile = self.hh.mmu._preload_profile()
+        self.assertEqual(unit.p.gate_preload_attempts, 7)
+        self.assertEqual(profile.endstop, 'none')
+        self.assertEqual(profile.homing_max, 60.0)
+        self.assertEqual(profile.parking_distance, -20.0)
+        self.assertEqual(profile.attempts, 1)
+        self.assertEqual(profile.clear_distance, -500.0)
+        self.assertEqual(profile.jog_scan_window, [-500.0, 500.0])
+        self.assertEqual(self.hh.errors, [])
+
+    def test_no_filament_is_not_misreported_as_empty_or_available(self):
+        self.hh.place_filament(2, position=-100000.0)
+        self.hh.run_gcode('MMU_PRELOAD GATE=2')
+
+        self.assertEqual(self.hh.mmu.gate_status[2], GATE_UNKNOWN)
+        self.assertEqual(self.hh.errors, [])
+
+    def test_fitted_exit_sensor_does_not_take_already_preloaded_shortcut(self):
+        self.hh.place_filament(1, position=self.fil.layout['mmu_exit'] + 5.0)
+        self.assertTrue(self.hh.sensor('mmu_exit_1').present)
+        self.fil.history.clear()
+
+        self.hh.run_gcode('MMU_PRELOAD GATE=1')
+
+        legs = [(distance, reason) for gate, distance, reason in self.fil.history
+                if gate == 1]
+        self.assertEqual([distance for distance, _reason in legs],
+                         [self.FIXED_MOVE, self.PARKING_MOVE])
+        self.assertFalse(any('homing' in reason.lower() for _distance, reason in legs), legs)
+        self.assertEqual(self.hh.mmu.gate_status[1], GATE_UNKNOWN)
+        self.assertNotIn('already preloaded', ' '.join(self.hh.console).lower())
+
+    def test_pending_spool_identity_is_applied_after_completed_fixed_move(self):
+        self.hh.place_filament(1, position=TIP_AT_GATE)
+        self.hh.mmu.pending_spool_id = 7
+        self.hh.run_gcode('MMU_PRELOAD GATE=1')
+
+        self.assertEqual(self.hh.mmu.gate_spool_id[1], 7)
+        self.assertEqual(self.hh.mmu.gate_status[1], GATE_UNKNOWN)
+
+    def test_current_loaded_gate_is_refused_before_motion(self):
+        self.hh.mmu.select_gate(0)
+        self.hh.mmu.filament_pos = FILAMENT_POS_LOADED
+        self.fil.history.clear()
+
+        self.hh.run_gcode('MMU_PRELOAD GATE=0')
+
+        self.assertEqual(self.fil.history, [])
+        self.assertTrue(any('filament is loaded' in error.lower()
+                            for error in self.hh.errors), self.hh.errors)
+
+    def test_crossload_preloads_another_gate_and_restores_loaded_state(self):
+        self.hh.place_filament(0)
+        self.hh.place_filament(2, position=TIP_AT_GATE)
+        self.hh.mmu.select_gate(0)
+        self.hh.mmu.filament_pos = FILAMENT_POS_LOADED
+
+        self.hh.run_gcode('MMU_PRELOAD GATE=2')
+
+        self.assertEqual(self.hh.mmu.gate_selected, 0)
+        self.assertEqual(self.hh.mmu.filament_pos, FILAMENT_POS_LOADED)
+        self.assertEqual(self.hh.mmu.gate_status[2], GATE_UNKNOWN)
+        self.assertEqual(self.hh.errors, [])
 
 
 class TestNfcEndstopTrips(unittest.TestCase):

--- a/test/test_mmu_motion.py
+++ b/test/test_mmu_motion.py
@@ -584,7 +584,7 @@ class TestSensorlessPreload(MotionTestCase):
         self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_attempts=9')
         self.assertEqual(self.hh.errors, [], 'sensorless preload setup was not clean')
 
-    def test_fixed_preload_is_one_plain_move_then_parking(self):
+    def test_fixed_preload_is_one_plain_move_without_parking(self):
         self.hh.place_filament(1, position=TIP_AT_GATE)
         self.fil.history.clear()
 
@@ -592,12 +592,22 @@ class TestSensorlessPreload(MotionTestCase):
 
         legs = [(distance, reason) for gate, distance, reason in self.fil.history
                 if gate == 1]
-        self.assertEqual(len(legs), 2, legs)
+        self.assertEqual(len(legs), 1, legs)
         self.assertAlmostEqual(legs[0][0], self.FIXED_MOVE)
-        self.assertAlmostEqual(legs[1][0], self.PARKING_MOVE)
         self.assertFalse(any('homing' in reason.lower() for _distance, reason in legs), legs)
-        self.assertAlmostEqual(
-            self.fil.tip[1], TIP_AT_GATE + self.FIXED_MOVE + self.PARKING_MOVE)
+        self.assertAlmostEqual(self.fil.tip[1], TIP_AT_GATE + self.FIXED_MOVE)
+
+    def test_runtime_parking_distance_is_accepted_but_ignored(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_parking_distance=25')
+        self.hh.place_filament(1, position=TIP_AT_GATE)
+        self.fil.history.clear()
+
+        self.hh.run_gcode('MMU_PRELOAD GATE=1')
+
+        legs = [(distance, reason) for gate, distance, reason in self.fil.history
+                if gate == 1]
+        self.assertEqual([distance for distance, _reason in legs], [self.FIXED_MOVE])
+        self.assertEqual(self.hh.errors, [])
 
     def test_attempts_are_forced_to_one_and_gate_remains_unknown(self):
         self.hh.place_filament(1, position=TIP_AT_GATE)
@@ -664,7 +674,7 @@ class TestSensorlessPreload(MotionTestCase):
         legs = [(distance, reason) for gate, distance, reason in self.fil.history
                 if gate == 1]
         self.assertEqual([distance for distance, _reason in legs],
-                         [self.FIXED_MOVE, self.PARKING_MOVE])
+                         [self.FIXED_MOVE])
         self.assertFalse(any('homing' in reason.lower() for _distance, reason in legs), legs)
         self.assertEqual(self.hh.mmu.gate_status[1], GATE_UNKNOWN)
         self.assertNotIn('already preloaded', ' '.join(self.hh.console).lower())

--- a/test/test_mmu_nfc_scan.py
+++ b/test/test_mmu_nfc_scan.py
@@ -329,7 +329,7 @@ class TestPreloadNfcCompound(NfcScanTestCase):
         self.assertFalse(any('nfc' in reason or 'homing' in reason for reason in reasons),
                          reasons)
         self.assertEqual([distance for _gate, distance, _reason in self.fil.history],
-                         [120.0, -20.0])
+                         [120.0])
         self.assertEqual(self.hh.mmu.gate_status[0], GATE_UNKNOWN)
         self.assertNotIn('with nfc scan', ' '.join(self.hh.console).lower())
         self.assertEqual(self.hh.errors, [])

--- a/test/test_mmu_nfc_scan.py
+++ b/test/test_mmu_nfc_scan.py
@@ -41,6 +41,7 @@ NFC_PER_GATE_ENCODER = hh_profiles.NFC_PER_GATE.derive(
 
 logging.getLogger().setLevel(logging.CRITICAL)
 
+GATE_UNKNOWN = -1
 GATE_AVAILABLE = 1
 FILAMENT_POS_UNLOADED = 0
 FILAMENT_POS_LOADED = 10
@@ -313,6 +314,25 @@ class TestPreloadNfcCompound(NfcScanTestCase):
         said = ' '.join(self.hh.console[at:]).lower()
         self.assertIn('preloading gate 0...', said)
         self.assertNotIn('nfc:', said)
+
+    def test_sensorless_preload_bypasses_nfc_compound_and_scan_motion(self):
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_parking_distance=-20')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_homing_max=120')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=none')
+        self.fil.attach_tag(0, TAG, {'material': 'PLA'}, offset=40.0)
+        self.hh.place_filament(0, position=-100.0)
+        self.fil.history.clear()
+
+        self.hh.run_gcode('MMU_PRELOAD GATE=0')
+
+        reasons = [reason.lower() for _gate, _distance, reason in self.fil.history]
+        self.assertFalse(any('nfc' in reason or 'homing' in reason for reason in reasons),
+                         reasons)
+        self.assertEqual([distance for _gate, distance, _reason in self.fil.history],
+                         [120.0, -20.0])
+        self.assertEqual(self.hh.mmu.gate_status[0], GATE_UNKNOWN)
+        self.assertNotIn('with nfc scan', ' '.join(self.hh.console).lower())
+        self.assertEqual(self.hh.errors, [])
 
     def test_last_preloaded_gate_is_recorded_on_success(self):
         """MMU_SPOOLMAN_TAG GATE=LAST relies on this being set after a normal successful preload."""

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -5,7 +5,7 @@
 # [% if %] guard or a missing template section shows up here rather than on a user's
 # printer.
 #
-# There are 19 shipped machine types. Eight boot in the harness today:
+# There are 19 shipped machine types. Nine boot in the harness today:
 #
 #   boxturtle  4 gates,  VirtualSelector       - Type B, the default everywhere else
 #   tradrack  10 gates,  LinearServoSelector   - a PHYSICAL selector, so the suite is not
@@ -17,6 +17,7 @@
 #                                                servo has no universally safe gate defaults
 #   mmx        4 gates,  ServoSelector         - vendor-supplied gate angles, including a
 #                                                full load/unload behavioral test
+#   kms        4 gates,  VirtualSelector       - default KMS buffer with per-gate exit sensors
 #   emu        5 gates,  VirtualSelector       - the only shipped profile with a
 #                                                PROPORTIONAL (analog) buffer sensor
 #   ercf 1.1   9 gates,  LinearServoSelector   - unit0 of ercf_vvd; encoder gate homing
@@ -29,7 +30,7 @@
 #   "13 need the machine x board pin selection" - a board choice is all that was needed;
 #       ercf_vvd carries BOARD_TYPE_ERB_1 and BOARD_TYPE_VVD_1_0.
 #   "2 need a heater_generic fake" - added (klippy_root/extras/heater_generic.py); ViViD
-#       was one of the two, KMS is the other and should now boot as well.
+#       and KMS now both boot with their real heater configuration.
 #   "1 needs an unselected choice param" - the MMU serial device, whose symbol NAME comes
 #       from `ls /dev/serial/by-id/*` (Kconfig:112-116) and so does not exist on a host with
 #       no MMU attached. The answer is to omit it: the choice falls back to ..._OTHER and
@@ -57,6 +58,7 @@ BOOTABLE = {
     'chameleon': (4, 'RotarySelector'),
     'pico_mmu': (4, 'ServoSelector'),
     'mmx': (4, 'ServoSelector'),
+    'kms': (4, 'VirtualSelector'),
     'emu': (5, 'VirtualSelector'),
     # The only multi-unit entry. 13 is a CROSS-UNIT SUM (unit0 9 + unit1 4), not one unit's
     # count, and the selector named here is unit0's - unit1 is an IndexedSelector and gets
@@ -126,6 +128,19 @@ class TestEveryBootableProfile(unittest.TestCase):
         hh = self._check('mmx')
         selector = hh.mmu.mmu_unit(0).selector
         self.assertEqual(selector.servo_gate_angles, [60, 0, 180, 120])
+
+    def test_kms(self):
+        """KMS defaults keep its per-gate exits active for runtime sensorless experiments."""
+        hh = self._check('kms')
+        unit = hh.mmu.mmu_unit(0)
+        self.assertEqual(unit.p.gate_homing_endstop, 'mmu_exit')
+        self.assertEqual(unit.p.gate_preload_endstop, 'mmu_exit')
+        for gate in range(4):
+            self.assertIsNotNone(hh.sensor('mmu_exit_%d' % gate))
+
+        hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=none')
+        self.assertEqual(unit.p.gate_preload_endstop, 'none')
+        self.assertEqual(hh.errors, [])
 
     def test_emu(self):
         self._check('emu')

--- a/test/test_mmu_selector.py
+++ b/test/test_mmu_selector.py
@@ -35,6 +35,7 @@ logging.getLogger().setLevel(logging.CRITICAL)
 FILAMENT_POS_UNLOADED = 0
 FILAMENT_POS_LOADED = 10
 FILAMENT_POS_UNKNOWN = -1
+GATE_UNKNOWN = -1
 TOOL_GATE_UNKNOWN = -1
 TIP_AT_GATE = -40.0             # past the entry switch: where a user's push leaves it
 
@@ -125,6 +126,21 @@ class TestLinearSelector(SelectorTestCase):
     """
 
     PROFILE = 'tradrack'
+
+    def test_selected_gate_can_use_sensorless_preload_without_crossload_capability(self):
+        unit = self.hh.mmu.mmu_unit(0)
+        self.assertFalse(unit.can_crossload, 'precondition: Tradrack cannot crossload')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_parking_distance=-10')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_homing_max=60')
+        self.hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=none')
+        self.hh.mmu.select_gate(1)
+        self.hh.place_filament(1, position=TIP_AT_GATE)
+
+        self.hh.run_gcode('MMU_PRELOAD GATE=1')
+
+        self.assertEqual(self.hh.mmu.gate_selected, 1)
+        self.assertEqual(self.hh.mmu.gate_status[1], GATE_UNKNOWN)
+        self.assertEqual(self.hh.errors, [])
 
     def test_homing_succeeds(self):
         """


### PR DESCRIPTION
## Summary

- allow `gate_preload_endstop: none` to perform one fixed forward preload move followed by the configured parking move
- force sensorless preload to one attempt and leave the gate status unknown because filament presence cannot be verified
- support runtime switching through `MMU_TEST_CONFIG` while preserving configured retry behavior when switching back to a normal endstop
- bypass preload NFC compound/clear/jog behavior only in sensorless mode
- leave all existing non-`none` preload paths unchanged

## Safety

For sensorless crossloading, the configured fixed distance must remain inside the target gate's independent filament path. Selector crossload capability alone does not prove that a shared hub or downstream filament path is clear.

## Testing

- full suite: 1,213 tests passed
- post-adjustment configuration, motion, and NFC validation suite: 160 tests passed
- focused NFC preload suite: 54 tests passed
- `git diff --check`
