### PR TITLE
Consolidate Kconfig definitions and expose buffer validation support

### DIFF
--- a/extras/mmu/unit/mmu_buffer.py
+++ b/extras/mmu/unit/mmu_buffer.py
@@ -112,6 +112,20 @@ class MmuBuffer:
         self.connected_units.append(mmu_unit)
 
 
+    def supports_validation(self):
+        """
+        Whether the proportional sensor can drive active validation probes (extruder collision
+        homing, load/unload validation, recovery grip checks). Probes displace the buffer away
+        from its spring rest position so require a rest state with headroom toward compression:
+          'tension' - preloaded at tension rail, best friction immunity
+          'neutral' - dual sprung, discrimination relies on spring force ramp
+        'compression' rests at the compression rail (vsensor pre-triggered, probes blind) and
+        'none' has no restoring force (reading reflects last motion, not column force), so both
+        are limited to sync-feedback control
+        """
+        return self.proportional_sensor is not None and self.buffer_spring_state in ('tension', 'neutral')
+
+
     def sync_tension_callback(self, eventtime, t_sensor_name, tension_state, runout_helper):
         """
         Button event handler for sync-feedback tension switch

--- a/installer/Kconfig.capabilities
+++ b/installer/Kconfig.capabilities
@@ -84,10 +84,6 @@ config MMU_HAS_EJECT_BUTTONS
 config MMU_HAS_BUFFER_MCU
   def_bool n
 
-# EMU design has a per-gate MCU and this controls the connection logic
-config MMU_HAS_PER_GATE_MCU
-  def_bool n
-
 # Some custom designs have some pre-packaged hardware configuration
 config PARAM_MISC_HARDWARE
   string
@@ -102,7 +98,9 @@ menu "Design attributes"
     It is unlikely that you want to change anything here so be careful.
 
   config MMU_HAS_PER_GATE_MCU
+    bool
     prompt "Design has per-gate MCU's" if PER_GATE_MCU
+    default n
     help
       If you are seeing this you must have enabled per-gate MCU support.
       This option allows you to turn it off so it won't appear again

--- a/installer/Kconfig.endstops
+++ b/installer/Kconfig.endstops
@@ -182,7 +182,7 @@ menu "Endstops and Bowden movement"
   comment "_Extruder homing"
 
   choice CHOICE_EXTRUDER_HOMING_ENDSTOP
-    prompt "Extruder homing endstop    "
+    prompt "Extruder homing endstop     "
     help
       It can be desirable to have an endstop defined near the toolhead.
       This can be "none" if toolhead sensor is available otherwise
@@ -255,7 +255,7 @@ menu "Endstops and Bowden movement"
 # -------------------------------------
 
   config PARAM_BOWDEN_LOAD_HOMING_BUFFER
-    float "Bowden load homing buffer  "
+    float "Bowden load homing buffer   "
     default 20
     help
       Distance to reduce fast bowden load to prevent collisions
@@ -267,7 +267,7 @@ menu "Endstops and Bowden movement"
     default 30
 
   config PARAM_EXTRUDER_COLLISION_HOMING_CURRENT
-    prompt "Collision homing current   "
+    prompt "Collision homing current    "
     depends on CHOICE_EXTRUDER_HOMING_ENDSTOP_ENCODER || CHOICE_EXTRUDER_HOMING_ENDSTOP_TOUCH
     help
       When using extruder collision homing method (encoder or mmu_gear_touch)
@@ -275,7 +275,7 @@ menu "Endstops and Bowden movement"
       the % current reduction.
 
   config PARAM_EXTRUDER_HOMING_MAX
-    float "Extruder homing max        "
+    float "Extruder homing max         "
     default 100
     help
       The maximum distance filament will travel attempting to home
@@ -292,7 +292,7 @@ menu "Endstops and Bowden movement"
         However the extruder homing can be forced by setting this option.
 
     config PARAM_TOOLHEAD_HOMING_MAX
-      float "Toolhead sensor homing max "
+      float "Toolhead sensor homing max  "
       depends on MMU_HAS_SENSOR_TOOLHEAD
       default 40
       help

--- a/installer/Kconfig.pins
+++ b/installer/Kconfig.pins
@@ -111,10 +111,7 @@ menu "Pins / TMC"
     string
   config PIN_SELECTOR_ENDSTOP
     string
-  config PIN_SELECTOR_SERVO
-    string
-
-  @repeat var=i min=0 max=11@
+  @repeat var=i min=4 max=11@
     config PIN_GATE_ENDSTOP_$(i)
       string
   @endrepeat@
@@ -175,11 +172,13 @@ menu "Pins / TMC"
     if INDEXED_SELECTOR
       @repeat var=i min=0 max=3@
         config PIN_GATE_ENDSTOP_$(i)
+          string
           prompt "Gate $(i) endstop pin" if PARAM_NUM_GATES > $(i)
       @endrepeat@
     endif
 
     config PIN_SELECTOR_SERVO
+      string
       prompt "Servo pin           " if MMU_HAS_SELECTOR_SERVO
   endmenu
 
@@ -190,17 +189,6 @@ menu "Pins / TMC"
   config HAS_ESPOOLER_ENABLE_PIN
     def_bool n
 
-  @repeat var=i min=0 max=11@
-    config PIN_ESPOOLER_EN_$(i)
-      string
-    config PIN_ESPOOLER_RWD_$(i)
-      string
-    config PIN_ESPOOLER_FWD_$(i)
-      string
-    config PIN_ESPOOLER_TRIG_$(i)
-      string
-  @endrepeat@
-
   menu "eSpooler pins"
     depends on MMU_HAS_ESPOOLER
 
@@ -208,12 +196,16 @@ menu "Pins / TMC"
       if PARAM_NUM_GATES > $(i)
         comment "_"
         config PIN_ESPOOLER_EN_$(i)
+          string
           prompt "eSpooler enable $(i) pin " if HAS_ESPOOLER_ENABLE_PIN
         config PIN_ESPOOLER_RWD_$(i)
+          string
           prompt "eSpooler rewind $(i) pin "
         config PIN_ESPOOLER_FWD_$(i)
+          string
           prompt "eSpooler forward $(i) pin"
         config PIN_ESPOOLER_TRIG_$(i)
+          string
           prompt "eSpooler trigger $(i) pin"
       endif
     @endrepeat@
@@ -223,16 +215,12 @@ menu "Pins / TMC"
 # Eject buttons
 # -------------------------------------
 
-  @repeat var=i min=0 max=11@
-    config PIN_EJECT_BUTTON_$(i)
-      string
-  @endrepeat@
-
   menu "Mmu eject buttons"
     depends on MMU_HAS_EJECT_BUTTONS
 
     @repeat var=i min=0 max=11@
       config PIN_EJECT_BUTTON_$(i)
+        string
         prompt "Eject button $(i) pin " if PARAM_NUM_GATES > $(i)
     @endrepeat@
   endmenu
@@ -240,15 +228,6 @@ menu "Pins / TMC"
 # -------------------------------------
 # Sync-Feedback Buffer
 # -------------------------------------
-
-  config PIN_BUFFER_TENSION
-    string
-  config PIN_BUFFER_COMPRESSION
-    string
-  config PIN_BUFFER_ANALOG
-    string
-  config PIN_BUFFER_NEOPIXEL
-    string
 
   @repeat var=i min=0 max=3@
     config PIN_BUFFER_SENSOR_$(i)
@@ -259,12 +238,16 @@ menu "Pins / TMC"
     depends on MMU_HAS_SYNC_FEEDBACK_BUFFER && !MMU_SHARED_SYNC_FEEDBACK_BUFFER
 
     config PIN_BUFFER_TENSION
+      string
       prompt "Sync feedback tension pin    " if MMU_HAS_SENSOR_BUFFER_TENSION
     config PIN_BUFFER_COMPRESSION
+      string
       prompt "Sync feedback compression pin" if MMU_HAS_SENSOR_BUFFER_COMPRESSION
     config PIN_BUFFER_ANALOG
+      string
       prompt "Proportional (analog) pin    " if MMU_HAS_SENSOR_BUFFER_PROPORTIONAL
     config PIN_BUFFER_NEOPIXEL
+      string
       prompt "Neopixel pin                 " if MMU_HAS_LEDS && !CUSTOM_LED_SETUP
   endmenu
 
@@ -272,16 +255,12 @@ menu "Pins / TMC"
 # Entry sensor
 # -------------------------------------
 
-  @repeat var=i min=0 max=11@
-    config PIN_ENTRY_SENSOR_$(i)
-      string
-  @endrepeat@
-
   menu "Mmu entry sensor pins"
     depends on MMU_HAS_SENSOR_ENTRY
 
     @repeat var=i min=0 max=11@
       config PIN_ENTRY_SENSOR_$(i)
+        string
         prompt "Entry sensor $(i) pin " if PARAM_NUM_GATES > $(i)
     @endrepeat@
   endmenu
@@ -290,16 +269,12 @@ menu "Pins / TMC"
 # Exit sensor
 # -------------------------------------
 
-  @repeat var=i min=0 max=11@
-    config PIN_EXIT_SENSOR_$(i)
-      string
-  @endrepeat@
-
   menu "Mmu exit sensor pins"
     depends on MMU_HAS_SENSOR_EXIT
 
     @repeat var=i min=0 max=11@
       config PIN_EXIT_SENSOR_$(i)
+        string
         prompt "Exit sensor $(i) pin " if PARAM_NUM_GATES > $(i)
     @endrepeat@
   endmenu
@@ -317,15 +292,10 @@ menu "Pins / TMC"
 
   config PIN_ENCODER
     string
-  config PIN_NEOPIXEL
-    string
-  config PIN_FAN
-    string
-
-  config PIN_ENCODER
     prompt "Encoder pin           " if MMU_HAS_ENCODER && !MMU_SHARED_ENCODER
 
   config PIN_NEOPIXEL
+    string
     prompt "Neopixel pin          " if MMU_HAS_LEDS && !MMU_HAS_PER_GATE_MCU && !CUSTOM_LED_SETUP
 
   menu "Neopixel per-gate pins" 
@@ -347,6 +317,7 @@ menu "Pins / TMC"
   endmenu
 
   config PIN_FAN
+    string
     prompt "Cooling fan           " if MMU_HAS_FANS && !MMU_HAS_PER_GATE_MCU
 
   menu "Fan per-gate pins" 


### PR DESCRIPTION
## Summary

- co-locate pin symbol types with their prompts while preserving board-specific defaults and hidden gate declarations
- consolidate MMU_HAS_PER_GATE_MCU into one typed, conditionally prompted definition
- add MmuBuffer.supports_validation() for proportional sensors with tension or neutral spring states

## Testing

- before/after Kconfig differential matrix: 8 scenarios matched for every symbol type, value, visibility, assignability, visible prompt, and written config value
- make UT=test_mmu_profiles.py test (34 tests)
- make UT=test_mmu_bootup.py test (36 tests)
- exercised supports_validation() through the EMU harness for tension, neutral, compression, none, and missing proportional sensor cases
- git diff --check