### PR TITLE
Clean up MMU Kconfig defaults

### DIFF
--- a/installer/Kconfig.preload_eject
+++ b/installer/Kconfig.preload_eject
@@ -18,8 +18,11 @@ menu "Filament preloading and ejection"
   choice CHOICE_GATE_PRELOAD_ENDSTOP
     prompt "Gate preload endstop        "
     help
-      Typically this will be the individual mmu exit sensor if is configured else the same
-      as the gate homing endstop
+      Typically this will be the individual mmu exit sensor if one is configured, otherwise
+      the same as the gate homing endstop.
+
+    default CHOICE_GATE_PRELOAD_ENDSTOP_EXIT if MMU_HAS_SENSOR_EXIT
+    default CHOICE_GATE_PRELOAD_ENDSTOP_DEFAULT
 
     config CHOICE_GATE_PRELOAD_ENDSTOP_DEFAULT
       bool "Same as gate homing endstop"

--- a/installer/mmu_types/Kconfig.box_turtle
+++ b/installer/mmu_types/Kconfig.box_turtle
@@ -11,6 +11,7 @@ config MMU_TYPE_BOX_TURTLE_1_0
   imply  MMU_HAS_SENSOR_ENTRY
   imply  MMU_HAS_SENSOR_EXIT
   imply  MMU_HAS_SENSOR_SHARED_EXIT
+  imply  PREFERS_CHOICE_GATE_HOMING_ENDSTOP_SHARED_EXIT
   select PARAM_VARIABLE_ROTATION_DISTANCES
   select PARAM_VARIABLE_BOWDEN_LENGTHS
   select PARAM_REQUIRE_BOWDEN_MOVE
@@ -74,9 +75,9 @@ if MMU_TYPE_BOX_TURTLE_1_0
   source "Kconfig.capabilities"
 
 
-  ####################
-  ##### Defaults #####
-  ####################
+  # -------------------------------------
+  # Defaults
+  # -------------------------------------
 
   config PARAM_VENDOR
     default "BoxTurtle"
@@ -88,6 +89,7 @@ if MMU_TYPE_BOX_TURTLE_1_0
     default BOARD_TYPE_AFC_LITE_1_0
   endchoice
 
+  # Gear stepper ---------------------------
   config PARAM_GEAR_GEAR_RATIO
     default "50:10"
   config PARAM_GEAR_RUN_CURRENT
@@ -95,14 +97,34 @@ if MMU_TYPE_BOX_TURTLE_1_0
   config PARAM_GEAR_HOLD_CURRENT
     default 0.1
 
+  config PARAM_SYNC_GEAR_CURRENT
+    default 70
+
+  # Gate endstops and homing ---------------
   config PARAM_GATE_HOMING_MAX
     default 300
-  config PARAM_GATE_PRELOAD_HOMING_MAX
-    default 200
   config PARAM_GATE_PARKING_DISTANCE
     default -100
+
+  config PARAM_GATE_PRELOAD_HOMING_MAX
+    default 200
+  config PARAM_GATE_PRELOAD_PARKING_DISTANCE
+    default 10
+
   config PARAM_GATE_FINAL_EJECT_DISTANCE
     default 100
+
+  # NFC reader setup (if fitted) -----------
+  config PARAM_NFC_GATE_JOG_SCAN_WINDOW
+    default "0, 480"
+  config PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW
+    default "0, 480"
+  config PARAM_NFC_GATE_CLEAR_DISTANCE
+    default -70
+  config PARAM_NFC_PRELOAD_CLEAR_DISTANCE
+    default 70
+  config PARAM_NFC_NEIGHBOR_CHECK
+    default y
 
   comment "_"
 

--- a/installer/mmu_types/Kconfig.emu
+++ b/installer/mmu_types/Kconfig.emu
@@ -80,14 +80,13 @@ if MMU_TYPE_EMU_1_0
     default "EMU"
   config PARAM_VERSION
     default "1.0"  
-
   config PARAM_NUM_GATES
     default 5
-
   choice BOARD_TYPE
     default BOARD_TYPE_SLB_1_0
   endchoice
 
+  # Gear stepper ---------------------------
   config PARAM_GEAR_GEAR_RATIO
     default "1:1"
   config PARAM_GEAR_RUN_CURRENT
@@ -97,6 +96,10 @@ if MMU_TYPE_EMU_1_0
   config PARAM_GEAR_MICROSTEPS
     default 4
 
