### PR TITLE
Add Qidi Q2 toolhead and cutter defaults

### DIFF
--- a/installer/mmu_types/Kconfig.qidi_box
+++ b/installer/mmu_types/Kconfig.qidi_box
@@ -60,6 +60,9 @@ if MMU_TYPE_QIDI_BOX_1_0
   choice BOARD_TYPE
     default BOARD_TYPE_QIDI_BOX_2_0
   endchoice
+  choice CHOICE_TOOLHEAD_TYPE
+    default TOOLHEAD_TYPE_QIDI_Q2
+  endchoice
 
   # Gear stepper ---------------------------
   config PARAM_GEAR_GEAR_RATIO
@@ -68,6 +71,20 @@ if MMU_TYPE_QIDI_BOX_1_0
     default 13.6
   config PARAM_GEAR_MICROSTEPS
     default 16
+
+  # Q2 toolhead cutter --------------------
+  if MMU_HAS_TOOLHEAD_CUTTER && TOOLHEAD_TYPE_QIDI_Q2
+    config VAR_CUT_TIP_PIN_LOC_XY
+      default "15, 0.5"
+    config VAR_CUT_TIP_PIN_LOC_COMPRESSED_XY
+      default "-0.5, 0.5"
+    config VAR_CUT_TIP_RETRACT_LENGTH
+      default 15
+    config BOOL_CUT_TIP_SIMPLE_TIP_FORMING
+      default n
+    config VAR_CUT_TIP_PUSHBACK_LENGTH
+      default 0
+  endif
 
   # Speeds ---------------------------------
   config PARAM_GEAR_LOAD_SPEED

--- a/installer/toolheads/Kconfig
+++ b/installer/toolheads/Kconfig
@@ -22,7 +22,7 @@ config MMU_SHARED_TOOLHEAD
   bool
   default n
 
-choice TOOLHEAD_TYPE
+choice CHOICE_TOOLHEAD_TYPE
   prompt "Toolhead"
   default CHOICE_TOOLHEAD_TYPE_OTHER
   help 

--- a/installer/toolheads/Kconfig.qidi_q2
+++ b/installer/toolheads/Kconfig.qidi_q2
@@ -1,0 +1,17 @@
+config TOOLHEAD_TYPE_QIDI_Q2
+  bool "QIDI Q2 Extruder"
+  imply MMU_HAS_SENSOR_EXTRUDER
+  imply MMU_HAS_TOOLHEAD_CUTTER
+
+if TOOLHEAD_TYPE_QIDI_Q2
+  config PARAM_TOOLHEAD_TYPE
+    default "QIDI Q2 Extruder"
+  config PARAM_TOOLHEAD_EXTRUDER_TO_NOZZLE
+    default 72
+  config PARAM_TOOLHEAD_SENSOR_TO_NOZZLE
+    default 62
+  config PARAM_TOOLHEAD_ENTRY_TO_EXTRUDER
+    default 8
+  config PARAM_TOOLHEAD_RESIDUAL_FILAMENT
+    default 2
+endif

--- a/test/installer/test_qidi_box.py
+++ b/test/installer/test_qidi_box.py
@@ -36,6 +36,8 @@ class TestQidiBoxProfile(unittest.TestCase):
             "PARAM_HAS_BYPASS": "0",
             "PARAM_GEAR_ROTATION_DISTANCE": "13.6",
             "PARAM_GEAR_MICROSTEPS": "16",
+            "PARAM_GEAR_GEAR_RATIO": "1:1",
+            "PARAM_TOOLHEAD_TYPE": "QIDI Q2 Extruder",
             "PARAM_GATE_HOMING_ENDSTOP": "mmu_shared_exit",
             "PARAM_GATE_HOMING_MAX": "1500",
             "PARAM_GATE_PRELOAD_ENDSTOP": "none",
@@ -51,6 +53,9 @@ class TestQidiBoxProfile(unittest.TestCase):
 
         self.assertTrue(self.kconfig.is_enabled("BOARD_TYPE_QIDI_BOX_2_0"))
         self.assertFalse(self.kconfig.is_enabled("BOARD_TYPE_OTHER"))
+        self.assertTrue(
+            self.kconfig.is_enabled("TOOLHEAD_TYPE_QIDI_Q2"))
+        self.assertFalse(self.kconfig.is_enabled("CHOICE_TOOLHEAD_TYPE_OTHER"))
 
     def test_path_variation_and_bypass_defaults_can_be_overridden(self):
         with cfg._env(cfg._SINGLE_UNIT_ENV):
@@ -185,11 +190,74 @@ class TestQidiBoxProfile(unittest.TestCase):
         machine = self.rendered["config/base/mmu.cfg"]
         self.assertIn("extruder_switch_pin         : !THR:PA1", machine)
 
