### PR TITLE
Add preload sequence details to MMU status

### DIFF
--- a/extras/mmu/commands/mmu_status.py
+++ b/extras/mmu/commands/mmu_status.py
@@ -134,8 +134,45 @@ class MmuStatusCommand(BaseCommand):
             self.toolchange_retract = mmu.toolchange_retract
             self.filament_remaining = mmu_unit.extruder_wrapper.filament_remaining
             self.buffer_range = mmu_unit.buffer.buffer_range if mmu_unit.has_buffer() else 0.
+            unit_suffix = f" (UNIT {mmu_unit.unit_index})" if mmu.mmu_machine.num_units > 1 else ""
 
-            lines.append("\n\nLOAD SEQUENCE:")
+            lines.append(f"\n\nPRELOAD SEQUENCE{unit_suffix}:")
+
+            # Gate preloading ---------------------------------------------------
+
+            preload = mmu._preload_profile()
+            if preload.endstop == SENSOR_GATE_NONE:
+                lines.append(
+                    "\n- Filament preloads with one fixed forward move of "
+                    f"{self._f_calc('gate_preload_homing_max')}; no endstop is used and "
+                    "filament presence cannot be verified"
+                )
+                lines.append("\n- No separate preload parking move is performed")
+            else:
+                preload_endstop = (
+                    "ENCODER motion detection"
+                    if preload.endstop == SENSOR_ENCODER
+                    else f"{preload.endstop.upper()} sensor"
+                )
+                attempts = f", with up to {preload.attempts} attempts" if preload.attempts > 1 else ""
+                lines.append(
+                    "\n- Filament preloads by homing a maximum of "
+                    f"{self._f_calc('gate_preload_homing_max')} to {preload_endstop}{attempts}"
+                )
+                if preload.endstop == SENSOR_ENCODER:
+                    lines.append(
+                        "\n- Filament reverse-homes until encoder motion clears, then parks by moving "
+                        f"{self._f_calc('gate_preload_parking_distance')}"
+                    )
+                else:
+                    lines.append(
+                        "\n- Filament is parked by moving "
+                        f"{self._f_calc('gate_preload_parking_distance')} from the preload endstop"
+                    )
+
+            self._append_preload_rfid_summary(lines, mmu_unit, preload)
+
+            lines.append(f"\n\nLOAD SEQUENCE{unit_suffix}:")
 
             # Gate loading -------------------------------------------------------
 
@@ -287,7 +324,7 @@ class MmuStatusCommand(BaseCommand):
                     "to neutralize tension"
                 )
 
-            lines.append("\n\nUNLOAD SEQUENCE:")
+            lines.append(f"\n\nUNLOAD SEQUENCE{unit_suffix}:")
 
             # Tip forming --------------------------------------------------------
 
@@ -401,6 +438,69 @@ class MmuStatusCommand(BaseCommand):
 
         # Always warn if not fully calibrated or needs recovery
         mmu.report_necessary_recovery(use_autotune=False)
