### PR TITLE
Add QIDI Box MMU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ manage the details from the first filament load to the last toolchange.
 Happy Hare supports most community-built MMU/AFC systems, including
 **Box Turtle**, **ERCF**, **EMU**, **Tradrack**, **BTT ViViD**, **Night Owl**,
 **Angry Beaver**, **3MS**, **3D Chameleon**, **QuattroBox**, **PicoMMU**,
-**MMX**, **KMS**, and custom designs. Its capability-based architecture gives
+**MMX**, **KMS**, **QIDI Box**, and custom designs. Its capability-based architecture gives
 selector machines and modular gear-per-gate systems native motor and sensor
 control, with room to grow into multi-unit and mixed-hardware printers.
 

--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -32,6 +32,7 @@
 #     MMX6
 #     VVD                BTT ViViD
 #     KMS                https://github.com/muzixiaoyang/KMS
+#     QIDI               QIDI Box
 #     EMU
 #     LowRider
 #     Prusa         3.0  Not yet supported - Comming soon
@@ -268,6 +269,7 @@ show_bypass                 : [[PARAM_HAS_BYPASS]]		# 1 = Force showing of bypas
 # Touch option for gear stepper provides the (experimental) automatic detection of the extruder entrance
 # (see 'extruder_homing_endstop; mmu_gear_touch' in mmu_parameters.cfg)
 #
+[% if PARAM_GEAR_TMC != "" %]
 [[ "[" ~ PARAM_GEAR_TMC ~ " mmu_stepper " ~ UNIT_NAME ~ "_gear]" ]]
 uart_pin                 : [[PIN_GEAR_UART]]
 [% if BOARD_TYPE_EASY_BRD %]
@@ -288,6 +290,8 @@ driver_SGTHRS            : 60		# 255 is most sensitive value, 0 is least sensiti
 #driver_SGTHRS            : 60		# 255 is most sensitive value, 0 is least sensitive
 [% endif %]
 
+[% endif %]
+
 [mmu_stepper [[UNIT_NAME]]_gear]
 step_pin                 : [[PIN_GEAR_STEP]]
 dir_pin                  : [[PIN_GEAR_DIR]]
@@ -298,7 +302,7 @@ microsteps               : [[PARAM_GEAR_MICROSTEPS]]		# Recommend 16. Increase o
 full_steps_per_rotation  : [[PARAM_GEAR_FULL_STEPS_PER_ROTATION]]		# 200 for 1.8 degree, 400 for 0.9 degree
 
 # Uncomment the two lines below to enable filament "touch" movement option with gear motor
-[% if PIN_GEAR_DIAG != "" %]
+[% if PARAM_GEAR_TMC != "" and PIN_GEAR_DIAG != "" %]
 extra_endstops: 
     mmu_gear_touch=[[PARAM_GEAR_TMC]]_[[UNIT_NAME]]_gear:virtual_endstop
 [% else %]
@@ -313,6 +317,7 @@ extra_endstops:
 #
 [% for i in range(1, PARAM_NUM_GATES|int) %]
 # Filament Drive Gear_[[i]] --------------------------
+[% if PARAM_GEAR_TMC != "" %]
 [[ "[" ~ PARAM_GEAR_TMC ~ " mmu_stepper " ~ UNIT_NAME ~ "_gear_" ~ i ~ "]" ]]
 uart_pin                 : [[ (PIN_GEAR_UART_|d)[i] ]]
 [% if PIN_GEAR_DIAG != "" and (PIN_GEAR_DIAG_|d)[i] != "" %]
@@ -320,11 +325,13 @@ diag_pin                 : [[ (PIN_GEAR_DIAG_|d)[i] ]]
 driver_SGTHRS            : 60
 [% endif %]
 
+[% endif %]
+
 [mmu_stepper [[UNIT_NAME]]_gear_[[i]]]
 step_pin                 : [[ (PIN_GEAR_STEP_|d)[i] ]]
 dir_pin                  : [[ (PIN_GEAR_DIR_|d)[i] ]]
 enable_pin               : [[ (PIN_GEAR_ENABLE_|d)[i] ]]
-[% if PIN_GEAR_DIAG != "" and (PIN_GEAR_DIAG_|d)[i] != "" %]
+[% if PARAM_GEAR_TMC != "" and PIN_GEAR_DIAG != "" and (PIN_GEAR_DIAG_|d)[i] != "" %]
 extra_endstops: 
     mmu_gear_touch=[[PARAM_GEAR_TMC]]_[[UNIT_NAME]]_gear_[[i]]:virtual_endstop
 [% endif %]

--- a/extras/mmu/mmu_constants.py
+++ b/extras/mmu/mmu_constants.py
@@ -36,6 +36,7 @@ VENDOR_VVD            = "VVD"
 VENDOR_KMS            = "KMS"
 VENDOR_EMU            = "EMU"
 VENDOR_LOW_RIDER      = "LowRider"