-    def test_generic_qidi_q2_toolhead_dimensions_are_preserved(self):
+    def test_qidi_q2_toolhead_dimensions_and_sensor(self):
         machine = self.rendered["config/base/mmu.cfg"]
         self.assertIn("toolhead_extruder_to_nozzle : 72", machine)
         self.assertIn("toolhead_sensor_to_nozzle   : 62", machine)
         self.assertIn("toolhead_entry_to_extruder  : 8", machine)
+        self.assertIn("extruder_switch_pin         : !THR:PA1", machine)
+
+    def test_qidi_q2_implies_cutter_with_tuned_defaults(self):
+        self.assertTrue(self.kconfig.is_enabled("MMU_HAS_TOOLHEAD_CUTTER"))
+        expected = {
+            "VAR_CUT_TIP_PIN_LOC_XY": "15, 0.5",
+            "VAR_CUT_TIP_PIN_LOC_COMPRESSED_XY": "-0.5, 0.5",
+            "VAR_CUT_TIP_RETRACT_LENGTH": "15",
+            "VAR_CUT_TIP_SIMPLE_TIP_FORMING": "False",
+            "VAR_CUT_TIP_PUSHBACK_LENGTH": "0",
+        }
+        for symbol, value in expected.items():
+            with self.subTest(symbol=symbol):
+                self.assertEqual(self.kconfig.get(symbol), value)
+
+    def test_qidi_q2_cutter_can_be_disabled(self):
+        with cfg._env(cfg._SINGLE_UNIT_ENV):
+            without_cutter = cfg._kconfig(
+                "qidi_box_without_cutter",
+                {
+                    "MMU_TYPE_QIDI_BOX_1_0": True,
+                    "MMU_HAS_TOOLHEAD_CUTTER": False,
+                },
+            )
+        self.assertFalse(without_cutter.is_enabled("MMU_HAS_TOOLHEAD_CUTTER"))
+
+    def test_qidi_q2_cutter_defaults_do_not_apply_to_q1(self):
+        with cfg._env(cfg._SINGLE_UNIT_ENV):
+            q1_with_cutter = cfg._kconfig(
+                "qidi_box_q1_with_cutter",
+                {
+                    "MMU_TYPE_QIDI_BOX_1_0": True,
+                    "TOOLHEAD_TYPE_QIDI_Q1_PRO": True,
+                    "MMU_HAS_TOOLHEAD_CUTTER": True,
+                },
+            )
+        self.assertEqual(q1_with_cutter.get("VAR_CUT_TIP_PIN_LOC_XY"),
+                         "14, 250")
+
+    def test_qidi_q2_cutter_defaults_can_be_overridden(self):
+        with cfg._env(cfg._SINGLE_UNIT_ENV):
+            customized = cfg._kconfig(
+                "qidi_box_custom_cutter",
+                {
+                    "MMU_TYPE_QIDI_BOX_1_0": True,
+                    "VAR_CUT_TIP_PIN_LOC_XY": "20, 1",
+                    "VAR_CUT_TIP_PIN_LOC_COMPRESSED_XY": "1, 1",
+                    "VAR_CUT_TIP_RETRACT_LENGTH": 12,
+                    "BOOL_CUT_TIP_SIMPLE_TIP_FORMING": True,
+                    "VAR_CUT_TIP_PUSHBACK_LENGTH": 2,
+                },
+            )
+
+        expected = {
+            "VAR_CUT_TIP_PIN_LOC_XY": "20, 1",
+            "VAR_CUT_TIP_PIN_LOC_COMPRESSED_XY": "1, 1",
+            "VAR_CUT_TIP_RETRACT_LENGTH": "12",
+            "VAR_CUT_TIP_SIMPLE_TIP_FORMING": "True",
+            "VAR_CUT_TIP_PUSHBACK_LENGTH": "2",
+        }
+        for symbol, value in expected.items():
+            with self.subTest(symbol=symbol):
+                self.assertEqual(customized.get(symbol), value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a QIDI Q2 toolhead profile with the known toolhead dimensions and extruder sensor capability
- default QIDI Box configurations to the Q2 toolhead and imply its toolhead cutter
- apply Q2-specific cutter defaults while keeping them user-overridable
- name the toolhead choice so menuconfig reset works without renaming existing choice-member symbols
- validate the existing QIDI Box gear rotation distance, microsteps, and 1:1 gear ratio

## Testing
- `PYTHONPATH=installer/lib/kconfiglib ./venv/bin/python -m unittest -v test.installer.test_qidi_box` (12 tests passed)