### PR TITLE
Fix buffer-only FlowGuard status reporting

### DIFF
--- a/extras/mmu/unit/mmu_sync_feedback.py
+++ b/extras/mmu/unit/mmu_sync_feedback.py
@@ -380,15 +380,20 @@ class MmuSyncFeedback:
 
         # Buffer controlled sync feedback
         if self.mmu_unit.has_buffer() and self.ctrl:
+            flowguard_status = dict(self.flowguard_status)
+            flowguard_status.update({
+                'active': self.flowguard_active,
+                'enabled': bool(self.p.flowguard_enabled),
+            })
             if self.mmu_unit.has_encoder():
-                self.flowguard_status['encoder_mode'] = self.p.flowguard_encoder_mode # Ok to mutate status
+                flowguard_status['encoder_mode'] = self.p.flowguard_encoder_mode
             status.update({
                 'sync_feedback_state': self.get_sync_feedback_string(),
                 'sync_feedback_enabled': self.is_enabled(),
                 'sync_feedback_bias_raw': round(self._get_sync_bias_raw(), 2),
                 'sync_feedback_bias_modelled': round(self._get_sync_bias_modelled(), 2),
                 'sync_feedback_flow_rate': self.flow_rate,
-                'flowguard': self.flowguard_status,
+                'flowguard': flowguard_status,
                 'tangle_prevention': {
                     'enabled': bool(self.p.tangle_prevention_enabled),
                     'active': self._tangle_prevention_active,

--- a/test/test_mmu_sensor_enable.py
+++ b/test/test_mmu_sensor_enable.py
@@ -324,5 +324,46 @@ class FlowGuardSuppressionTestCase(unittest.TestCase):
         self.assertEqual(called, ['clog'])
 
 
+class FlowGuardBufferStatusTestCase(unittest.TestCase):
+    """The buffer status API must report the live monitoring flags, not cached telemetry."""
+
+    def setUp(self):
+        self.hh = session('emu')
+        self.hh.boot()
+        self.assertEqual(self.hh.errors, [], 'bootup was not clean')
+        self.mmu = self.hh.mmu
+        self.sf = self.mmu.mmu_machine.units[0].sync_feedback
+        self.assertTrue(self.sf.mmu_unit.has_buffer())
+        self.assertFalse(self.sf.mmu_unit.has_encoder())
+
+    def tearDown(self):
+        self.hh.close()
+
+    def flowguard_status(self):
+        return self.mmu.get_status(self.hh.reactor.monotonic())['flowguard']
+
+    def test_buffer_only_status_tracks_live_flowguard_flags(self):
+        self.assertEqual(
+            (self.flowguard_status()['enabled'], self.flowguard_status()['active']),
+            (True, False),
+        )
+
+        self.mmu.select_gate(0)
+        self.mmu._enable_filament_monitoring()
+        self.assertEqual(
+            (self.flowguard_status()['enabled'], self.flowguard_status()['active']),
+            (True, True),
+        )
+
+        # The controller's cached 'active' field is its private warm-up state. It must
+        # not leak back out as the public monitoring state after monitoring is disabled.
+        self.sf.flowguard_status['active'] = True
+        self.mmu._disable_filament_monitoring()
+        self.assertEqual(
+            (self.flowguard_status()['enabled'], self.flowguard_status()['active']),
+            (True, False),
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- report FlowGuard enabled from the live unit configuration on buffer-backed units
- report FlowGuard active from the live monitoring scope instead of the controller warm-up cache
- preserve controller trip and level telemetry without mutating the cached status dict
- add regression coverage using the buffer-only, encoder-free EMU profile

## Testing
- focused FlowGuard and multi-unit sensor tests: 8 passed
- full suite: 1221 passed