+VENDOR_QIDI           = "QIDI"
 VENDOR_OTHER          = "Other"
 
 UNIT_ALT_DISPLAY_NAMES = {
@@ -44,6 +45,7 @@ UNIT_ALT_DISPLAY_NAMES = {
     VENDOR_NIGHT_OWL:    "Night Owl",
     VENDOR_VVD:          "BTT ViViD",
     VENDOR_LOW_RIDER:    "Low Rider",
+    VENDOR_QIDI:         "QIDI Box",
 }
 
 VENDORS = [
@@ -63,6 +65,7 @@ VENDORS = [
     VENDOR_KMS,
     VENDOR_EMU,
     VENDOR_LOW_RIDER,
+    VENDOR_QIDI,
     VENDOR_OTHER,
 ]
 

--- a/extras/mmu/mmu_unit.py
+++ b/extras/mmu/mmu_unit.py
@@ -117,6 +117,7 @@ class MmuUnit:
             VENDOR_KMS:          replace(DEF_PROFILE, filament_always_gripped=True),
             VENDOR_EMU:          replace(DEF_PROFILE, variable_bowden_lengths=True, filament_always_gripped=True),
             VENDOR_LOW_RIDER:    replace(DEF_PROFILE, selector_type=SELECTOR_ROTARY),
+            VENDOR_QIDI:         replace(DEF_PROFILE, variable_rotation_distances=False, filament_always_gripped=True),
         }
 
         if self.mmu_vendor == VENDOR_PRUSA:
@@ -267,8 +268,10 @@ class MmuUnit:
                 logging.info("MMU: Loaded: [%s]" % base_tmc_section)
                 break
 
-        if gear_tmc is None:
+        if gear_tmc is None and self.mmu_vendor != VENDOR_QIDI:
             raise config.error("Gear stepper TMC configuration not found for %s on mmu_unit %s" % (gear_name, self.name))
+        if gear_tmc is None:
+            logging.info("MMU: No software-controlled TMC for %s on QIDI mmu_unit %s" % (gear_name, self.name))
 
         # If multiple gear steppers share all possible attributes (saves repeated configuration)
         if self.multigear:

--- a/installer/Kconfig.pins
+++ b/installer/Kconfig.pins
@@ -35,6 +35,12 @@ menu "Pins / TMC"
       bool "TMC5160"
     config CHOICE_GEAR_TMC2240
       bool "TMC2240"
+    config CHOICE_GEAR_TMC_NONE
+      bool "None / hardware controlled"
+      depends on MMU_TYPE_QIDI_BOX_1_0
+      help
+        Select this when the stepper driver current and mode are configured
+        in hardware and Klipper only controls step, direction and enable.
   endchoice
 
   config PARAM_GEAR_TMC
@@ -45,6 +51,7 @@ menu "Pins / TMC"
     default "tmc2660" if CHOICE_GEAR_TMC2660
     default "tmc5160" if CHOICE_GEAR_TMC5160
     default "tmc2240" if CHOICE_GEAR_TMC2240
+    default ""        if CHOICE_GEAR_TMC_NONE
 
 # -------------------------------------
 # Gear stepper
@@ -52,7 +59,7 @@ menu "Pins / TMC"
 
   menu "Gear pins"
     config PIN_GEAR_UART
-      string "Gear UART pin    "
+      string "Gear UART pin    " if !CHOICE_GEAR_TMC_NONE
     config PIN_GEAR_STEP
       string "Gear step pin    "
     config PIN_GEAR_DIR
@@ -60,7 +67,7 @@ menu "Pins / TMC"
     config PIN_GEAR_ENABLE
       string "Gear enable pin  "
     config PIN_GEAR_DIAG
-      string "Gear diag pin    "
+      string "Gear diag pin    " if !CHOICE_GEAR_TMC_NONE
 
     @repeat var=i min=1 max=11@
       config PIN_GEAR_UART_$(i)
@@ -80,7 +87,7 @@ menu "Pins / TMC"
         if PARAM_NUM_GATES > $(i)
           comment "_"
           config PIN_GEAR_UART_$(i)
-            prompt "Gear $(i) UART pin  "
+            prompt "Gear $(i) UART pin  " if !CHOICE_GEAR_TMC_NONE
           config PIN_GEAR_STEP_$(i)
             prompt "Gear $(i) step pin  "
           config PIN_GEAR_DIR_$(i)
@@ -88,7 +95,7 @@ menu "Pins / TMC"
           config PIN_GEAR_ENABLE_$(i)
             prompt "Gear $(i) enable pin"
           config PIN_GEAR_DIAG_$(i)
-            prompt "Gear $(i) diag pin  "
+            prompt "Gear $(i) diag pin  " if !CHOICE_GEAR_TMC_NONE
         endif
       @endrepeat@
     endif

--- a/installer/boards/Kconfig
+++ b/installer/boards/Kconfig
@@ -19,7 +19,7 @@ choice BOARD_TYPE
     the default pin layout for your setup. After selecting board
     pins can be customized in Advanced Settings.
 
-  if !MMU_TYPE_KMS_1_0 && !MMU_TYPE_VVD_1_0 && !MMU_HAS_PER_GATE_MCU
+  if !MMU_TYPE_KMS_1_0 && !MMU_TYPE_VVD_1_0 && !MMU_TYPE_QIDI_BOX_1_0 && !MMU_HAS_PER_GATE_MCU
     rsource "Kconfig.*"
   endif
 
@@ -38,8 +38,13 @@ choice BOARD_TYPE
     rsource "custom/Kconfig.vvd"
   endif
 
+  # QIDI Box has a fixed custom mcu
+  if MMU_TYPE_QIDI_BOX_1_0
+    rsource "custom/Kconfig.qidi_box"
+  endif
+
   # Offer other where it makes sense as last option
-  if !MMU_TYPE_KMS_1_0 && !MMU_TYPE_VVD_1_0
+  if !MMU_TYPE_KMS_1_0 && !MMU_TYPE_VVD_1_0 && !MMU_TYPE_QIDI_BOX_1_0
     config BOARD_TYPE_OTHER
       bool "Not listed / Other"
 

--- a/installer/boards/custom/Kconfig.qidi_box
+++ b/installer/boards/custom/Kconfig.qidi_box
@@ -1,0 +1,72 @@
+config BOARD_TYPE_QIDI_BOX_2_0
+  bool "QIDI Box v2 MCU"
+  help
+    Stock QIDI Box controller based on an STM32F401xC and connected over
+    USB serial. When building mainline Klipper firmware, select the
+    STM32F401xC and the 32KiB bootloader/0x8000 flash offset
+    (CONFIG_STM32_FLASH_START_8000).
+
+if BOARD_TYPE_QIDI_BOX_2_0
+  config PARAM_BOARD_TYPE
+    default "QIDI Box v2 (STM32F401xC)"
+
+  choice CHOICE_MMU_CONNECTION_TYPE
+    default CHOICE_MMU_CONNECTION_TYPE_SERIAL
+  endchoice
+  choice CHOICE_MMU_SERIAL_CONNECTION
+    # Stock firmware: usb-Klipper_QIDI_BOX_V2_*
+    default $(mmu_serial_config,1,QIDI_BOX) if $(serial_exists,1,QIDI_BOX)
+    # Mainline firmware: usb-Klipper_stm32f401xc_*
+    default $(mmu_serial_config,1,stm32f401xc) if $(serial_exists,1,stm32f401xc)
+    default $(mmu_serial_config,1,stm32)
+  endchoice
+
+  # The stock drivers expose only step, direction and enable. Motor current
+  # is configured in hardware; there are no UART or DIAG connections.
+  config PIN_GEAR_STEP
+    default "$(MCU_NAME):PC14"
+  config PIN_GEAR_DIR
+    default "$(MCU_NAME):PC13"
+  config PIN_GEAR_ENABLE
+    default "!$(MCU_NAME):PC15"
+
+  config PIN_GEAR_STEP_1
+    default "$(MCU_NAME):PB9"
+  config PIN_GEAR_DIR_1
+    default "$(MCU_NAME):PB8"
+  config PIN_GEAR_ENABLE_1
+    default "!$(MCU_NAME):PC0"
+
+  config PIN_GEAR_STEP_2
+    default "$(MCU_NAME):PC12"
+  config PIN_GEAR_DIR_2
+    default "$(MCU_NAME):PC11"
+  config PIN_GEAR_ENABLE_2
+    default "!$(MCU_NAME):PD2"
+
+  config PIN_GEAR_STEP_3
+    default "$(MCU_NAME):PC8"
+  config PIN_GEAR_DIR_3
+    default "$(MCU_NAME):PB2"
+  config PIN_GEAR_ENABLE_3
+    default "!$(MCU_NAME):PC10"
+
+  config PIN_ENTRY_SENSOR_0
+    default "!$(MCU_NAME):PA0"
+  config PIN_ENTRY_SENSOR_1
+    default "!$(MCU_NAME):PB3"
+  config PIN_ENTRY_SENSOR_2
+    default "!$(MCU_NAME):PA13"
+  config PIN_ENTRY_SENSOR_3
+    default "!$(MCU_NAME):PA7"
+
+  config PIN_SHARED_EXIT_SENSOR
+    default "^!$(MCU_NAME):PB1"
+  config PIN_BUFFER_TENSION
+    default "^$(MCU_NAME):PB0"
+
+  # The filament switch is on the printer's THR head MCU, not this board.
+  config PIN_EXTRUDER_SENSOR
+    default "!THR:PA1"
+
+endif

--- a/installer/mmu_types/Kconfig.qidi_box
+++ b/installer/mmu_types/Kconfig.qidi_box
@@ -1,0 +1,113 @@
+config MMU_TYPE_QIDI_BOX_1_0
+  bool "QIDI Box"
+  help
+    QIDI Box is a four-gate type-B MMU with one always-engaged gear
+    motor per gate, a shared hub sensor, pre-gate sensors, a tension
+    feedback buffer, and a built-in filament dryer. The stock stepper
+    drivers are configured in hardware rather than through TMC UART.
+  select VIRTUAL_SELECTOR
+  select MMU_HAS_SENSOR_ENTRY
+  select MMU_HAS_SENSOR_SHARED_EXIT
+  select MMU_HAS_SENSOR_EXTRUDER
+  select MMU_HAS_SYNC_FEEDBACK_BUFFER
+  select MMU_HAS_SENSOR_BUFFER_TENSION
+  select UNSELECT_MMU_HAS_SENSOR_BUFFER_COMPRESSION
+  select UNSELECT_MMU_HAS_SENSOR_BUFFER_PROPORTIONAL
+  select MMU_HAS_ENVIRONMENT_SENSOR
+  select MMU_HAS_HEATER
+  select PARAM_REQUIRE_BOWDEN_MOVE
+  select PARAM_FILAMENT_ALWAYS_GRIPPED
+  select UNSELECT_VARIABLE_BOWDEN_LENGTHS
+  select UNSELECT_VARIABLE_ROTATION_DISTANCES
+  select UNSELECT_HAS_BYPASS
+  select PARAM_SYNC_TO_EXTRUDER
+  select PARAM_SYNC_FORM_TIP
+  select PARAM_SYNC_PURGE
+  select DISABLE_NUM_GATES_OPTION
+
+if MMU_TYPE_QIDI_BOX_1_0
+
+  # These objects are supplied by the stock QIDI configuration. Happy Hare
+  # references them but must not generate duplicate sensor/heater sections.
+  config CUSTOM_ENVIRONMENT_SENSOR_SETUP
+    def_bool y
+  config CUSTOM_HEATER_SETUP
+    def_bool y
+
+  config PARAM_ENVIRONMENT_SENSOR
+    string "Existing environment sensor"
+    default "box1_env"
+    help
+      Name of the existing temperature_sensor object for the QIDI Box.
+
+  config PARAM_FILAMENT_HEATER
+    string "Existing filament heater"
+    default "box1_heater"
+    help
+      Name of the existing heater_generic object for the QIDI Box dryer.
+
+  choice CHOICE_BUFFER_SPRING_STATE
+    default CHOICE_BUFFER_SPRING_STATE_TENSION
+  endchoice
+
+  choice CHOICE_GEAR_TMC
+    default CHOICE_GEAR_TMC_NONE
+  endchoice
+
+  # There are no per-gate exit sensors. Use a short fixed preload move so a
+  # gate can be prepared without entering or claiming the shared hub path.
+  choice CHOICE_GATE_PRELOAD_ENDSTOP
+    default CHOICE_GATE_PRELOAD_ENDSTOP_NONE
+  endchoice
+
+  if SHOW_MMU_ADDITIONS_WITH_TYPE
+    source "Kconfig.mmu_additions"
+  endif
+
+  source "Kconfig.capabilities"
+
+  config PARAM_VENDOR
+    default "QIDI"
+  config PARAM_VERSION
+    default "1.0"
+  config PARAM_NUM_GATES
+    default 4
+  choice BOARD_TYPE
+    default BOARD_TYPE_QIDI_BOX_2_0
+  endchoice
+
+  config PARAM_GEAR_GEAR_RATIO
+    default "1:1"
+  config PARAM_GEAR_ROTATION_DISTANCE
+    default 13.6
+  config PARAM_GEAR_MICROSTEPS
+    default 16
+
+  config PARAM_GEAR_LOAD_SPEED
+    default 120
+  config PARAM_GEAR_SHORT_MOVE_SPEED
+    default 80
+  config PARAM_EXTRUDER_LOAD_SPEED
+    default 16
+  config PARAM_EXTRUDER_UNLOAD_SPEED
+    default 16
+
+  config PARAM_GATE_HOMING_MAX
+    default 1500
+  config PARAM_GATE_PRELOAD_HOMING_MAX
+    default 200
+  config PARAM_GATE_PARKING_DISTANCE
+    default -80
+  config PARAM_GATE_FINAL_EJECT_DISTANCE
+    default 1500
+
+  config PARAM_BUFFER_RANGE
+    default 8
+  config PARAM_BUFFER_MAXRANGE
+    default 12
+  config PARAM_SYNC_FEEDBACK_SPEED_MULTIPLIER
+    default 5
+
+  comment "_"
+
+endif

--- a/test/README.md
+++ b/test/README.md
@@ -248,7 +248,8 @@ the log away instead of repainting it. Useful meta-commands beyond `/help`:
 | `/clear` | as `/redraw`, but empty the log rather than repaint it |
 | `/scroll [N]`, `/s` | scroll back through the log (see below) |
 | `/sensor NAME on\|off\|enable\|disable` | `on/off` drives the switch through its real button callback; `enable/disable` flips `sensor_enabled` so Happy Hare treats it as **not fitted** |
-| `/place`, `/preload`, `/exhaust` | set the scene: filament at a gate, preloaded, or run out |
+| `/place`, `/remove`, `/preload`, `/exhaust` | set the scene: filament inserted, removed, preloaded, or run out |
+| `/reset` | rebuild the selected profile in the same state as a fresh simulator start |
 | `/log [N]`, `/trace 0-4` | the log file, and how much detail goes into it |
 | `/timestamp [on\|off]` | stamp MMU output with the virtual clock; **on by default** at a terminal |
 

--- a/test/README.md
+++ b/test/README.md
@@ -248,7 +248,7 @@ the log away instead of repainting it. Useful meta-commands beyond `/help`:
 | `/clear` | as `/redraw`, but empty the log rather than repaint it |
 | `/scroll [N]`, `/s` | scroll back through the log (see below) |
 | `/sensor NAME on\|off\|enable\|disable` | `on/off` drives the switch through its real button callback; `enable/disable` flips `sensor_enabled` so Happy Hare treats it as **not fitted** |
-| `/place`, `/remove`, `/preload`, `/exhaust` | set the scene: filament inserted, removed, preloaded, or run out |
+| `/place`, `/insert`, `/remove`, `/preload`, `/exhaust` | quietly place filament, actively insert it, remove it, preload it, or run it out |
 | `/reset` | rebuild the selected profile in the same state as a fresh simulator start |
 | `/log [N]`, `/trace 0-4` | the log file, and how much detail goes into it |
 | `/timestamp [on\|off]` | stamp MMU output with the virtual clock; **on by default** at a terminal |

--- a/test/console.py
+++ b/test/console.py
@@ -788,7 +788,6 @@ class Console:
     def run_command(self, line):
         mark = len(self.sink)
         unhandled_mark = len(self.hh.gcode.unhandled)
-        self._seed_filament_for_preload(line)
         gate_status_before = None
         is_eject = bool(re.match(r'^\s*MMU_EJECT(?:\s|$)', line, re.I))
         if is_eject or (re.match(r'^\s*MMU_GATE_MAP(?:\s|$)', line, re.I)
@@ -826,18 +825,6 @@ class Console:
         self.streaming = False
         self._warn_unhandled(line, unhandled_mark)
         self._warn_silent_macro(line, mark)
-
-    def _seed_filament_for_preload(self, line):
-        """Model the user's insertion before an interactive raw MMU_PRELOAD."""
-        if not re.match(r'^\s*MMU_PRELOAD(?:\s|$)', line, re.I):
-            return
-        match = re.search(r'(?:^|\s)GATE\s*=\s*(-?\d+)', line, re.I)
-        gate = int(match.group(1)) if match else self.hh.mmu.gate_selected
-        if not 0 <= gate < self.hh.mmu.num_gates:
-            return
-        entry = self.hh.mmu.sensor_manager.check_gate_sensor('mmu_entry', gate)
-        if entry is False and self.hh.mmu.gate_maps.gate_status[gate] == GATE_EMPTY:
-            self.hh.place_filament(gate, position=TIP_AT_GATE)
 
     def _sync_filament_to_gate_map(self, before):
         """Make explicit MMU_GATE_MAP availability changes physical in the simulator."""

--- a/test/console.py
+++ b/test/console.py
@@ -1345,6 +1345,7 @@ class Console:
         ('/sensor NAME on|off|enable|disable',
          'on/off drives the switch; enable/disable makes HH ignore it entirely'),
         ('/place GATE [POS]', 'put a filament tip at POS mm (default %g)' % TIP_AT_GATE),
+        ('/insert GATE [POS]', 'place filament and fire its entry-sensor callback'),
         ('/remove GATE', 'remove that gate\'s filament and clear its path sensors'),
         ('/preload GATE', 'place then MMU_PRELOAD that gate'),
         ('/exhaust GATE', 'give the filament a finite tail - this is what a runout IS'),
@@ -1663,6 +1664,18 @@ class Console:
         gate = int(args[0])
         pos = float(args[1]) if len(args) > 1 else TIP_AT_GATE
         self.hh.place_filament(gate, position=pos)
+
+    def _meta_insert(self, args):
+        if not 1 <= len(args) <= 2:
+            raise ValueError('usage: /insert GATE [POS]')
+        gate = int(args[0])
+        if not 0 <= gate < self.hh.mmu.num_gates:
+            raise ValueError('gate must be between 0 and %d' % (self.hh.mmu.num_gates - 1))
+        pos = float(args[1]) if len(args) > 1 else TIP_AT_GATE
+        mark = len(self.sink)
+        self.hh.place_filament(gate, position=pos, quiet=False)
+        self._settle_moonraker()
+        self._drain(mark)
 
     def _meta_remove(self, args):
         if len(args) != 1:

--- a/test/console.py
+++ b/test/console.py
@@ -788,6 +788,7 @@ class Console:
     def run_command(self, line):
         mark = len(self.sink)
         unhandled_mark = len(self.hh.gcode.unhandled)
+        self._seed_filament_for_preload(line)
         gate_status_before = None
         is_eject = bool(re.match(r'^\s*MMU_EJECT(?:\s|$)', line, re.I))
         if is_eject or (re.match(r'^\s*MMU_GATE_MAP(?:\s|$)', line, re.I)
@@ -825,6 +826,18 @@ class Console:
         self.streaming = False
         self._warn_unhandled(line, unhandled_mark)
         self._warn_silent_macro(line, mark)
+
+    def _seed_filament_for_preload(self, line):
+        """Model the user's insertion before an interactive raw MMU_PRELOAD."""
+        if not re.match(r'^\s*MMU_PRELOAD(?:\s|$)', line, re.I):
+            return
+        match = re.search(r'(?:^|\s)GATE\s*=\s*(-?\d+)', line, re.I)
+        gate = int(match.group(1)) if match else self.hh.mmu.gate_selected
+        if not 0 <= gate < self.hh.mmu.num_gates:
+            return
+        entry = self.hh.mmu.sensor_manager.check_gate_sensor('mmu_entry', gate)
+        if entry is False and self.hh.mmu.gate_maps.gate_status[gate] == GATE_EMPTY:
+            self.hh.place_filament(gate, position=TIP_AT_GATE)
 
     def _sync_filament_to_gate_map(self, before):
         """Make explicit MMU_GATE_MAP availability changes physical in the simulator."""

--- a/test/console.py
+++ b/test/console.py
@@ -1345,6 +1345,7 @@ class Console:
         ('/sensor NAME on|off|enable|disable',
          'on/off drives the switch; enable/disable makes HH ignore it entirely'),
         ('/place GATE [POS]', 'put a filament tip at POS mm (default %g)' % TIP_AT_GATE),
+        ('/remove GATE', 'remove that gate\'s filament and clear its path sensors'),
         ('/preload GATE', 'place then MMU_PRELOAD that gate'),
         ('/exhaust GATE', 'give the filament a finite tail - this is what a runout IS'),
         ('/filament', 'per-gate tip/tail description'),
@@ -1361,6 +1362,7 @@ class Console:
         ('/header [GROUPS]', 'set header groups: %s, or "all"/"off"' % ','.join(GROUPS)),
         ('/log [N]', 'path to mmu.log and its last N lines (default 20)'),
         ('/errors', 'every !! message this session'),
+        ('/reset', 'rebuild the simulator in this profile\'s startup state'),
         ('/help', 'this list'),
         ('/quit', 'exit (also Ctrl-D)'),
     )
@@ -1429,6 +1431,21 @@ class Console:
         if self.scrollback is not None:
             self.scrollback.clear()
         self.clear_log()
+
+    def _meta_reset(self, args):
+        """Discard all simulated machine state and boot the selected profile afresh."""
+        if args:
+            raise ValueError('usage: /reset')
+        self.close()
+        self.fil = None
+        self.startup_output = []
+        self.clock_epoch = None
+        self.failures = 0
+        self._clear_sink()
+        if self.scrollback is not None:
+            self.scrollback.clear()
+        self.boot()
+        self.info('simulator reset to %s startup state' % self.args.profile)
 
     def _meta_redraw(self, args):
         """Repaint everything, log included. /clear is the same thing minus the history."""
@@ -1646,6 +1663,19 @@ class Console:
         gate = int(args[0])
         pos = float(args[1]) if len(args) > 1 else TIP_AT_GATE
         self.hh.place_filament(gate, position=pos)
+
+    def _meta_remove(self, args):
+        if len(args) != 1:
+            raise ValueError('usage: /remove GATE')
+        gate = int(args[0])
+        if not 0 <= gate < self.hh.mmu.num_gates:
+            raise ValueError('gate must be between 0 and %d' % (self.hh.mmu.num_gates - 1))
+        with self.hh.quiet_sensors():
+            # A later /place represents a newly inserted spool-backed strand, even if this
+            # gate had previously been /exhaust'ed into a finite runout tail.
+            self.fil.refill(gate, sync=False)
+            self.fil.remove(gate)
+        self.hh.reactor.advance(0.)
 
     def _meta_preload(self, args):
         gate = int(args[0])

--- a/test/console.py
+++ b/test/console.py
@@ -621,7 +621,8 @@ class Console:
 
     def _refresh_startup_filament_row(self):
         """Make the cached boot banner describe the post-preload simulator state."""
-        current = self.hh.mmu.get_filament_position_string()
+        current, _plain = self.hh.mmu.logger._color_message(
+            self.hh.mmu.get_filament_position_string())
         refreshed = []
         for message in self.startup_output:
             lines = message.split('\n')

--- a/test/console.py
+++ b/test/console.py
@@ -566,6 +566,7 @@ class Console:
         # machine, so this costs the older profiles nothing.
         if preloading:
             self._preload_all()
+            self._refresh_startup_filament_row()
 
         # A live fake Moonraker + Spoolman, seeded to agree with the primed gate map. Without
         # it every call Happy Hare makes to Moonraker goes into the void, so an NFC read ends
@@ -617,6 +618,16 @@ class Console:
             self._dispatch('MMU_SELECT GATE=%d' % selected)
             self.hh.reactor.advance(0.)
         self._clear_sink()  # setup noise is not console history
+
+    def _refresh_startup_filament_row(self):
+        """Make the cached boot banner describe the post-preload simulator state."""
+        current = self.hh.mmu.get_filament_position_string()
+        refreshed = []
+        for message in self.startup_output:
+            lines = message.split('\n')
+            lines = [current if line.startswith('[T') else line for line in lines]
+            refreshed.append('\n'.join(lines))
+        self.startup_output = refreshed
 
     def close(self):
         if self.hh is not None:

--- a/test/console.py
+++ b/test/console.py
@@ -789,13 +789,18 @@ class Console:
         mark = len(self.sink)
         unhandled_mark = len(self.hh.gcode.unhandled)
         gate_status_before = None
-        if (re.match(r'^\s*MMU_GATE_MAP(?:\s|$)', line, re.I)
-                and re.search(r'(?:^|\s)AVAILABLE\s*=', line, re.I)):
+        is_eject = bool(re.match(r'^\s*MMU_EJECT(?:\s|$)', line, re.I))
+        if is_eject or (re.match(r'^\s*MMU_GATE_MAP(?:\s|$)', line, re.I)
+                        and re.search(r'(?:^|\s)AVAILABLE\s*=', line, re.I)):
             gate_status_before = list(self.hh.mmu.gate_maps.gate_status)
         # Stream Happy Hare's output as it happens rather than after the command returns.
         # Scoped to here, not global: _dispatch() is also the raw path for setup and for the
         # tests, and both need it silent.
-        self.streaming = True
+        # MMU_EJECT's final row is produced immediately after HH marks the gate
+        # empty, but before the harness mirrors that map transition into its
+        # physical filament model. Buffer this one command so the final row can
+        # be refreshed after that synchronization; other commands still stream.
+        self.streaming = not is_eject
         try:
             self._dispatch(line)
         except Exception as exc:                    # noqa: BLE001
@@ -804,8 +809,11 @@ class Console:
             # parameter would end the session.
             print(paint('!! %s' % exc, '1;31', self.color))
             self.failures += 1
+        physical_changed = False
         if gate_status_before is not None:
-            self._sync_filament_to_gate_map(gate_status_before)
+            physical_changed = self._sync_filament_to_gate_map(gate_status_before)
+        if is_eject and physical_changed:
+            self._refresh_latest_filament_row(mark)
         # Settle whatever the command armed. Re-run unconditionally: a failed advance
         # skips its clock assignment, so this also repairs a mid-flight clock.
         try:
@@ -821,10 +829,12 @@ class Console:
     def _sync_filament_to_gate_map(self, before):
         """Make explicit MMU_GATE_MAP availability changes physical in the simulator."""
         after = self.hh.mmu.gate_maps.gate_status
+        changed = False
         with self.hh.quiet_sensors():
             for gate, (old, new) in enumerate(zip(before, after)):
                 if old == new:
                     continue
+                changed = True
                 if new == GATE_EMPTY:
                     self.fil.remove(gate)
                 elif new in (GATE_AVAILABLE, GATE_AVAILABLE_FROM_BUFFER):
@@ -833,6 +843,19 @@ class Console:
                     self.fil.refill(gate, sync=False)
                     self.fil.park(gate)
                 # GATE_UNKNOWN describes knowledge, not a physical state: preserve it.
+        return changed
+
+    def _refresh_latest_filament_row(self, mark):
+        """Replace the final buffered visual row after simulator state catches up."""
+        current, _plain = self.hh.mmu.logger._color_message(
+            self.hh.mmu.get_filament_position_string())
+        for index in range(len(self.sink) - 1, mark - 1, -1):
+            lines = self.sink[index].split('\n')
+            for line_index in range(len(lines) - 1, -1, -1):
+                if lines[line_index].startswith('[T'):
+                    lines[line_index] = current
+                    self.sink[index] = '\n'.join(lines)
+                    return
 
     def _home_before_bootup(self):
         """

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -31,6 +31,11 @@ PRINTER_STUB = """
 [mcu]
 serial: /dev/null
 
+# QIDI's filament switch is connected to its separate THR toolhead MCU. This
+# harmless external-MCU stub lets the qidi console profile resolve !THR:PA1.
+[mcu THR]
+serial: /dev/null
+
 [printer]
 kinematics: none
 max_velocity: 300
@@ -78,6 +83,18 @@ run_current: 0.5
 [neopixel cabinet_leds]
 pin: mcu:PA10
 chain_count: 12
+
+# External stock-QIDI dryer objects. Happy Hare references these by name but
+# deliberately does not generate them because their hardware setup belongs to
+# the printer configuration. The harness implementations need only the object
+# names and temperature limits.
+[temperature_sensor box1_env]
+min_temp: -20
+max_temp: 100
+
+[heater_generic box1_heater]
+min_temp: 0
+max_temp: 80
 """
 
 

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -434,7 +434,11 @@ class Session:
                 return 'extruder'
             return 'synced'
 
-        model = FilamentPath(self.mmu.num_gates, layout=layout)
+        # Profiles may refine the generic BoxTurtle-like geometry. An explicit
+        # call-site layout wins over those profile defaults one landmark at a time.
+        model_layout = dict(getattr(self.profile, 'filament_layout', {}) or {})
+        model_layout.update(layout or {})
+        model = FilamentPath(self.mmu.num_gates, layout=model_layout)
         model.configure_buffers(
             self.mmu.mmu_machine.units,
             selected_gate=lambda: self.mmu.gate_selected,

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -361,7 +361,16 @@ KMS = Profile(
 # are supplied by the harness's external-object stub.
 QIDI = Profile(
     'qidi',
-    syms={'MMU_TYPE_QIDI_BOX_1_0': True},
+    syms={
+        'MMU_TYPE_QIDI_BOX_1_0': True,
+        # Simulator-only: the console seeds each gate 110 mm downstream of
+        # entry (-40 vs -150). A 200 mm fixed preload from there would put
+        # every startup filament across the shared hub switch, even though a
+        # real QIDI has substantially more entry-to-hub travel. Keep the
+        # production Kconfig default at 200 mm; 100 mm is enough to exercise
+        # fixed/crossload preload without occupying the simulated hub.
+        'PARAM_GATE_PRELOAD_HOMING_MAX': 100,
+    },
     description='QIDI Box 1.0 - 4 gates, fixed QIDI v2 MCU and THR sensor',
     # The generic harness layout has only 160 mm between entry and shared exit,
     # which makes QIDI's 200 mm fixed preload unrealistically cross the hub switch.

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -348,6 +348,15 @@ KMS = Profile(
           'TOOLHEAD_TYPE_JABBERWOCKY': True},
     description='KMS 1.0 defaults - 4 gates, exit sensors, Jabberwocky toolhead')
 
+# QIDI Box: fixed STM32F401xC controller, four hardware-current-controlled gear
+# drivers, shared hub endstop, tension feedback, and an extruder-entry sensor on
+# the separate THR toolhead MCU. The stock dryer objects live in printer.cfg and
+# are supplied by the harness's external-object stub.
+QIDI = Profile(
+    'qidi',
+    syms={'MMU_TYPE_QIDI_BOX_1_0': True},
+    description='QIDI Box 1.0 - 4 gates, fixed QIDI v2 MCU and THR sensor')
+
 # EMU: 5 gates, and the only shipped profile that brings a PROPORTIONAL (analog) buffer
 # sensor with it. That makes it the profile that exercises MmuAdcHelper's ADC compat shim
 # for real, and the virtual compression/tension sensors derived from an analog reading
@@ -578,7 +587,7 @@ run_current: 0.6
 # also the startup picker's source, so its list and the accepted profile objects stay one
 # thing. The buffered and dual-extruder ERCF variants below are registered for tests but are
 # deliberately absent: one is synthetic and the other needs EXTRA_EXTRUDER_STUB.
-CONSOLE_PROFILES = (ERCF_VVD, BOXTURTLE, TRADRACK, CHAMELEON, PICO_MMU, MMX, KMS, EMU, ENCODER,
+CONSOLE_PROFILES = (ERCF_VVD, BOXTURTLE, TRADRACK, CHAMELEON, PICO_MMU, MMX, KMS, QIDI, EMU, ENCODER,
                     NFC_SINGLE, NFC_PER_GATE, NFC_NEIGHBOR_CHECK, NFC_NEIGHBOR_EVICT,
                     NFC_GATE_CLEAR,
                     NFC_PN5180, NFC_PN5180_PER_GATE, NFC_PN532, NFC_PN532_SW_I2C,

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -116,8 +116,29 @@ def clone_across_units(name, base, unit_names, description=''):
 # selectors now home and move filament too - see test_mmu_selector.py.
 BOXTURTLE = Profile(
     'boxturtle',
-    syms={'MMU_TYPE_BOX_TURTLE_1_0': True},
-    description='BoxTurtle 1.0 - Type B, VirtualSelector, 4 gates, multigear')
+    syms={
+        'MMU_TYPE_BOX_TURTLE_1_0': True,
+        # Match the physical BoxTurtle split explicitly in the simulator:
+        # normal loading homes at the shared hub, while crossload/preload uses
+        # the independent per-gate exit sensor.
+        'CHOICE_GATE_HOMING_ENDSTOP_SHARED_EXIT': True,
+        'CHOICE_GATE_PRELOAD_ENDSTOP_EXIT': True,
+        'PARAM_GATE_PRELOAD_PARKING_DISTANCE': 10,
+        # Keep optional NFC fixtures neutral/safe unless their derived profile
+        # explicitly enables neighbor or self-jog behavior. These are harness
+        # controls, not changes to the BoxTurtle installer defaults.
+        'PARAM_NFC_GATE_JOG_SCAN_WINDOW': '-50, 480',
+        'PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW': '0, 480',
+        'PARAM_NFC_NEIGHBOR_CHECK': False,
+        'PARAM_NFC_GATE_CLEAR_DISTANCE': 0,
+        'PARAM_NFC_PRELOAD_CLEAR_DISTANCE': 0,
+    },
+    description='BoxTurtle 1.0 - Type B, VirtualSelector, 4 gates, multigear',
+    # The per-gate exit is just past each drive, while the shared exit is at
+    # the downstream hub. BoxTurtle parks 10 mm beyond the former when
+    # preloading and 100 mm before the latter after normal gate homing, so the
+    # two sensors cannot occupy the generic harness's former 10 mm spacing.
+    filament_layout={'mmu_shared_exit': 100.0})
 
 # BoxTurtle + one COMMON NFC reader serving all gates and the bypass (RC522 over SPI).
 #

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -136,9 +136,10 @@ BOXTURTLE = Profile(
     description='BoxTurtle 1.0 - Type B, VirtualSelector, 4 gates, multigear',
     # The per-gate exit is just past each drive, while the shared exit is at
     # the downstream hub. BoxTurtle parks 10 mm beyond the former when
-    # preloading and 100 mm before the latter after normal gate homing, so the
-    # two sensors cannot occupy the generic harness's former 10 mm spacing.
-    filament_layout={'mmu_shared_exit': 100.0})
+    # preloading and 100 mm before the latter after normal gate homing. Leave
+    # 150 mm between them so that retraction parks 50 mm beyond the per-gate
+    # exit instead of landing on (and numerically just behind) that switch.
+    filament_layout={'mmu_shared_exit': 150.0})
 
 # BoxTurtle + one COMMON NFC reader serving all gates and the bypass (RC522 over SPI).
 #

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -55,22 +55,29 @@ class Profile:
     units:        list of UnitProfile, or None/empty for a single-unit machine.
                   Supplying it is what selects cfg.py's multi-unit render path;
                   every profile below except ERCF_VVD is the one-unit case.
+    filament_layout: optional simulator-only overrides for physical sensor positions.
+                  This never affects rendered printer configuration.
     """
 
-    def __init__(self, name, syms=None, extra_params=None, description='', units=None):
+    def __init__(self, name, syms=None, extra_params=None, description='', units=None,
+                 filament_layout=None):
         self.name = name
         self.syms = dict(syms or {})
         self.extra_params = dict(extra_params or {})
         self.description = description
         self.units = list(units or [])
+        self.filament_layout = dict(filament_layout or {})
 
-    def derive(self, name, syms=None, extra_params=None, description='', units=None):
+    def derive(self, name, syms=None, extra_params=None, description='', units=None,
+               filament_layout=None):
         merged_syms = dict(self.syms)
         merged_syms.update(syms or {})
         merged_params = dict(self.extra_params)
         merged_params.update(extra_params or {})
-        return Profile(name, merged_syms, merged_params, description or self.description,
-                       units if units is not None else self.units)
+        return Profile(
+            name, merged_syms, merged_params, description or self.description,
+            units if units is not None else self.units,
+            self.filament_layout if filament_layout is None else filament_layout)
 
     def __repr__(self):
         return 'Profile(%r)' % (self.name,)
@@ -355,7 +362,17 @@ KMS = Profile(
 QIDI = Profile(
     'qidi',
     syms={'MMU_TYPE_QIDI_BOX_1_0': True},
-    description='QIDI Box 1.0 - 4 gates, fixed QIDI v2 MCU and THR sensor')
+    description='QIDI Box 1.0 - 4 gates, fixed QIDI v2 MCU and THR sensor',
+    # The generic harness layout has only 160 mm between entry and shared exit,
+    # which makes QIDI's 200 mm fixed preload unrealistically cross the hub switch.
+    # Model the reported few-hundred-mm internal leg and ~750 mm hub-to-extruder leg.
+    filament_layout={
+        'mmu_shared_exit': 150.0,
+        'extruder_entry': 900.0,
+        'extruder': 900.0,
+        'toolhead': 940.0,
+        'filament_compression': 900.0,
+    })
 
 # EMU: 5 gates, and the only shipped profile that brings a PROPORTIONAL (analog) buffer
 # sensor with it. That makes it the profile that exercises MmuAdcHelper's ADC compat shim

--- a/test/installer/test_qidi_box.py
+++ b/test/installer/test_qidi_box.py
@@ -1,0 +1,134 @@
+# QIDI Box Kconfig profile and rendering tests.
+
+import re
+import unittest
+
+from test.hh import cfg, profiles
+
+
+class TestQidiBoxProfile(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.profile = profiles.Profile(
+            "qidi_box",
+            syms={"MMU_TYPE_QIDI_BOX_1_0": True},
+        )
+        with cfg._env(cfg._SINGLE_UNIT_ENV):
+            cls.kconfig = cfg._kconfig(cls.profile.name, cls.profile.syms)
+            cls.other_kconfig = cfg._kconfig(
+                "non-qidi-driver-check",
+                {"MMU_TYPE_BOX_TURTLE_1_0": True},
+            )
+        cls.rendered = cfg.render(cls.profile)
+
+    def test_machine_and_motion_defaults(self):
+        expected = {
+            "PARAM_VENDOR": "QIDI",
+            "PARAM_VERSION": "1.0",
+            "PARAM_NUM_GATES": "4",
+            "PARAM_BOARD_TYPE": "QIDI Box v2 (STM32F401xC)",
+            "PARAM_SELECTOR_TYPE": "VirtualSelector",
+            "PARAM_VARIABLE_BOWDEN_LENGTHS": "0",
+            "PARAM_VARIABLE_ROTATION_DISTANCES": "0",
+            "PARAM_REQUIRE_BOWDEN_MOVE": "1",
+            "PARAM_FILAMENT_ALWAYS_GRIPPED": "1",
+            "PARAM_HAS_BYPASS": "0",
+            "PARAM_GEAR_ROTATION_DISTANCE": "13.6",
+            "PARAM_GEAR_MICROSTEPS": "16",
+            "PARAM_GATE_HOMING_ENDSTOP": "mmu_shared_exit",
+            "PARAM_GATE_HOMING_MAX": "1500",
+            "PARAM_GATE_PRELOAD_ENDSTOP": "none",
+            "PARAM_GATE_PRELOAD_HOMING_MAX": "200",
+            "PARAM_GATE_PRELOAD_ATTEMPTS": "1",
+            "PARAM_GATE_PARKING_DISTANCE": "-80",
+            "PARAM_GATE_FINAL_EJECT_DISTANCE": "1500",
+            "PARAM_EXTRUDER_HOMING_ENDSTOP": "extruder",
+        }
+        for symbol, value in expected.items():
+            with self.subTest(symbol=symbol):
+                self.assertEqual(self.kconfig.get(symbol), value)
+
+        self.assertTrue(self.kconfig.is_enabled("BOARD_TYPE_QIDI_BOX_2_0"))
+        self.assertFalse(self.kconfig.is_enabled("BOARD_TYPE_OTHER"))
+
+    def test_stock_sensors_buffer_and_dryer_are_enabled(self):
+        for symbol in (
+            "MMU_HAS_SENSOR_ENTRY",
+            "MMU_HAS_SENSOR_SHARED_EXIT",
+            "MMU_HAS_SENSOR_EXTRUDER",
+            "MMU_HAS_SYNC_FEEDBACK_BUFFER",
+            "MMU_HAS_SENSOR_BUFFER_TENSION",
+            "MMU_HAS_ENVIRONMENT_SENSOR",
+            "MMU_HAS_HEATER",
+        ):
+            with self.subTest(symbol=symbol):
+                self.assertTrue(self.kconfig.is_enabled(symbol))
+        self.assertFalse(self.kconfig.is_enabled("MMU_HAS_SENSOR_EXIT"))
+
+        hardware = self.rendered["config/base/mmu_hardware.cfg"]
+        self.assertNotIn("mmu_exit_switch_pin_0", hardware)
+        self.assertIn("environment_sensor       : box1_env", hardware)
+        self.assertIn("filament_heater          : box1_heater", hardware)
+        self.assertNotIn("max_concurrent_heaters", hardware)
+        self.assertIn("buffer_range            : 8", hardware)
+        self.assertIn("buffer_maxrange         : 12", hardware)
+
+        parameters = self.rendered["config/base/mmu_parameters.cfg"]
+        self.assertIn("gate_preload_endstop          : none", parameters)
+        self.assertIn("gate_preload_homing_max       : 200", parameters)
+        self.assertIn("sync_feedback_enabled           : 1", parameters)
+        self.assertIn("sync_feedback_speed_multiplier  : 5", parameters)
+        self.assertIn("gear_load_speed             : 120", parameters)
+
+    def test_hardware_controlled_drivers_do_not_render_tmc_sections(self):
+        self.assertEqual(self.kconfig.get("PARAM_GEAR_TMC"), "")
+        self.assertEqual(self.other_kconfig.get("PARAM_GEAR_TMC"), "tmc2209")
+        self.assertFalse(self.other_kconfig.is_enabled("CHOICE_GEAR_TMC_NONE"))
+        self.assertFalse(self.other_kconfig.is_enabled("BOARD_TYPE_QIDI_BOX_2_0"))
+        hardware = self.rendered["config/base/mmu_hardware.cfg"]
+        self.assertIsNone(re.search(
+            r"^\[tmc\w+ mmu_stepper unit0_gear(?:_\d+)?\]$",
+            hardware,
+            re.MULTILINE,
+        ))
+        for suffix in ("", "_1", "_2", "_3"):
+            self.assertIn("[mmu_stepper unit0_gear%s]" % suffix, hardware)
+
+    def test_fixed_board_pinout(self):
+        hardware = self.rendered["config/base/mmu_hardware.cfg"]
+        for expected in (
+            "step_pin                 : unit0:PC14",
+            "dir_pin                  : unit0:PC13",
+            "enable_pin               : !unit0:PC15",
+            "step_pin                 : unit0:PB9",
+            "dir_pin                  : unit0:PB8",
+            "enable_pin               : !unit0:PC0",
+            "step_pin                 : unit0:PC12",
+            "dir_pin                  : unit0:PC11",
+            "enable_pin               : !unit0:PD2",
+            "step_pin                 : unit0:PC8",
+            "dir_pin                  : unit0:PB2",
+            "enable_pin               : !unit0:PC10",
+            "mmu_entry_switch_pin_0     : !unit0:PA0",
+            "mmu_entry_switch_pin_1     : !unit0:PB3",
+            "mmu_entry_switch_pin_2     : !unit0:PA13",
+            "mmu_entry_switch_pin_3     : !unit0:PA7",
+            "mmu_shared_exit_switch_pin : ^!unit0:PB1",
+            "tension_pin             : ^unit0:PB0",
+        ):
+            with self.subTest(config=expected):
+                self.assertIn(expected, hardware)
+
+        machine = self.rendered["config/base/mmu.cfg"]
+        self.assertIn("extruder_switch_pin         : !THR:PA1", machine)
+
+    def test_generic_qidi_q2_toolhead_dimensions_are_preserved(self):
+        machine = self.rendered["config/base/mmu.cfg"]
+        self.assertIn("toolhead_extruder_to_nozzle : 72", machine)
+        self.assertIn("toolhead_sensor_to_nozzle   : 62", machine)
+        self.assertIn("toolhead_entry_to_extruder  : 8", machine)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_mmu_config.py
+++ b/test/test_mmu_config.py
@@ -66,6 +66,15 @@ class TestBoxTurtleRender(unittest.TestCase):
 
     def test_parameters_and_macro_var_sections(self):
         self.assertIn('mmu_unit_parameters unit0', cfg.sections(self.rendered[PARAMS]))
+        parser = cfg.assemble(self.rendered)
+        params = dict(parser.items('mmu_unit_parameters unit0'))
+        self.assertEqual(params['gate_homing_endstop'], 'mmu_shared_exit')
+        self.assertEqual(params['gate_homing_max'], '300')
+        self.assertEqual(params['gate_parking_distance'], '-100')
+        self.assertEqual(params['gate_preload_endstop'], 'mmu_exit')
+        self.assertEqual(params['gate_preload_homing_max'], '200')
+        self.assertEqual(params['gate_preload_parking_distance'], '10')
+
         secs = cfg.sections(self.rendered[MACRO_VARS])
         # HH reads .variables off these at connect/ready
         # (extras/mmu/mmu_controller.py:205-207, 219-221)

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -540,13 +540,18 @@ class TestBootupOutput(unittest.TestCase):
     def test_box_turtle_banner_filament_row_matches_post_preload_status(self):
         """The cached welcome must not retain its pre-preload sensor readings."""
         console = console_mod.Console(console_mod.parse_args(
-            ['--profile', 'boxturtle', '--no-log', '--plain']))
+            ['--profile', 'boxturtle', '--no-log']))
         self.addCleanup(console.close)
         console.boot()
 
         banner = '\n'.join(console.startup_output)
         banner_row = next(line for line in banner.split('\n') if line.startswith('[T0]'))
-        self.assertEqual(banner_row, console.hh.mmu.get_filament_position_string())
+        expected, _plain = console.hh.mmu.logger._color_message(
+            console.hh.mmu.get_filament_position_string())
+        self.assertEqual(banner_row, expected)
+        self.assertIn('<span style="color:#', banner_row)
+        self.assertNotIn('{{', banner_row)
+        self.assertNotIn('{5}', banner_row)
         self.assertTrue(console.hh.sensor('mmu_exit_0').present)
         self.assertFalse(console.hh.sensor('unit0:mmu_shared_exit').present)
 

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -537,6 +537,19 @@ class TestBootupOutput(unittest.TestCase):
         self.assertIn('Ready', joined)
         self.assertEqual(console.sink, [], 'preload noise leaked into the console history')
 
+    def test_box_turtle_banner_filament_row_matches_post_preload_status(self):
+        """The cached welcome must not retain its pre-preload sensor readings."""
+        console = console_mod.Console(console_mod.parse_args(
+            ['--profile', 'boxturtle', '--no-log', '--plain']))
+        self.addCleanup(console.close)
+        console.boot()
+
+        banner = '\n'.join(console.startup_output)
+        banner_row = next(line for line in banner.split('\n') if line.startswith('[T0]'))
+        self.assertEqual(banner_row, console.hh.mmu.get_filament_position_string())
+        self.assertTrue(console.hh.sensor('mmu_exit_0').present)
+        self.assertFalse(console.hh.sensor('unit0:mmu_shared_exit').present)
+
     def _avail_row(self, console):
         """The gate-availability row of the bootup table. One sink entry is one MESSAGE, and
         the whole table arrives as a single multi-line one, so split before matching."""

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -570,6 +570,23 @@ class TestBootupOutput(unittest.TestCase):
         self.assertFalse(console.hh.sensor('mmu_entry_0').present)
         self.assertFalse(console.hh.sensor('mmu_exit_0').present)
 
+    def test_raw_preload_after_eject_models_reinsertion_at_entry(self):
+        console = console_mod.Console(console_mod.parse_args(
+            ['--profile', 'boxturtle', '--no-log', '--plain']))
+        self.addCleanup(console.close)
+        console.boot()
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            console.run_command('MMU_EJECT')
+            self.assertFalse(console.hh.sensor('mmu_entry_0').present)
+            console.run_command('MMU_PRELOAD')
+
+        self.assertEqual(console.failures, 0)
+        self.assertEqual(console.hh.mmu.gate_status[0], 1)
+        self.assertTrue(console.hh.sensor('mmu_entry_0').present)
+        self.assertTrue(console.hh.sensor('mmu_exit_0').present)
+        self.assertFalse(console.hh.sensor('unit0:mmu_shared_exit').present)
+
     def _avail_row(self, console):
         """The gate-availability row of the bootup table. One sink entry is one MESSAGE, and
         the whole table arrives as a single multi-line one, so split before matching."""

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -570,6 +570,23 @@ class TestBootupOutput(unittest.TestCase):
         self.assertFalse(console.hh.sensor('mmu_entry_0').present)
         self.assertFalse(console.hh.sensor('mmu_exit_0').present)
 
+    def test_box_turtle_unload_parks_between_exit_and_shared_exit(self):
+        console = console_mod.Console(console_mod.parse_args(
+            ['--profile', 'boxturtle', '--no-log', '--plain']))
+        self.addCleanup(console.close)
+        console.boot()
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            console.run_command('MMU_LOAD')
+            console.run_command('MMU_UNLOAD')
+
+        self.assertAlmostEqual(console.fil.tip[0], 50, places=5)
+        self.assertTrue(console.hh.sensor('mmu_entry_0').present)
+        self.assertTrue(console.hh.sensor('mmu_exit_0').present)
+        self.assertFalse(console.hh.sensor('unit0:mmu_shared_exit').present)
+        self.assertEqual(console.failures, 0)
+        self.assertEqual(console.hh.errors, [])
+
     def test_preload_requires_explicit_filament_placement_after_eject(self):
         """Raw gcode must preserve the missing-filament failure; /place sets the scene."""
         console = console_mod.Console(console_mod.parse_args(

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -555,6 +555,21 @@ class TestBootupOutput(unittest.TestCase):
         self.assertTrue(console.hh.sensor('mmu_exit_0').present)
         self.assertFalse(console.hh.sensor('unit0:mmu_shared_exit').present)
 
+    def test_box_turtle_eject_row_matches_the_now_empty_physical_gate(self):
+        """Eject output must not retain the entry reading from before model removal."""
+        console = console_mod.Console(console_mod.parse_args(
+            ['--profile', 'boxturtle', '--no-log']))
+        self.addCleanup(console.close)
+        console.boot()
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            console.run_command('MMU_EJECT')
+
+        row = console.hh.mmu.get_filament_position_string()
+        self.assertIn('EMPTY', row)
+        self.assertFalse(console.hh.sensor('mmu_entry_0').present)
+        self.assertFalse(console.hh.sensor('mmu_exit_0').present)
+
     def _avail_row(self, console):
         """The gate-availability row of the bootup table. One sink entry is one MESSAGE, and
         the whole table arrives as a single multi-line one, so split before matching."""

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -570,18 +570,25 @@ class TestBootupOutput(unittest.TestCase):
         self.assertFalse(console.hh.sensor('mmu_entry_0').present)
         self.assertFalse(console.hh.sensor('mmu_exit_0').present)
 
-    def test_raw_preload_after_eject_models_reinsertion_at_entry(self):
+    def test_preload_requires_explicit_filament_placement_after_eject(self):
+        """Raw gcode must preserve the missing-filament failure; /place sets the scene."""
         console = console_mod.Console(console_mod.parse_args(
             ['--profile', 'boxturtle', '--no-log', '--plain']))
         self.addCleanup(console.close)
         console.boot()
 
-        with contextlib.redirect_stdout(io.StringIO()):
+        with contextlib.redirect_stdout(io.StringIO()) as output:
             console.run_command('MMU_EJECT')
-            self.assertFalse(console.hh.sensor('mmu_entry_0').present)
-            console.run_command('MMU_PRELOAD')
+            console.run_command('MMU_PRELOAD GATE=0')
 
-        self.assertEqual(console.failures, 0)
+        self.assertIn("Couldn't pick up filament at gate", output.getvalue())
+        self.assertEqual(console.hh.mmu.gate_status[0], 0)
+        self.assertFalse(console.hh.sensor('mmu_entry_0').present)
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            console.meta('/place 0')
+            console.run_command('MMU_PRELOAD GATE=0')
+
         self.assertEqual(console.hh.mmu.gate_status[0], 1)
         self.assertTrue(console.hh.sensor('mmu_entry_0').present)
         self.assertTrue(console.hh.sensor('mmu_exit_0').present)

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -330,7 +330,9 @@ class TestInstallDirBoots(unittest.TestCase):
         hh.run_gcode('MMU_PRELOAD GATE=0')
         hh.reactor.advance(0.)
         self.assertEqual(hh.mmu.gate_status[0], 1, 'preload did not mark the gate available')
-        self.assertAlmostEqual(fil.tip[0], -100.0, places=1)
+        expected = (fil.layout['mmu_exit']
+                    + hh.mmu.mmu_unit(0).p.gate_preload_parking_distance)
+        self.assertAlmostEqual(fil.tip[0], expected, places=1)
         self.assertEqual(hh.errors, [])
 
 

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -610,6 +610,38 @@ class TestBootupOutput(unittest.TestCase):
         self.assertFalse(console.hh.sensor('unit0:mmu_shared_exit').present)
         self.assertEqual(console.fil.tail[0], float('-inf'))
 
+    def test_insert_fires_entry_autoload_when_enabled(self):
+        console = console_mod.Console(console_mod.parse_args(
+            ['--profile', 'boxturtle', '--no-log', '--plain']))
+        self.addCleanup(console.close)
+        console.boot()
+
+        with contextlib.redirect_stdout(io.StringIO()) as output:
+            console.meta('/remove 0')
+            console.meta('/insert 0')
+
+        self.assertIn('Preloading gate 0...', output.getvalue())
+        self.assertEqual(console.hh.mmu.gate_status[0], 1)
+        self.assertTrue(console.hh.sensor('mmu_entry_0').present)
+        self.assertTrue(console.hh.sensor('mmu_exit_0').present)
+        self.assertFalse(console.hh.sensor('unit0:mmu_shared_exit').present)
+
+    def test_insert_does_not_preload_when_gate_autoload_is_disabled(self):
+        console = console_mod.Console(console_mod.parse_args(
+            ['--profile', 'boxturtle', '--no-log', '--plain']))
+        self.addCleanup(console.close)
+        console.boot()
+        console.hh.mmu.mmu_unit(1).p.gate_autoload = 0
+
+        with contextlib.redirect_stdout(io.StringIO()) as output:
+            console.meta('/remove 1')
+            console.meta('/insert 1')
+
+        self.assertNotIn('Preloading gate 1...', output.getvalue())
+        self.assertTrue(console.hh.sensor('mmu_entry_1').present)
+        self.assertFalse(console.hh.sensor('mmu_exit_1').present)
+        self.assertEqual(console.fil.tip[1], console_mod.TIP_AT_GATE)
+
     def test_reset_rebuilds_the_profile_startup_state(self):
         console = console_mod.Console(console_mod.parse_args(
             ['--profile', 'boxturtle', '--no-log', '--plain']))

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -594,6 +594,41 @@ class TestBootupOutput(unittest.TestCase):
         self.assertTrue(console.hh.sensor('mmu_exit_0').present)
         self.assertFalse(console.hh.sensor('unit0:mmu_shared_exit').present)
 
+    def test_remove_clears_a_gate_path_without_turning_it_into_runout(self):
+        console = console_mod.Console(console_mod.parse_args(
+            ['--profile', 'boxturtle', '--no-log', '--plain']))
+        self.addCleanup(console.close)
+        console.boot()
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            console.fil.exhaust(0, sync=False)
+            console.meta('/remove 0')
+
+        self.assertEqual(console.hh.mmu.gate_status[0], 1)
+        self.assertFalse(console.hh.sensor('mmu_entry_0').present)
+        self.assertFalse(console.hh.sensor('mmu_exit_0').present)
+        self.assertFalse(console.hh.sensor('unit0:mmu_shared_exit').present)
+        self.assertEqual(console.fil.tail[0], float('-inf'))
+
+    def test_reset_rebuilds_the_profile_startup_state(self):
+        console = console_mod.Console(console_mod.parse_args(
+            ['--profile', 'boxturtle', '--no-log', '--plain']))
+        self.addCleanup(console.close)
+        console.boot()
+        original_session = console.hh
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            console.meta('/remove 0')
+            console.meta('/sensor mmu_entry_0 disable')
+            console.meta('/reset')
+
+        self.assertIsNot(console.hh, original_session)
+        self.assertEqual(console.hh.mmu.gate_status[0], 1)
+        self.assertTrue(console.hh.sensor('mmu_entry_0').present)
+        self.assertTrue(console.hh.sensor('mmu_entry_0').sensor.runout_helper.sensor_enabled)
+        self.assertTrue(console.hh.sensor('mmu_exit_0').present)
+        self.assertFalse(console.hh.sensor('unit0:mmu_shared_exit').present)
+
     def _avail_row(self, console):
         """The gate-availability row of the bootup table. One sink entry is one MESSAGE, and
         the whole table arrives as a single multi-line one, so split before matching."""

--- a/test/test_mmu_motion.py
+++ b/test/test_mmu_motion.py
@@ -346,7 +346,9 @@ class TestQuietPlacement(MotionTestCase):
         self.hh.settle()
         homed = [r for _g, _d, r in self.fil.history if 'mmu_exit_0' in r]
         self.assertTrue(homed, 'expected a homing move to the gate sensor')
-        self.assertAlmostEqual(self.fil.tip[0], TIP_PARKED, places=2)
+        preload_park = (self.fil.layout['mmu_exit']
+                        + self.hh.mmu.mmu_unit(0).p.gate_preload_parking_distance)
+        self.assertAlmostEqual(self.fil.tip[0], preload_park, places=2)
         self.assertEqual(self.hh.mmu.gate_status[0], GATE_AVAILABLE)
         self.assertTrue(self.hh.sensor('mmu_entry_0').present,
                         'the gear is downstream of the entry switch - preload cannot clear it')
@@ -373,8 +375,9 @@ class TestLoadGate(MotionTestCase):
 
     def test_homes_forward_to_the_gate_sensor(self):
         """
-        BoxTurtle's gate_homing_endstop is mmu_exit at 0, so _load_gate drives forward
-        from the park position until that switch trips - exactly 100mm.
+        BoxTurtle's gate_homing_endstop is the shared exit at 100, so _load_gate
+        drives forward from the model's initial -100 position until that switch
+        trips - exactly 200mm.
 
         It does NOT park: _load_gate leaves the filament standing ON the gate, which is
         the starting position the bowden load expects. (It used to appear to park here,
@@ -384,17 +387,17 @@ class TestLoadGate(MotionTestCase):
         overshoot = self.hh.mmu._load_gate()
         self.assertEqual(self.hh.mmu.filament_pos, FILAMENT_POS_HOMED_GATE)
         self.assertEqual(overshoot, 0.0)
-        self.assertAlmostEqual(self.fil.tip[0], self.fil.layout['mmu_exit'], places=2)
+        self.assertAlmostEqual(self.fil.tip[0], self.fil.layout['mmu_shared_exit'], places=2)
         self.assertEqual(self.hh.errors, [])
 
     def test_the_gate_sensor_was_tripped_on_the_way(self):
-        """A forward homing move of exactly 100mm, from park to the gate switch."""
+        """A forward homing move reaches the shared hub switch."""
         self.hh.mmu._load_gate()
         trips = [d for _g, d, reason in self.fil.history
-                 if 'homing -> mmu_exit_0' in reason and d > 0]
+                 if 'homing -> unit0:mmu_shared_exit' in reason and d > 0]
         self.assertTrue(trips, 'never homed forward onto the gate sensor')
-        self.assertAlmostEqual(trips[0], 100.0, places=3)
-        self.assertTrue(self.hh.sensor('mmu_exit_0').present,
+        self.assertAlmostEqual(trips[0], 200.0, places=3)
+        self.assertTrue(self.hh.sensor('unit0:mmu_shared_exit').present,
                         '_load_gate leaves the filament on the gate switch')
 
     def test_second_home_against_an_already_triggered_switch_is_free(self):
@@ -487,7 +490,7 @@ class TestParkedState(MotionTestCase):
         self.hh.mmu._load_gate()
 
     def test_the_gate_switch_is_reached_by_the_load(self):
-        self.assertTrue(self.hh.sensor('mmu_exit_0').present)
+        self.assertTrue(self.hh.sensor('unit0:mmu_shared_exit').present)
         self.assertEqual(self.hh.errors, [])
 
     def test_parking_afterwards_clears_the_gate_switch(self):
@@ -498,9 +501,11 @@ class TestParkedState(MotionTestCase):
         """
         mmu = self.hh.mmu
         mmu._park_from_gate(mmu._gate_profile())
-        self.assertFalse(self.hh.sensor('mmu_exit_0').present)
+        self.assertFalse(self.hh.sensor('unit0:mmu_shared_exit').present)
         self.assertTrue(self.hh.sensor('mmu_entry_0').present)
-        self.assertAlmostEqual(self.fil.tip[0], TIP_PARKED, places=2)
+        gate_park = (self.fil.layout['mmu_shared_exit']
+                     + mmu.mmu_unit(0).p.gate_parking_distance)
+        self.assertAlmostEqual(self.fil.tip[0], gate_park, places=2)
         self.assertEqual(self.hh.errors, [])
 
     def test_hh_agrees_the_gate_is_loaded(self):
@@ -516,8 +521,11 @@ class TestPreload(MotionTestCase):
         self.hh.run_gcode('MMU_PRELOAD GATE=1')
         self.assertEqual(self.hh.mmu.gate_status[1], GATE_AVAILABLE)
         self.assertEqual(self.hh.mmu.filament_pos, FILAMENT_POS_UNLOADED)
-        self.assertAlmostEqual(self.fil.tip[1], TIP_PARKED, places=2)
-        self.assertFalse(self.hh.sensor('mmu_exit_1').present)
+        preload_park = (self.fil.layout['mmu_exit']
+                        + self.hh.mmu.mmu_unit(0).p.gate_preload_parking_distance)
+        self.assertAlmostEqual(self.fil.tip[1], preload_park, places=2)
+        self.assertTrue(self.hh.sensor('mmu_exit_1').present)
+        self.assertFalse(self.hh.sensor('unit0:mmu_shared_exit').present)
         self.assertTrue(self.hh.sensor('mmu_entry_1').present,
                         'a parked filament still runs back through the entry switch')
         self.assertEqual(self.hh.errors, [])
@@ -530,22 +538,24 @@ class TestPreload(MotionTestCase):
         """
         self.hh.place_filament(2, position=TIP_AT_GATE, quiet=False)
         self.hh.settle()
-        self.assertAlmostEqual(self.fil.tip[2], TIP_PARKED, places=2)
+        preload_park = (self.fil.layout['mmu_exit']
+                        + self.hh.mmu.mmu_unit(0).p.gate_preload_parking_distance)
+        self.assertAlmostEqual(self.fil.tip[2], preload_park, places=2)
         self.assertEqual(self.hh.mmu.gate_status[2], GATE_AVAILABLE)
         self.assertEqual(self.hh.errors, [])
 
     def test_preload_passes_the_gate_sensor_on_the_way(self):  # noqa: D401
         """
-        Preload homes forward to the gate endstop and then retracts to park, so the
-        exit switch must have been tripped mid-sequence even though it reads clear at
-        the end. Confirms the sequence rather than just the endpoint.
+        Preload homes forward to the per-gate exit and parks 10mm beyond it, so
+        the exit remains covered while the downstream shared hub remains clear.
         """
         self.hh.place_filament(1, position=TIP_AT_GATE)
         self.hh.run_gcode('MMU_PRELOAD GATE=1')
         reached = [d for gate, d, reason in self.fil.history
                    if gate == 1 and 'mmu_exit_1' in reason]
         self.assertTrue(reached, 'preload never homed to the gate sensor')
-        self.assertFalse(self.hh.sensor('mmu_exit_1').present)
+        self.assertTrue(self.hh.sensor('mmu_exit_1').present)
+        self.assertFalse(self.hh.sensor('unit0:mmu_shared_exit').present)
 
     def test_plain_preload_announces_itself_once_and_without_nfc(self):
         """

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -109,7 +109,7 @@ class TestEveryBootableProfile(unittest.TestCase):
 
         model = hh.filament()
         self.assertEqual(model.layout['mmu_exit'], 0)
-        self.assertEqual(model.layout['mmu_shared_exit'], 100)
+        self.assertEqual(model.layout['mmu_shared_exit'], 150)
         hh.place_filament(0, position=-40)
         hh.run_gcode('MMU_PRELOAD GATE=0')
         self.assertAlmostEqual(model.tip[0], 10)

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -45,6 +45,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 import logging
+import re
 import unittest
 
 from test.hh import session
@@ -151,7 +152,8 @@ class TestEveryBootableProfile(unittest.TestCase):
         unit = hh.mmu.mmu_unit(0)
         self.assertEqual(unit.p.gate_homing_endstop, 'mmu_shared_exit')
         self.assertEqual(unit.p.gate_preload_endstop, 'none')
-        self.assertEqual(unit.p.gate_preload_homing_max, 200)
+        # Simulator override only; the installer/Kconfig default remains 200 mm.
+        self.assertEqual(unit.p.gate_preload_homing_max, 100)
         self.assertEqual(unit.p.extruder_homing_endstop, 'extruder')
         self.assertEqual(unit.filament_heater, 'heater_generic box1_heater')
         self.assertEqual(unit.environment_sensor, 'temperature_sensor box1_env')
@@ -160,10 +162,22 @@ class TestEveryBootableProfile(unittest.TestCase):
         self.assertEqual(model.layout['mmu_entry'], -150)
         self.assertEqual(model.layout['mmu_shared_exit'], 150)
         self.assertEqual(model.layout['extruder'], 900)
-        hh.place_filament(0, position=-110)
-        hh.run_gcode('MMU_PRELOAD GATE=0')
-        self.assertAlmostEqual(model.tip[0], 90)
+        # Reproduce make console's startup preload of every gate. No other
+        # filament may leave the shared sensor asserted after the selected gate
+        # is ejected and preloaded again.
+        for gate in range(4):
+            hh.place_filament(gate, position=-40)
+            hh.run_gcode('MMU_PRELOAD GATE=%d' % gate)
         self.assertFalse(model.triggered('unit0:mmu_shared_exit'))
+
+        hh.run_gcode('MMU_SELECT GATE=0')
+        hh.run_gcode('MMU_EJECT')
+        hh.run_gcode('MMU_PRELOAD')
+        self.assertFalse(model.triggered('unit0:mmu_shared_exit'))
+        at = len(hh.console)
+        hh.run_gcode('MMU_STATUS')
+        status = re.sub(r'<[^>]+>', '', '\n'.join(hh.console[at:]))
+        self.assertIn('■◉■■■■■◯', status)
 
     def test_emu(self):
         self._check('emu')

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -18,6 +18,8 @@
 #   mmx        4 gates,  ServoSelector         - vendor-supplied gate angles, including a
 #                                                full load/unload behavioral test
 #   kms        4 gates,  VirtualSelector       - default KMS buffer with per-gate exit sensors
+#   qidi       4 gates,  VirtualSelector       - fixed QIDI v2 board, shared hub sensor,
+#                                                THR-hosted extruder sensor and stock dryer
 #   emu        5 gates,  VirtualSelector       - the only shipped profile with a
 #                                                PROPORTIONAL (analog) buffer sensor
 #   ercf 1.1   9 gates,  LinearServoSelector   - unit0 of ercf_vvd; encoder gate homing
@@ -59,6 +61,7 @@ BOOTABLE = {
     'pico_mmu': (4, 'ServoSelector'),
     'mmx': (4, 'ServoSelector'),
     'kms': (4, 'VirtualSelector'),
+    'qidi': (4, 'VirtualSelector'),
     'emu': (5, 'VirtualSelector'),
     # The only multi-unit entry. 13 is a CROSS-UNIT SUM (unit0 9 + unit1 4), not one unit's
     # count, and the selector named here is unit0's - unit1 is an IndexedSelector and gets
@@ -141,6 +144,17 @@ class TestEveryBootableProfile(unittest.TestCase):
         hh.run_gcode('MMU_TEST_CONFIG UNIT=0 gate_preload_endstop=none')
         self.assertEqual(unit.p.gate_preload_endstop, 'none')
         self.assertEqual(hh.errors, [])
+
+    def test_qidi(self):
+        """QIDI boots with its fixed board, external THR sensor and dryer objects."""
+        hh = self._check('qidi')
+        unit = hh.mmu.mmu_unit(0)
+        self.assertEqual(unit.p.gate_homing_endstop, 'mmu_shared_exit')
+        self.assertEqual(unit.p.gate_preload_endstop, 'none')
+        self.assertEqual(unit.p.gate_preload_homing_max, 200)
+        self.assertEqual(unit.p.extruder_homing_endstop, 'extruder')
+        self.assertEqual(unit.filament_heater, 'heater_generic box1_heater')
+        self.assertEqual(unit.environment_sensor, 'temperature_sensor box1_env')
 
     def test_emu(self):
         self._check('emu')

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -156,6 +156,15 @@ class TestEveryBootableProfile(unittest.TestCase):
         self.assertEqual(unit.filament_heater, 'heater_generic box1_heater')
         self.assertEqual(unit.environment_sensor, 'temperature_sensor box1_env')
 
+        model = hh.filament()
+        self.assertEqual(model.layout['mmu_entry'], -150)
+        self.assertEqual(model.layout['mmu_shared_exit'], 150)
+        self.assertEqual(model.layout['extruder'], 900)
+        hh.place_filament(0, position=-110)
+        hh.run_gcode('MMU_PRELOAD GATE=0')
+        self.assertAlmostEqual(model.tip[0], 90)
+        self.assertFalse(model.triggered('unit0:mmu_shared_exit'))
+
     def test_emu(self):
         self._check('emu')
 

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -98,7 +98,23 @@ class TestEveryBootableProfile(unittest.TestCase):
         return hh
 
     def test_boxturtle(self):
-        self._check('boxturtle')
+        hh = self._check('boxturtle')
+        unit = hh.mmu.mmu_unit(0)
+        self.assertEqual(unit.p.gate_homing_endstop, 'mmu_shared_exit')
+        self.assertEqual(unit.p.gate_homing_max, 300)
+        self.assertEqual(unit.p.gate_parking_distance, -100)
+        self.assertEqual(unit.p.gate_preload_endstop, 'mmu_exit')
+        self.assertEqual(unit.p.gate_preload_homing_max, 200)
+        self.assertEqual(unit.p.gate_preload_parking_distance, 10)
+
+        model = hh.filament()
+        self.assertEqual(model.layout['mmu_exit'], 0)
+        self.assertEqual(model.layout['mmu_shared_exit'], 100)
+        hh.place_filament(0, position=-40)
+        hh.run_gcode('MMU_PRELOAD GATE=0')
+        self.assertAlmostEqual(model.tip[0], 10)
+        self.assertTrue(model.triggered('mmu_exit_0'))
+        self.assertFalse(model.triggered('unit0:mmu_shared_exit'))
 
     def test_tradrack(self):
         """

--- a/test/test_mmu_toolchange.py
+++ b/test/test_mmu_toolchange.py
@@ -29,7 +29,6 @@ import logging
 import unittest
 
 from test.hh import session
-from test.hh.filament import TIP_PARKED
 
 logging.getLogger().setLevel(logging.CRITICAL)
 
@@ -82,7 +81,7 @@ class TestLoad(ToolchangeTestCase):
         self.hh.mmu.select_gate(0)
         self.hh.run_gcode('MMU_LOAD')
         reasons = [r for _g, _d, r in self.fil.history]
-        self.assertTrue(any('mmu_exit_0' in r for r in reasons),
+        self.assertTrue(any('unit0:mmu_shared_exit' in r for r in reasons),
                         'never homed to the gate')
         self.assertTrue(any('filament_compression' in r for r in reasons),
                         'never homed to the extruder compression sensor')
@@ -94,7 +93,9 @@ class TestLoad(ToolchangeTestCase):
         moves = [d for _g, d, reason in self.fil.history
                  if 'homing -> unit0:filament_compression' in reason]
         buffer = self.hh.mmu.mmu_machine.units[0].buffer
-        expected = self.fil.layout['extruder_entry'] + buffer.buffer_maxrange * 0.7
+        expected = (self.fil.layout['extruder_entry']
+                    + buffer.buffer_maxrange * 0.7
+                    - self.fil.layout['mmu_shared_exit'])
         self.assertTrue(moves)
         # Loading immediately reverse-homes off compression with the extruder; that
         # second transition is only a microscopic release move.
@@ -165,7 +166,9 @@ class TestUnload(ToolchangeTestCase):
     def test_unload_returns_filament_to_the_park_position(self):
         self.hh.run_gcode('MMU_UNLOAD')
         self.assertEqual(self.hh.mmu.filament_pos, FILAMENT_POS_UNLOADED)
-        self.assertAlmostEqual(self.fil.tip[0], TIP_PARKED, places=1)
+        park = (self.fil.layout['mmu_shared_exit']
+                + self.hh.mmu.mmu_unit(0).p.gate_parking_distance)
+        self.assertAlmostEqual(self.fil.tip[0], park, places=1)
         self.assertEqual(self.hh.errors, [])
 
     def test_unload_clears_the_path_sensors(self):
@@ -176,7 +179,7 @@ class TestUnload(ToolchangeTestCase):
         user) clears it.
         """
         self.hh.run_gcode('MMU_UNLOAD')
-        self.assertFalse(self.hh.sensor('mmu_exit_0').present)
+        self.assertFalse(self.hh.sensor('unit0:mmu_shared_exit').present)
         self.assertTrue(self.hh.sensor('mmu_entry_0').present)
 
     def test_unload_names_the_gate_it_is_unloading(self):
@@ -200,7 +203,8 @@ class TestUnload(ToolchangeTestCase):
 
     def test_load_unload_is_a_round_trip(self):
         """The whole point: a cycle must leave the machine where it started."""
-        start = TIP_PARKED
+        start = (self.fil.layout['mmu_shared_exit']
+                 + self.hh.mmu.mmu_unit(0).p.gate_parking_distance)
         self.hh.run_gcode('MMU_UNLOAD')
         self.assertAlmostEqual(self.fil.tip[0], start, places=1)
         self.hh.run_gcode('MMU_LOAD')
@@ -240,7 +244,9 @@ class TestToolChange(ToolchangeTestCase):
         self.assertEqual(self.hh.mmu.tool_selected, 2)
         self.assertEqual(self.hh.mmu.gate_selected, 2)
         self.assertEqual(self.hh.mmu.filament_pos, FILAMENT_POS_LOADED)
-        self.assertAlmostEqual(self.fil.tip[0], TIP_PARKED, places=1)
+        park = (self.fil.layout['mmu_shared_exit']
+                + self.hh.mmu.mmu_unit(0).p.gate_parking_distance)
+        self.assertAlmostEqual(self.fil.tip[0], park, places=1)
         self.assertGreater(self.fil.tip[2], self.fil.layout['extruder_entry'])
         self.assertEqual(self.hh.errors, [])
 


### PR DESCRIPTION
## Summary

- add a selectable QIDI Box 1.0 MMU profile with VirtualSelector, four fixed gear drives, shared hub homing, sensorless 200 mm preload, tension feedback, and stock dryer references
- add the fixed STM32F401xC QIDI Box v2 controller pinout and USB discovery defaults for stock and mainline Klipper firmware
- support QIDI hardware-controlled stepper drivers without generating TMC/UART sections while preserving TMC requirements for every other MMU
- add the qidi make-console profile and rendering/runtime regression coverage

## Testing

- PYTHONPATH=installer/lib/kconfiglib:$PYTHONPATH venv/bin/python -m unittest test.installer.test_qidi_box test.installer.test_build test.test_mmu_profiles
- 43 tests passed
- PYTHONPATH=installer/lib/kconfiglib:$PYTHONPATH venv/bin/python -m test.console --profile qidi --script /dev/null --plain --header off --no-log --no-moonraker