### PR TITLE
Keep conditional macro defaults active

### DIFF
--- a/installer/macro_vars/Kconfig.blobifier
+++ b/installer/macro_vars/Kconfig.blobifier
@@ -1,5 +1,5 @@
 menu "Blobifier            (_BLOBIFIER)"
-  depends on MMU_HAS_BLOBIFIER
+  visible if MMU_HAS_BLOBIFIER
   forceshow
   help
     Blobifier purging system configuration variables.

--- a/installer/macro_vars/Kconfig.client
+++ b/installer/macro_vars/Kconfig.client
@@ -1,5 +1,5 @@
 menu "Client macros        (_MMU_CLIENT)"
-  depends on INSTALL_CLIENT_MACROS
+  visible if INSTALL_CLIENT_MACROS
   forceshow
   help
     Happy Hare client macro configuration variables.

--- a/installer/macro_vars/Kconfig.cut_tip
+++ b/installer/macro_vars/Kconfig.cut_tip
@@ -1,5 +1,5 @@
 menu "Toolhead tip cutting (_MMU_CUT_TIP)"
-  depends on MMU_HAS_TOOLHEAD_CUTTER
+  visible if MMU_HAS_TOOLHEAD_CUTTER
   forceshow
   help
     Happy Hare toolhead tip cutting macro configuration variables.

--- a/installer/macro_vars/Kconfig.servo_cutter
+++ b/installer/macro_vars/Kconfig.servo_cutter
@@ -1,5 +1,5 @@
 menu "Servo cutter at MMU  (_MMU_SERVO_CUTTER)"
-  depends on  MMU_HAS_SERVO_CUTTER
+  visible if MMU_HAS_SERVO_CUTTER
   forceshow
   help
     Happy Hare servo filament cutting macro configuration variables.

--- a/test/test_mmu_config.py
+++ b/test/test_mmu_config.py
@@ -171,6 +171,31 @@ class TestBoxTurtleRender(unittest.TestCase):
         self.assertIn('max_extrude_only_distance', extruder)       # from the template
 
 
+class TestConditionalMacroDefaults(unittest.TestCase):
+
+    def test_hidden_feature_menus_keep_rendering_defaults_active(self):
+        """Menu visibility must not turn required Jinja values into empty strings."""
+        with cfg._env(cfg._SINGLE_UNIT_ENV):
+            kc = cfg._kconfig('conditional_macro_defaults', {
+                'INSTALL_CLIENT_MACROS': False,
+                'MMU_HAS_TOOLHEAD_CUTTER': False,
+                'MMU_HAS_BLOBIFIER': False,
+                'MMU_HAS_SERVO_CUTTER': False,
+            })
+
+        expected = {
+            'VAR_CLIENT_UNLOAD_TOOL_ON_CANCEL': 'False',
+            'VAR_CUT_TIP_RESTORE_POSITION': 'False',
+            'VAR_CUT_TIP_BLADE_POS': '37.5',
+            'VAR_BLOBIFIER_PURGE_SPD': '400',
+            'VAR_SERVO_CUTTER_SERVO_DURATION': '1.5',
+        }
+        for name, value in expected.items():
+            with self.subTest(symbol=name):
+                self.assertEqual(kc.syms[name].str_value, value)
+                self.assertTrue(kc.syms[name].config_string)
+
+
 class TestMenuconfigMacroStrings(unittest.TestCase):
 
     def _pre_unload_value(self, configured, profile_name):


### PR DESCRIPTION
## Summary
- use `visible if` for feature-gated macro-variable menus
- keep child defaults active when their menu is hidden
- add regression coverage for disabled feature menus and serialized defaults

## Testing
- `./venv/bin/python -m unittest test.test_mmu_config` (30 tests pass)