### PR TITLE
Align proportional sensor display

### DIFF
--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -1023,7 +1023,7 @@ class MmuController(MmuFilamentMovement):
                 sf_char = "T"
             if sf_state == "neutral":
                 if self.sensor_manager.has_sensor(SENSOR_PROPORTIONAL) and sf_value is not None:
-                    return f"[{f'{sf_value:.1f}'.center(5)}]"
+                    return f"[{f'{sf_value: .1f}'.ljust(5)}]"
                 sf_char = "N"
 
             if c_sensor:

--- a/test/filament_display_review.py
+++ b/test/filament_display_review.py
@@ -816,6 +816,24 @@ class TestFilamentDisplayGateArea(unittest.TestCase):
 class TestFilamentDisplayBufferAndSyncFeedback(unittest.TestCase):
     """Tension/compression/proportional sensor combinations feed the buffer_segment() bracket."""
 
+    def test_proportional_sensor_keeps_decimal_aligned(self):
+        sensors = build_sensors(SENSOR_ENCODER, "no_optional_sensors")
+        sensors[SENSOR_PROPORTIONAL] = True
+
+        def visual_for(bias):
+            return render("", FilamentDisplayState(
+                pos=FILAMENT_POS_IN_BOWDEN,
+                gate_homing_endstop=SENSOR_ENCODER,
+                sensors=sensors,
+                has_encoder=True,
+                has_buffer=True,
+                sync_feedback_state="neutral",
+                sync_feedback_bias_modelled=bias,
+            ), verbose=False)
+
+        self.assertIn("[-0.4 ]", visual_for(-0.4))
+        self.assertIn("[ 0.4 ]", visual_for(0.4))
+
     def test_buffer_matrix(self):
         print()
         for style_name, is_bold in BOLD_STYLES:


### PR DESCRIPTION
## Summary
- keep the decimal point aligned for positive and negative proportional sensor readings
- reserve a leading sign column and place spare padding after the value
- add regression coverage for both display forms

## Test
- python3 -m unittest test.filament_display_review.TestFilamentDisplayBufferAndSyncFeedback.test_proportional_sensor_keeps_decimal_aligned