+  config PARAM_SYNC_GEAR_CURRENT
+    default 52
+
+  # Speeds  --------------------------------
   config PARAM_GEAR_LOAD_SPEED
     default 250
   config PARAM_GEAR_LOAD_ACCEL
@@ -118,9 +121,21 @@ if MMU_TYPE_EMU_1_0
   config PARAM_GEAR_HOMING_SPEED
     default 80
 
-  config PARAM_SYNC_GEAR_CURRENT
-    default 52
+  # Gate endstops and homing ---------------
+  config PARAM_GATE_HOMING_MAX
+    default 600
+  config PARAM_GATE_PARKING_DISTANCE
+    default -1
 
+  config PARAM_GATE_PRELOAD_HOMING_MAX
+    default 600
+  config PARAM_GATE_PRELOAD_PARKING_DISTANCE
+    default -1
+
+  config PARAM_GATE_FINAL_EJECT_DISTANCE
+    default 100
+
+  # NFC reader setup (if fitted) -----------
   config PARAM_NFC_GATE_JOG_SCAN_WINDOW
     default "0, 480"
   config PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW
@@ -132,6 +147,7 @@ if MMU_TYPE_EMU_1_0
   config PARAM_NFC_NEIGHBOR_CHECK
     default y
 
+  # Other ----------------------------------
   config PARAM_COLOR_ORDER
     default "GRBW"
   
@@ -152,18 +168,6 @@ if MMU_TYPE_EMU_1_0
       generated_default "neopixel:_$(UNIT_NAME)_gate%i_leds (1,2,3,4)" "" "; " PARAM_NUM_GATES
     
   endif
-
-  # "Gates" config
-  config PARAM_GATE_HOMING_MAX
-    default 600
-  config PARAM_GATE_PRELOAD_HOMING_MAX
-    default 600
-  config PARAM_GATE_PRELOAD_PARKING_DISTANCE
-    default -1
-  config PARAM_GATE_PARKING_DISTANCE
-    default -1
-  config PARAM_GATE_FINAL_EJECT_DISTANCE
-    default 100
 
   config PARAM_FILAMENT_HEATERS 
     generated_default "$(UNIT_NAME)_heater%i" "" PARAM_NUM_GATES

--- a/installer/mmu_types/Kconfig.kms
+++ b/installer/mmu_types/Kconfig.kms
@@ -88,14 +88,17 @@ if MMU_TYPE_KMS_1_0
   # "Gates" config
   config PARAM_GATE_HOMING_MAX
     default 300
+  config PARAM_GATE_PARKING_DISTANCE
+    default -20
+
   config PARAM_GATE_PRELOAD_HOMING_MAX
     default 300
   config PARAM_GATE_PRELOAD_PARKING_DISTANCE
     default -10
-  config PARAM_GATE_PARKING_DISTANCE
-    default -20
+
   config PARAM_GATE_FINAL_EJECT_DISTANCE
     default 300
+
   config PARAM_GATE_ENDSTOP_TO_ENCODER
     default 14
 

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -112,6 +112,26 @@ BOXTURTLE = Profile(
     syms={'MMU_TYPE_BOX_TURTLE_1_0': True},
     description='BoxTurtle 1.0 - Type B, VirtualSelector, 4 gates, multigear')
 
+# Stable, deliberately neutral fixture for tests of generic MMU behavior. BoxTurtle's real
+# defaults evolve with the machine; motion, NFC-validation and encoder tests should not all
+# change meaning whenever that happens. Profile-specific tests and make console continue to
+# use BOXTURTLE above, while this fixture preserves the former per-gate homing/parking shape
+# and keeps optional NFC arbitration disabled until a test explicitly enables it.
+BOXTURTLE_TEST = BOXTURTLE.derive(
+    'boxturtle_test',
+    syms={
+        'CHOICE_GATE_HOMING_ENDSTOP_EXIT': True,
+        'CHOICE_GATE_PRELOAD_ENDSTOP_DEFAULT': True,
+        'PARAM_GATE_PRELOAD_PARKING_DISTANCE': -100,
+        'PARAM_SYNC_GEAR_CURRENT': 50,
+        'PARAM_NFC_GATE_JOG_SCAN_WINDOW': '-50, 50',
+        'PARAM_NFC_PRELOAD_JOG_SCAN_WINDOW': '-50, 50',
+        'PARAM_NFC_NEIGHBOR_CHECK': False,
+        'PARAM_NFC_GATE_CLEAR_DISTANCE': 0,
+        'PARAM_NFC_PRELOAD_CLEAR_DISTANCE': 0,
+    },
+    description='Neutral BoxTurtle fixture for generic harness tests')
+
 # BoxTurtle + one COMMON NFC reader serving all gates and the bypass (RC522 over SPI).
 #
 # MMU_HAS_COMMON_NFC_READER is what gates both the [mmu_nfc_reader NAME] section AND