+
+
+    def _append_preload_rfid_summary(self, lines, mmu_unit, preload):
+        """Describe the RFID/NFC paths which can contribute to a preload."""
+        first, last = mmu_unit.gate_bounds()
+        gates = list(range(first, last + 1))
+        manager = mmu_unit.nfc_manager
+
+        configured = []
+        enabled = []
+        if manager is not None:
+            configured = [gate for gate in gates if manager.has_gate_nfc_reader(gate)]
+            enabled = [gate for gate in configured if manager.is_enabled(gate=gate)]
+
+        if preload.endstop in (SENSOR_GATE_NONE, SENSOR_ENCODER):
+            reason = (
+                "fixed preload has no endstop"
+                if preload.endstop == SENSOR_GATE_NONE
+                else "encoder homing cannot be combined with an NFC endstop"
+            )
+            lines.append(f"\n- RFID/NFC scanning during preload is OFF ({reason})")
+        elif enabled:
+            gate_text = self._gate_list(enabled)
+            neg, pos = preload.jog_scan_window if len(preload.jog_scan_window) == 2 else (0., 0.)
+            lines.append(
+                f"\n- RFID/NFC scanning during preload is ON for {gate_text}: tags are detected "
+                f"during the homing move; after the preload endstop the forward scan range is "
+                f"0.0mm to +{max(0., pos):.1f}mm (configured endstop-relative window "
+                f"{neg:+.1f}mm to {pos:+.1f}mm)"
+            )
+            disabled = [gate for gate in configured if gate not in enabled]
+            if disabled:
+                lines.append(f"; readers on {self._gate_list(disabled)} are disabled")
+        elif configured:
+            lines.append(
+                "\n- RFID/NFC scanning during preload is OFF; per-gate readers are configured "
+                f"for {self._gate_list(configured)} but disabled"
+            )
+        else:
+            lines.append("\n- RFID/NFC scanning during preload is OFF; no per-gate readers are configured")
+
+        if manager is not None and manager.has_shared_nfc_reader():
+            state = "ON" if manager.is_enabled(shared=True) else "OFF"
+            lines.append(
+                f"\n- Shared RFID/NFC reader is {state}; it assigns a presented tag before "
+                "preload and does not scan during preload motion"
+            )
+
+
+    @staticmethod
+    def _gate_list(gates):
+        """Compact a sorted gate list into user-facing ranges."""
+        ranges = []
+        start = previous = gates[0]
+        for gate in gates[1:]:
+            if gate == previous + 1:
+                previous = gate
+                continue
+            ranges.append((start, previous))
+            start = previous = gate
+        ranges.append((start, previous))
+        values = [str(start) if start == end else f"{start}-{end}" for start, end in ranges]
+        return "gate " + values[0] if len(values) == 1 and "-" not in values[0] else "gates " + ", ".join(values)
 
 
     def _f_calc(self, formula):

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -2471,8 +2471,13 @@ class TestTheDefaultProfile(unittest.TestCase):
         """
         for unit in self.console.hh.mmu.mmu_machine.units:
             self.console._dispatch('MMU_SELECT GATE=%d' % unit.first_gate)
+            del self.console.sink[:]
             with contextlib.redirect_stdout(io.StringIO()):
                 self.console._dispatch('MMU_STATUS SHOWCONFIG=1')
+            shown = '\n'.join(self.console.sink)
+            self.assertIn('PRELOAD SEQUENCE (UNIT %d):' % unit.unit_index, shown)
+            self.assertIn('LOAD SEQUENCE (UNIT %d):' % unit.unit_index, shown)
+            self.assertIn('UNLOAD SEQUENCE (UNIT %d):' % unit.unit_index, shown)
 
     def _encoder_line(self):
         del self.console.sink[:]

--- a/test/test_mmu_nfc.py
+++ b/test/test_mmu_nfc.py
@@ -90,6 +90,31 @@ class TestPerGateNfcBoots(unittest.TestCase):
         for i in range(4):
             self.assertIn('mmu_nfc_reader unit0_nfc%d' % i, self.hh.printer.objects)
 
+    def test_showconfig_describes_preload_motion_endstop_and_nfc_range(self):
+        del self.hh.console[:]
+        self.hh.run_gcode('MMU_STATUS SHOWCONFIG=1')
+
+        shown = '\n'.join(str(msg) for msg in self.hh.console)
+        self.assertIn('PRELOAD SEQUENCE:', shown)
+        self.assertIn('gate_preload_homing_max', shown)
+        self.assertIn('MMU_EXIT sensor', shown)
+        self.assertIn('gate_preload_parking_distance', shown)
+        self.assertIn('RFID/NFC scanning during preload is ON for gates 0-3', shown)
+        self.assertIn('forward scan range is 0.0mm to +50.0mm', shown)
+        self.assertIn('configured endstop-relative window -50.0mm to +50.0mm', shown)
+
+    def test_showconfig_identifies_a_disabled_preload_reader(self):
+        mgr = self.unit().nfc_manager
+        mgr.gate_enabled[0] = False
+        try:
+            del self.hh.console[:]
+            self.hh.run_gcode('MMU_STATUS SHOWCONFIG=1')
+            shown = '\n'.join(str(msg) for msg in self.hh.console)
+            self.assertIn('RFID/NFC scanning during preload is ON for gates 1-3', shown)
+            self.assertIn('readers on gate 0 are disabled', shown)
+        finally:
+            mgr.gate_enabled[0] = True
+
     def test_defaults_inheritance_is_currently_inert(self):
         """
         Documents a KNOWN LIMITATION rather than asserting desired behaviour.
@@ -213,6 +238,19 @@ class TestCommonReaderWiring(unittest.TestCase):
             self.assertEqual(mgr.shared_reader.reader_type, 'rc522')
             self.assertTrue(all(r is None for r in mgr.gate_readers),
                             'a common reader must not populate per-gate slots')
+        finally:
+            hh.close()
+
+    def test_showconfig_distinguishes_common_reader_from_motion_scanning(self):
+        hh = session('nfc_single')
+        try:
+            hh.boot()
+            del hh.console[:]
+            hh.run_gcode('MMU_STATUS SHOWCONFIG=1')
+            shown = '\n'.join(str(msg) for msg in hh.console)
+            self.assertIn('RFID/NFC scanning during preload is OFF; no per-gate readers', shown)
+            self.assertIn('Shared RFID/NFC reader is ON', shown)
+            self.assertIn('does not scan during preload motion', shown)
         finally:
             hh.close()
 


### PR DESCRIPTION
## Summary
- add a PRELOAD SEQUENCE section to MMU_STATUS SHOWCONFIG=1
- report preload motion, endstop, parking, retries, and RFID/NFC scan availability and range
- distinguish shared readers from per-gate motion scanning
- suffix sequence headings with the active unit on multi-unit machines

## Testing
- venv/bin/python -m unittest test.test_mmu_nfc
- venv/bin/python -m unittest test.test_mmu_encoder.TestClogDetectionLength.test_showconfig_quotes_the_effective_clog_length test.test_mmu_console.TestTheDefaultProfile.test_showconfig_works_on_a_gate_of_every_unit
- python3 -m py_compile extras/mmu/commands/mmu_status.py
- git diff --check