@@ -122,14 +142,14 @@ BOXTURTLE = Profile(
 # "shared across MMU UNITS" and carried `depends on MULTI_UNIT`, making it unreachable on
 # a one-unit machine. The section rendered but `nfc_reader:` did not, so the reader was
 # orphaned and NFC silently did nothing. The harness caught that; it is now fixed.
-NFC_SINGLE = BOXTURTLE.derive(
+NFC_SINGLE = BOXTURTLE_TEST.derive(
     'nfc_single',
     syms={'MMU_HAS_NFC_READER': True, 'MMU_HAS_COMMON_NFC_READER': True},
     description='BoxTurtle + one common NFC reader (RC522/SPI)')
 
 # One reader per gate. This is the profile that exercises the per-gate read/LED path
 # and MmuNfcEndstop, and the one that surfaces the mmu_nfc_reader.py:132 crash.
-NFC_PER_GATE = BOXTURTLE.derive(
+NFC_PER_GATE = BOXTURTLE_TEST.derive(
     'nfc_per_gate',
     syms={'MMU_HAS_NFC_READER': True, 'MMU_HAS_PER_GATE_NFC_READERS': True},
     description='BoxTurtle + per-gate NFC readers')
@@ -372,7 +392,7 @@ EMU = Profile(
 # desired_headroom, the sample counts), so the section renders complete. That is the
 # test for whether hand-enabling a feature is legitimate - render it and read the
 # section, do not assume.
-ENCODER = BOXTURTLE.derive(
+ENCODER = BOXTURTLE_TEST.derive(
     'encoder',
     syms={
         'MMU_HAS_ENCODER': True,
@@ -586,7 +606,7 @@ CONSOLE_PROFILES = (ERCF_VVD, BOXTURTLE, TRADRACK, CHAMELEON, PICO_MMU, MMX, KMS
                     NFC_SPOOLMAN, NFC_SPOOLMAN_SHARED)
 
 PROFILES = {p.name: p for p in CONSOLE_PROFILES +
-            (ERCF_VVD_BUFFERS, ERCF_VVD_DUAL_EXTRUDER)}
+            (BOXTURTLE_TEST, ERCF_VVD_BUFFERS, ERCF_VVD_DUAL_EXTRUDER)}
 
 
 def get(name):

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -330,7 +330,7 @@ class TestInstallDirBoots(unittest.TestCase):
         hh.run_gcode('MMU_PRELOAD GATE=0')
         hh.reactor.advance(0.)
         self.assertEqual(hh.mmu.gate_status[0], 1, 'preload did not mark the gate available')
-        self.assertAlmostEqual(fil.tip[0], -100.0, places=1)
+        self.assertAlmostEqual(fil.tip[0], 10.0, places=1)
         self.assertEqual(hh.errors, [])
 
 
@@ -1742,7 +1742,7 @@ class TestConsoleScript(unittest.TestCase):
         # Put this gate through every fitted sensor; other gates remain merely parked.
         hh.place_filament(0, position=800.)
         affected = [name for name in console.fil.sensor_names()
-                    if console.fil.gate_of(name) in (None, 0)
+                    if console.fil.gate_of(name) == 0
                     # Buffer switches report stored slack/tension, not filament
                     # presence, and are intentionally not all true at once.
                     and not console.fil.models_sensor(name)]

--- a/test/test_mmu_endless_spool.py
+++ b/test/test_mmu_endless_spool.py
@@ -44,7 +44,7 @@ class EndlessSpoolTestCase(unittest.TestCase):
     ENABLE = 1
 
     def setUp(self):
-        self.hh = session('boxturtle')
+        self.hh = session('boxturtle_test')
         self.hh.boot()
         self.assertEqual(self.hh.errors, [], 'bootup was not clean')
         self.fil = self.hh.filament()

--- a/test/test_mmu_motion.py
+++ b/test/test_mmu_motion.py
@@ -55,7 +55,7 @@ GATE_AVAILABLE = 1
 
 
 class MotionTestCase(unittest.TestCase):
-    PROFILE = 'boxturtle'
+    PROFILE = 'boxturtle_test'
 
     def setUp(self):
         self.hh = session(self.PROFILE)

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -94,7 +94,26 @@ class TestEveryBootableProfile(unittest.TestCase):
         return hh
 
     def test_boxturtle(self):
-        self._check('boxturtle')
+        hh = self._check('boxturtle')
+        unit = hh.mmu.mmu_unit(0)
+        self.assertEqual(unit.p.gate_homing_endstop, 'mmu_shared_exit')
+        self.assertEqual(unit.p.gate_homing_max, 300)
+        self.assertEqual(unit.p.gate_parking_distance, -100)
+        self.assertEqual(unit.p.gate_preload_endstop, 'mmu_exit')
+        self.assertEqual(unit.p.gate_preload_homing_max, 200)
+        self.assertEqual(unit.p.gate_preload_parking_distance, 10)
+        self.assertEqual(unit.p.sync_gear_current, 70)
+
+    def test_boxturtle_nfc_defaults_are_valid_for_its_split_endstops(self):
+        for name in ('nfc_single', 'nfc_per_gate'):
+            with self.subTest(profile=name):
+                hh = self._boot(name)
+                unit = hh.mmu.mmu_unit(0)
+                self.assertEqual(unit.p.gate_homing_endstop, 'mmu_shared_exit')
+                self.assertEqual(unit.p.gate_preload_endstop, 'mmu_exit')
+                self.assertEqual(unit.p.nfc_gate_clear_distance, -70)
+                self.assertEqual(unit.p.nfc_preload_clear_distance, 70)
+                self.assertEqual(hh.errors, [])
 
     def test_tradrack(self):
         """

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -105,15 +105,23 @@ class TestEveryBootableProfile(unittest.TestCase):
         self.assertEqual(unit.p.sync_gear_current, 70)
 
     def test_boxturtle_nfc_defaults_are_valid_for_its_split_endstops(self):
-        for name in ('nfc_single', 'nfc_per_gate'):
-            with self.subTest(profile=name):
-                hh = self._boot(name)
-                unit = hh.mmu.mmu_unit(0)
-                self.assertEqual(unit.p.gate_homing_endstop, 'mmu_shared_exit')
-                self.assertEqual(unit.p.gate_preload_endstop, 'mmu_exit')
-                self.assertEqual(unit.p.nfc_gate_clear_distance, -70)
-                self.assertEqual(unit.p.nfc_preload_clear_distance, 70)
-                self.assertEqual(hh.errors, [])
+        from test.hh import profiles
+        profile = profiles.Profile(
+            'boxturtle_nfc_defaults',
+            syms={
+                'MMU_TYPE_BOX_TURTLE_1_0': True,
+                'MMU_HAS_NFC_READER': True,
+                'MMU_HAS_COMMON_NFC_READER': True,
+            })
+        hh = session(profile)
+        self.addCleanup(hh.close)
+        hh.boot()
+        unit = hh.mmu.mmu_unit(0)
+        self.assertEqual(unit.p.gate_homing_endstop, 'mmu_shared_exit')
+        self.assertEqual(unit.p.gate_preload_endstop, 'mmu_exit')
+        self.assertEqual(unit.p.nfc_gate_clear_distance, -70)
+        self.assertEqual(unit.p.nfc_preload_clear_distance, 70)
+        self.assertEqual(hh.errors, [])
 
     def test_tradrack(self):
         """

--- a/test/test_mmu_toolchange.py
+++ b/test/test_mmu_toolchange.py
@@ -42,7 +42,7 @@ TOOL_UNKNOWN = -2
 
 
 class ToolchangeTestCase(unittest.TestCase):
-    PROFILE = 'boxturtle'
+    PROFILE = 'boxturtle_test'
     PRELOAD_GATES = (0,)
 
     def setUp(self):


### PR DESCRIPTION
Summary:
- reorganize Box Turtle, EMU, and KMS defaults for consistent readability
- prefer Box Turtle shared-exit gate homing while defaulting preload to per-gate exits when available
- add Box Turtle sync-current, preload parking, and NFC defaults with safe clear directions
- cover Box Turtle split-endstop and NFC-enabled configurations

Tests:
- 49 installer tests
- 35 MMU profile tests