### PR TITLE
Add installer configuration recovery and v3 migration flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,9 @@ strip_prefix = $(patsubst $(1)%,%,$(2))
 backup_ext  := .old-$(shell date '+%Y%m%d-%H%M%S')
 backup_name = $(addsuffix $(backup_ext),$(1))
 backup = \
-	if [ -e "$(1)" ] && [ ! -e "$(call backup_name,$(1))" ]; then \
+	if [ -n "$(2)" ]; then \
+	  echo "$(C_INFO)Skipping backup of '$(1)' because recovery already preserved it$(C_OFF)"; \
+	elif [ -e "$(1)" ] && [ ! -e "$(call backup_name,$(1))" ]; then \
 	  echo "$(C_INFO)Making a backup of '$(1)' to '$(notdir $(call backup_name,$(1)))'$(C_OFF)"; \
 	  $(SUDO)cp -a "$(1)" "$(call backup_name,$(1))"; \
 	fi
@@ -405,7 +407,7 @@ $(call backup_name,$(KLIPPER_CONFIG_HOME)/%): $(OUT)/% | build
 
 # Recipe to backup Happy-Hare configs before installing
 $(call backup_name,$(KLIPPER_CONFIG_HOME)/mmu): $(addprefix $(OUT)/mmu/, $(hh_config_files)) | build
-	$(Q)$(call backup,$(basename $@))
+	$(Q)$(call backup,$(basename $@),$(F_NO_MMU_BACKUP))
 
 $(install_targets): build | python_deps
 

--- a/install.sh
+++ b/install.sh
@@ -798,7 +798,7 @@ else
   kalico="${HOME}/klipper/klippy/__init__.py"
 fi
 
-if [ -f ${kalico} ]; then
+if [ -f "${kalico}" ]; then
     if grep -q '^APP_NAME[[:space:]]*=[[:space:]]*"Kalico"' \
         "${kalico}" 2>/dev/null; then
         if [ "${F_OVERRIDE_CHECKS}" = "y" ]; then

--- a/install.sh
+++ b/install.sh
@@ -376,7 +376,9 @@ offer_v3_v4_choice() {
         echo "${C_INFO}Switching to the 'v3' branch...${C_OFF}"
         export BRANCH=v3
         "$SCRIPT_DIR/installer/self_update.sh" || exit 1
-        F_SKIP_UPDATE=force exec "$0" "$@"
+        # The branch switch above already fetched and pulled v3. Its installer uses
+        # SKIP_UPDATE (rather than v4's F_SKIP_UPDATE) to suppress a redundant update.
+        SKIP_UPDATE=YES F_SKIP_UPDATE=force exec "$0" "$@"
     else
         echo "${C_WARNING}Proceeding with the v4 upgrade. Your v3 'mmu' config directory will be${C_OFF}"
         echo "${C_WARNING}renamed to 'mmu.V3' for reference - nothing is deleted.${C_OFF}"

--- a/install.sh
+++ b/install.sh
@@ -335,7 +335,7 @@ v3_detected() {
     v3_cfg="$(guess_klipper_config_home)/mmu/base/mmu_parameters.cfg"
     [ ! -e "${guessed_kconfig}" ] \
         && [ -f "${v3_cfg}" ] \
-        && grep -qE '^happy_hare_version:[[:space:]]*3\.' "${v3_cfg}"
+        && grep -qE '^[[:space:]]*happy_hare_version[[:space:]]*[:=][[:space:]]*3\.' "${v3_cfg}"
 }
 
 # The v3 -> v4 choice ("blue pill" stay on v3 / "red pill" upgrade to v4) has to be

--- a/install.sh
+++ b/install.sh
@@ -166,53 +166,90 @@ recover_backup_config() {
     fi
 }
 
-# Recover from the newest eligible MMU backup. Backup names contain sortable
-# timestamps, so the final matching directory is the newest one.
+# Format the timestamp embedded in standard mmu.old-YYYYMMDD-HHMMSS backup names.
+format_recovery_choice() {
+    backup_name=$(basename "$1")
+    if [ "$2" = current ]; then
+        echo "${backup_name} (current config)"
+        return 0
+    fi
+
+    backup_timestamp=$(printf '%s\n' "${backup_name}" | sed -n \
+        's/^mmu\.old-\([0-9][0-9][0-9][0-9]\)\([0-9][0-9]\)\([0-9][0-9]\)-\([0-9][0-9]\)\([0-9][0-9]\)\([0-9][0-9]\)$/\1-\2-\3 \4:\5:\6/p')
+    if [ -n "${backup_timestamp}" ]; then
+        echo "${backup_name} (${backup_timestamp})"
+    else
+        echo "${backup_name}"
+    fi
+}
+
+# Recover entry 1 from the same ordering shown by --prev: the current installed
+# config when available, otherwise the newest timestamped backup.
 recover_last_config() {
     config_home=$(guess_klipper_config_home)
-    last_backup=
+    current_config="${config_home}/mmu"
 
+    if [ -d "${current_config}" ] && [ -f "${current_config}/.mmu_config" ]; then
+        recover_backup_config "${current_config}"
+        return 0
+    fi
+
+    last_backup=
     for backup_dir in "${config_home}"/mmu*; do
         [ -d "${backup_dir}" ] || continue
-        [ "${backup_dir}" != "${config_home}/mmu" ] || continue
+        [ "${backup_dir}" != "${current_config}" ] || continue
         [ -f "${backup_dir}/.mmu_config" ] || continue
         last_backup=${backup_dir}
     done
 
     if [ -z "${last_backup}" ]; then
-        echo "${C_WARNING}No MMU backup containing .mmu_config found in '${config_home}'${C_OFF}"
+        echo "${C_WARNING}No MMU configuration containing .mmu_config found in '${config_home}'${C_OFF}"
         return 0
     fi
 
     recover_backup_config "${last_backup}"
 }
 
-# List every eligible MMU backup and let the user choose which one to recover.
+# List the current config first, when available, followed by every eligible backup
+# in reverse lexical order. Standard backup timestamps make that newest-to-oldest.
 recover_previous_config() {
     config_home=$(guess_klipper_config_home)
-    backup_count=0
+    current_config="${config_home}/mmu"
 
-    echo "${C_INFO}Available MMU configuration backups:${C_OFF}"
+    # Build the ordered choice list in this function's positional parameters.
+    # Prepending each glob match reverses the normal oldest-to-newest ordering.
+    set --
     for backup_dir in "${config_home}"/mmu*; do
         [ -d "${backup_dir}" ] || continue
-        [ "${backup_dir}" != "${config_home}/mmu" ] || continue
+        [ "${backup_dir}" != "${current_config}" ] || continue
         [ -f "${backup_dir}/.mmu_config" ] || continue
+        set -- "${backup_dir}" "$@"
+    done
+    if [ -d "${current_config}" ] && [ -f "${current_config}/.mmu_config" ]; then
+        set -- "${current_config}" "$@"
+    fi
+
+    echo
+    echo "${C_INFO}Available MMU configuration backups:${C_OFF}"
+    backup_count=0
+    for backup_dir in "$@"; do
         backup_count=$((backup_count + 1))
-        echo "  ${backup_count}) $(basename "${backup_dir}")"
+        if [ "${backup_dir}" = "${current_config}" ]; then
+            echo "  ${backup_count}) $(format_recovery_choice "${backup_dir}" current)"
+        else
+            echo "  ${backup_count}) $(format_recovery_choice "${backup_dir}" backup)"
+        fi
     done
 
     if [ "${backup_count}" -eq 0 ]; then
-        echo "${C_WARNING}No MMU backup containing .mmu_config found in '${config_home}'${C_OFF}"
+        echo "${C_WARNING}No MMU configuration containing .mmu_config found in '${config_home}'${C_OFF}"
         return 0
     fi
 
     echo
-    selected=$(prompt_n "${backup_count}" "Choose a backup")
+    selected=$(prompt_n "${backup_count}" "Choose backup to restore from")
     current=0
-    for backup_dir in "${config_home}"/mmu*; do
-        [ -d "${backup_dir}" ] || continue
-        [ "${backup_dir}" != "${config_home}/mmu" ] || continue
-        [ -f "${backup_dir}/.mmu_config" ] || continue
+    for backup_dir in "$@"; do
         current=$((current + 1))
         if [ "${current}" -eq "${selected}" ]; then
             echo

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env sh
 #
-# Happy Hare MMU Software
+# Happy Hare v4 MMU Software
 #
 # Installer / Updater launch script with familiar options
 #
-# Carefully written to only use options that are widely available
+# Carefully written to only use shell options that are widely available
 # Please report any incompatibility via github issue
 #
 

--- a/install.sh
+++ b/install.sh
@@ -593,9 +593,15 @@ if { [ "${F_RECOVER_LAST}" ] || [ "${F_RECOVER_PREVIOUS}" ]; } && [ "${F_UNINSTA
     exit 1
 fi
 
+# Settle v3 vs v4 before recovery, self-update, or installation work. Detection
+# only inspects the existing v3 files and does not source a .mmu_config file.
+if [ "${F_SKIP_UPDATE}" != "force" ] && [ ! "${F_YES}" ] && v3_detected; then
+    offer_v3_v4_choice
+fi
+
 # Recovery must remain in this early preflight position. In particular, it must
-# run before self-update, v3 detection, KCONFIG_CONFIG setup, or any code that
-# sources a .mmu_config file. Only option, platform, and root-safety checks precede it.
+# run before self-update, KCONFIG_CONFIG setup, or any code that sources a
+# .mmu_config file. Only option/platform/root checks and the v3 choice precede it.
 if { [ "${F_RECOVER_LAST}" ] || [ "${F_RECOVER_PREVIOUS}" ]; } && [ ! "${F_CONFIG_RECOVERED}" ]; then
     if [ "${F_RECOVER_PREVIOUS}" ]; then
         recover_previous_config
@@ -603,13 +609,6 @@ if { [ "${F_RECOVER_LAST}" ] || [ "${F_RECOVER_PREVIOUS}" ]; } && [ ! "${F_CONFI
         recover_last_config
     fi
     export F_CONFIG_RECOVERED=y
-fi
-
-# Settle v3 vs v4 before self-update or installation work (see
-# offer_v3_v4_choice for why). Non-interactive callers keep the checkout's
-# current branch; choosing a migration policy requires a human decision.
-if [ "${F_SKIP_UPDATE}" != "force" ] && [ ! "${F_YES}" ] && v3_detected; then
-    offer_v3_v4_choice
 fi
 
 # Handle git self update or branch change

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@
 # Exit immediately on error (really important to catch menuconfig errors / non-saves / aborts)
 set -e
 
-SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT_DIR=${INSTALL_SH_SCRIPT_DIR:-$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)}
 SCRIPT_NAME=$(basename "$0")
 
 # Get current HH version from the mmu_constants.py file
@@ -39,17 +39,19 @@ usage() {
     echo "${C_INFO}[config_file]${C_OFF} is optional, if not specified the default config filename (.mmu_config) will be used."
     echo "  -i for interactive install (open menuconfig)"
     echo "  -u, -d for uninstall"
-    echo "  -y, --yes answer yes to all y/n prompts"
-    echo "  -l, --last recover .mmu_config files from the latest MMU backup"
-    echo "  -p, --prev choose an MMU backup and recover its .mmu_config files"
-    echo "  -f to just restore klipper/moonraker symlinks (recover after hard klipper update)"
-    echo "  -z skip github update check (nullifies -b <branch>)"
-    echo "  -s to skip restart of services"
     echo "  -b <branch> to switch to specified feature branch (sticky)"
     echo "  -n to specify a multiple MMU unit setup"
     echo "  -k <dir> non-default klipper home directory"
     echo "  -c <dir> non-default klipper config directory"
     echo "  -m <dir> non-default moonraker home directory"
+    echo "  -p, --prev choose an MMU backup and recover its configuration"
+    echo
+    echo "  Advanced:"
+    echo "  -y, --yes automatically answer yes to all y/n prompts"
+    echo "  -l, --last recover .mmu_config files from the last config backup"
+    echo "  -f to just restore klipper/moonraker symlinks (recover after hard klipper update)"
+    echo "  -z skip github update check (nullifies -b <branch>)"
+    echo "  -s to skip restart of services"
     # TODO: Repetier-Server stub support
     # echo "  -R specify Repetier-Server <stub> to override printer.cfg and klipper.service names"
     echo "  -a <name> to specify alternative klipper-service-name when installed with Kiauh"
@@ -130,10 +132,15 @@ time_elapsed() {
     echo
 }
 
-# Best-effort guess at the printer config directory, used only to detect a v3 install
-# before self-update/uninstall/menuconfig have touched anything. Kconfig resolves this
-# authoritatively later in the script; this just needs to be good enough for the
-# one-time upgrade prompt below.
+
+##################################
+##### Config Backup/Recovery #####
+##################################
+
+# Best-effort guess at the printer config directory for early recovery and v3 checks,
+# before self-update/menuconfig have touched anything. Kconfig resolves this
+# authoritatively later in the script; this just needs to be good enough for these
+# preflight operations.
 guess_klipper_config_home() {
     if [ -n "${TESTDIR}" ]; then
         echo "${TESTDIR}/printer_data/config"
@@ -146,24 +153,63 @@ guess_klipper_config_home() {
     fi
 }
 
-# Copy the base and any per-unit Kconfig files from a selected backup. Files
-# ending in .old are prior Kconfig snapshots rather than the saved configuration.
-recover_backup_config() {
-    selected_backup=$1
+# Copy the base and any per-unit Kconfig files from the restored MMU directory
+# into Happy-Hare. Files ending in .old are prior Kconfig snapshots.
+copy_recovered_kconfigs() {
+    restored_config=$1
+    recovery_destination=${SCRIPT_DIR}
+    if [ -n "${TESTDIR}" ]; then
+        recovery_destination=${TESTDIR}
+        mkdir -p "${recovery_destination}"
+    fi
+
     recovered=n
-    for config_file in "${selected_backup}"/.mmu_config*; do
+    for config_file in "${restored_config}"/.mmu_config*; do
         [ -f "${config_file}" ] || continue
         case "${config_file}" in
         *.old) continue ;;
         esac
-        echo "${C_INFO}Recovering '$(basename "${config_file}")' from '$(basename "${selected_backup}")'${C_OFF}"
-        cp -p -- "${config_file}" "${SCRIPT_DIR}/$(basename "${config_file}")"
+        echo "${C_INFO}Recovering '$(basename "${config_file}")' from '$(basename "${restored_config}")'${C_OFF}"
+        cp -p "${config_file}" "${recovery_destination}/$(basename "${config_file}")"
         recovered=y
     done
 
     if [ "${recovered}" = n ]; then
-        echo "${C_WARNING}No recoverable .mmu_config files found in '${selected_backup}'${C_OFF}"
+        echo "${C_WARNING}No recoverable .mmu_config files found in '${restored_config}'${C_OFF}"
     fi
+}
+
+# Preserve the current MMU directory with the installer's standard timestamped
+# backup naming, restore the selected directory wholesale, then recover its
+# active Kconfig files into Happy-Hare before normal install processing begins.
+restore_mmu_config() {
+    selected_config=$1
+    config_home=$(guess_klipper_config_home)
+    current_config="${config_home}/mmu"
+
+    # The installed config is already in the desired location. Only recover its
+    # Kconfig files into Happy-Hare; the normal install will make its usual backup.
+    if [ "${selected_config}" = "${current_config}" ]; then
+        copy_recovered_kconfigs "${current_config}"
+        return 0
+    fi
+
+    if [ -e "${current_config}" ]; then
+        backup_base="${config_home}/mmu.old-$(date +%Y%m%d-%H%M%S)"
+        current_backup=${backup_base}
+        backup_suffix=0
+        while [ -e "${current_backup}" ]; do
+            backup_suffix=$((backup_suffix + 1))
+            current_backup="${backup_base}-${backup_suffix}"
+        done
+
+        echo "${C_INFO}Backing up current MMU config to '$(basename "${current_backup}")'${C_OFF}"
+        mv "${current_config}" "${current_backup}"
+    fi
+
+    echo "${C_INFO}Restoring MMU config from '$(basename "${selected_config}")'${C_OFF}"
+    cp -R "${selected_config}" "${current_config}"
+    copy_recovered_kconfigs "${current_config}"
 }
 
 # Format the timestamp embedded in standard mmu.old-YYYYMMDD-HHMMSS backup names.
@@ -190,7 +236,7 @@ recover_last_config() {
     current_config="${config_home}/mmu"
 
     if [ -d "${current_config}" ] && [ -f "${current_config}/.mmu_config" ]; then
-        recover_backup_config "${current_config}"
+        restore_mmu_config "${current_config}"
         return 0
     fi
 
@@ -207,7 +253,7 @@ recover_last_config() {
         return 0
     fi
 
-    recover_backup_config "${last_backup}"
+    restore_mmu_config "${last_backup}"
 }
 
 # List the current config first, when available, followed by every eligible backup
@@ -253,7 +299,7 @@ recover_previous_config() {
         current=$((current + 1))
         if [ "${current}" -eq "${selected}" ]; then
             echo
-            recover_backup_config "${backup_dir}"
+            restore_mmu_config "${backup_dir}"
             return 0
         fi
     done
@@ -476,6 +522,12 @@ enforce_root_policy() {
     esac
 }
 
+# Unit tests source the real installer functions, then exercise them against
+# temporary filesystem fixtures without entering the installer main routine.
+if [ "${INSTALL_SH_SOURCE_ONLY:-}" = y ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
 
 # Convert long options to short options
 for arg in "$@"; do
@@ -541,6 +593,9 @@ if { [ "${F_RECOVER_LAST}" ] || [ "${F_RECOVER_PREVIOUS}" ]; } && [ "${F_UNINSTA
     exit 1
 fi
 
+# Recovery must remain in this early preflight position. In particular, it must
+# run before self-update, v3 detection, KCONFIG_CONFIG setup, or any code that
+# sources a .mmu_config file. Only option, platform, and root-safety checks precede it.
 if { [ "${F_RECOVER_LAST}" ] || [ "${F_RECOVER_PREVIOUS}" ]; } && [ ! "${F_CONFIG_RECOVERED}" ]; then
     if [ "${F_RECOVER_PREVIOUS}" ]; then
         recover_previous_config

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ usage() {
     echo "  -k <dir> non-default klipper home directory"
     echo "  -c <dir> non-default klipper config directory"
     echo "  -m <dir> non-default moonraker home directory"
-    echo "  -p, --prev choose an MMU backup and recover its configuration"
+    echo "  -p, --prev choose a MMU backup and recover its configuration"
     echo
     echo "  Advanced:"
     echo "  -y, --yes automatically answer yes to all y/n prompts"
@@ -210,6 +210,7 @@ restore_mmu_config() {
     echo "${C_INFO}Restoring MMU config from '$(basename "${selected_config}")'${C_OFF}"
     cp -R "${selected_config}" "${current_config}"
     copy_recovered_kconfigs "${current_config}"
+    export F_NO_MMU_BACKUP=y
 }
 
 # Format the timestamp embedded in standard mmu.old-YYYYMMDD-HHMMSS backup names.
@@ -595,7 +596,7 @@ fi
 
 # Settle v3 vs v4 before recovery, self-update, or installation work. Detection
 # only inspects the existing v3 files and does not source a .mmu_config file.
-if [ "${F_SKIP_UPDATE}" != "force" ] && [ ! "${F_YES}" ] && v3_detected; then
+if [ "${F_SKIP_UPDATE}" != "force" ] && v3_detected; then
     offer_v3_v4_choice
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -30,15 +30,18 @@ usage() {
     USAGE="Usage: $0"
     SPACE=$(echo "${USAGE}" | tr "[:print:]" " ")
     echo "${C_INFO}"
-    echo "${USAGE} [-i] [-u] [-d] [-z] [-s] [-t] [-r]"
+    echo "${USAGE} [-i] [-u] [-d] [-y] [-l] [-p] [-z] [-s] [-t] [-r]"
     echo "${SPACE} [-b <branch>]"
     echo "${SPACE} [-k <klipper_home_dir>] [-c <klipper_config_dir>] [-m <moonraker_home_dir>]"
-    echo "${SPACE} [-a <kiauh_alternate_klipper>] [config_file]" # [-p <repetier_server stub>]"
+    echo "${SPACE} [-a <kiauh_alternate_klipper>] [config_file]"
     echo "${C_OFF}"
     echo "${C_INFO}(no flags for safe re-install / upgrade)${C_OFF}"
     echo "${C_INFO}[config_file]${C_OFF} is optional, if not specified the default config filename (.mmu_config) will be used."
     echo "  -i for interactive install (open menuconfig)"
     echo "  -u, -d for uninstall"
+    echo "  -y, --yes answer yes to all y/n prompts"
+    echo "  -l, --last recover .mmu_config files from the latest MMU backup"
+    echo "  -p, --prev choose an MMU backup and recover its .mmu_config files"
     echo "  -f to just restore klipper/moonraker symlinks (recover after hard klipper update)"
     echo "  -z skip github update check (nullifies -b <branch>)"
     echo "  -s to skip restart of services"
@@ -48,7 +51,7 @@ usage() {
     echo "  -c <dir> non-default klipper config directory"
     echo "  -m <dir> non-default moonraker home directory"
     # TODO: Repetier-Server stub support
-    # echo "  -p specify Repetier-Server <stub> to override printer.cfg and klipper.service names"
+    # echo "  -R specify Repetier-Server <stub> to override printer.cfg and klipper.service names"
     echo "  -a <name> to specify alternative klipper-service-name when installed with Kiauh"
     echo "  -r allow running ${SCRIPT_NAME} from a root login (not through sudo)"
     echo "  -e, --emu Enables multi MCU support (e.g. for EMU design)"
@@ -70,6 +73,11 @@ ordinal() {
 }
 
 prompt_yn() {
+    if [ "${F_YES}" ]; then
+        printf "%s (y/n)? y\n" "$*"
+        return 1
+    fi
+
     while true; do
         printf "%s (y/n)? " "$*"
         if ! read -r yn; then
@@ -136,6 +144,82 @@ guess_klipper_config_home() {
     else
         echo "${HOME}/printer_data/config"
     fi
+}
+
+# Copy the base and any per-unit Kconfig files from a selected backup. Files
+# ending in .old are prior Kconfig snapshots rather than the saved configuration.
+recover_backup_config() {
+    selected_backup=$1
+    recovered=n
+    for config_file in "${selected_backup}"/.mmu_config*; do
+        [ -f "${config_file}" ] || continue
+        case "${config_file}" in
+        *.old) continue ;;
+        esac
+        echo "${C_INFO}Recovering '$(basename "${config_file}")' from '$(basename "${selected_backup}")'${C_OFF}"
+        cp -p -- "${config_file}" "${SCRIPT_DIR}/$(basename "${config_file}")"
+        recovered=y
+    done
+
+    if [ "${recovered}" = n ]; then
+        echo "${C_WARNING}No recoverable .mmu_config files found in '${selected_backup}'${C_OFF}"
+    fi
+}
+
+# Recover from the newest eligible MMU backup. Backup names contain sortable
+# timestamps, so the final matching directory is the newest one.
+recover_last_config() {
+    config_home=$(guess_klipper_config_home)
+    last_backup=
+
+    for backup_dir in "${config_home}"/mmu*; do
+        [ -d "${backup_dir}" ] || continue
+        [ "${backup_dir}" != "${config_home}/mmu" ] || continue
+        [ -f "${backup_dir}/.mmu_config" ] || continue
+        last_backup=${backup_dir}
+    done
+
+    if [ -z "${last_backup}" ]; then
+        echo "${C_WARNING}No MMU backup containing .mmu_config found in '${config_home}'${C_OFF}"
+        return 0
+    fi
+
+    recover_backup_config "${last_backup}"
+}
+
+# List every eligible MMU backup and let the user choose which one to recover.
+recover_previous_config() {
+    config_home=$(guess_klipper_config_home)
+    backup_count=0
+
+    echo "${C_INFO}Available MMU configuration backups:${C_OFF}"
+    for backup_dir in "${config_home}"/mmu*; do
+        [ -d "${backup_dir}" ] || continue
+        [ "${backup_dir}" != "${config_home}/mmu" ] || continue
+        [ -f "${backup_dir}/.mmu_config" ] || continue
+        backup_count=$((backup_count + 1))
+        echo "  ${backup_count}) $(basename "${backup_dir}")"
+    done
+
+    if [ "${backup_count}" -eq 0 ]; then
+        echo "${C_WARNING}No MMU backup containing .mmu_config found in '${config_home}'${C_OFF}"
+        return 0
+    fi
+
+    echo
+    selected=$(prompt_n "${backup_count}" "Choose a backup")
+    current=0
+    for backup_dir in "${config_home}"/mmu*; do
+        [ -d "${backup_dir}" ] || continue
+        [ "${backup_dir}" != "${config_home}/mmu" ] || continue
+        [ -f "${backup_dir}/.mmu_config" ] || continue
+        current=$((current + 1))
+        if [ "${current}" -eq "${selected}" ]; then
+            echo
+            recover_backup_config "${backup_dir}"
+            return 0
+        fi
+    done
 }
 
 # Point Moonraker's update manager at a specific branch, so future automatic updates
@@ -362,11 +446,14 @@ for arg in "$@"; do
     case "$arg" in
         --emu) set -- "$@" -e ;;
         --help) set -- "$@" -h ;;
+        --yes) set -- "$@" -y ;;
+        --last) set -- "$@" -l ;;
+        --prev) set -- "$@" -p ;;
         *)     set -- "$@" "$arg" ;;
     esac
 done
 
-while getopts "rehfiudzsb:nk:c:m:a:toqv" arg; do
+while getopts "rehfiudylpzsb:nk:c:m:a:toqv" arg; do
     case $arg in
     f)
         FIX_LINKS=y
@@ -374,6 +461,9 @@ while getopts "rehfiudzsb:nk:c:m:a:toqv" arg; do
         ;;
     i) F_MENUCONFIG=y ;;
     u | d) F_UNINSTALL=y ;;
+    y) export F_YES=y ;;
+    l) F_RECOVER_LAST=y ;;
+    p) F_RECOVER_PREVIOUS=y ;;
     z) export F_SKIP_UPDATE="${F_SKIP_UPDATE:=y}" ;;
     s) export F_NO_SERVICE=y ;;
     b) export BRANCH="${OPTARG}" ;;
@@ -382,7 +472,7 @@ while getopts "rehfiudzsb:nk:c:m:a:toqv" arg; do
     c) export CONFIG_KLIPPER_CONFIG_HOME="${OPTARG}" ;;
     m) export CONFIG_MOONRAKER_HOME="${OPTARG}" ;;
     # TODO: Repetier-Server stub support
-    # p)
+    # R)
     #     PRINTER_CONFIG=${OPTARG}.cfg
     #     KLIPPER_SERVICE=klipper_${OPTARG}.service
     #     echo "Repetier-Server <stub> specified. Over-riding printer.cfg to [${PRINTER_CONFIG}] & klipper.service to [${KLIPPER_SERVICE}]"
@@ -404,8 +494,29 @@ done
 detect_platform
 enforce_root_policy
 
-# Settle v3 vs v4 before self-update or installation work (see offer_v3_v4_choice for why).
-if [ "${F_SKIP_UPDATE}" != "force" ] && v3_detected; then
+if [ "${F_RECOVER_LAST}" ] && [ "${F_RECOVER_PREVIOUS}" ]; then
+    echo "${C_ERROR}Can't use --last and --prev at the same time!${C_OFF}"
+    exit 1
+fi
+
+if { [ "${F_RECOVER_LAST}" ] || [ "${F_RECOVER_PREVIOUS}" ]; } && [ "${F_UNINSTALL}" ]; then
+    echo "${C_ERROR}Can't recover a configuration and uninstall at the same time!${C_OFF}"
+    exit 1
+fi
+
+if { [ "${F_RECOVER_LAST}" ] || [ "${F_RECOVER_PREVIOUS}" ]; } && [ ! "${F_CONFIG_RECOVERED}" ]; then
+    if [ "${F_RECOVER_PREVIOUS}" ]; then
+        recover_previous_config
+    else
+        recover_last_config
+    fi
+    export F_CONFIG_RECOVERED=y
+fi
+
+# Settle v3 vs v4 before self-update or installation work (see
+# offer_v3_v4_choice for why). Non-interactive callers keep the checkout's
+# current branch; choosing a migration policy requires a human decision.
+if [ "${F_SKIP_UPDATE}" != "force" ] && [ ! "${F_YES}" ] && v3_detected; then
     offer_v3_v4_choice
 fi
 
@@ -623,6 +734,7 @@ fi
 if [ "${FIX_LINKS}" ]; then
     echo "${C_INFO}Restoring Happy Hare klipper extras and moonraker components links${C_OFF}"
     time_elapsed run_make fix_links
+    echo "${C_INFO}Run ~Happy-Hare/install.sh -i to (re)configure${C_OFF}"
     exit 0
 fi
 

--- a/installer/self_update.sh
+++ b/installer/self_update.sh
@@ -27,24 +27,30 @@ self_update() {
         return
     fi
 
-    echo "${C_NOTICE}Running on '${current_branch}' branch" \
-        "Checking for updates...${C_OFF}"
     # Both check for updates but also help me not loose changes accidently
     git fetch --quiet
 
     switch=0
-    if ! git diff --quiet --exit-code "origin/${current_branch}"; then
-        echo "${C_NOTICE}Found a new version of Happy Hare on github, updating...${C_OFF}"
+    if [ -n "${BRANCH}" ] && [ "${BRANCH}" != "${current_branch}" ]; then
+        # An explicit branch selection takes precedence over updating the branch we
+        # happened to start on. Switch first; the common pull below updates only the
+        # selected branch.
+        current_branch=${BRANCH}
+        echo "${C_NOTICE}Switching to '${current_branch}' branch${C_OFF}"
         if [ -n "$(git status --porcelain)" ]; then
             git stash push -m 'local changes stashed before self update' --quiet
         fi
         switch=1
-    fi
-
-    if [ -n "${BRANCH}" ] && [ "${BRANCH}" != "${current_branch}" ]; then
-        current_branch=${BRANCH}
-        echo "${C_NOTICE}Switching to '${current_branch}' branch${C_OFF}"
-        switch=1
+    else
+        echo "${C_NOTICE}Running on '${current_branch}' branch" \
+            "Checking for updates...${C_OFF}"
+        if ! git diff --quiet --exit-code "origin/${current_branch}"; then
+            echo "${C_NOTICE}Found a new version of Happy Hare on github, updating...${C_OFF}"
+            if [ -n "$(git status --porcelain)" ]; then
+                git stash push -m 'local changes stashed before self update' --quiet
+            fi
+            switch=1
+        fi
     fi
 
     if [ "${switch}" -eq 1 ]; then

--- a/test/installer/test_install_sh.py
+++ b/test/installer/test_install_sh.py
@@ -322,7 +322,7 @@ class TestInstallSh(unittest.TestCase):
         reexec = self.write(
             self.root / "reexec.sh",
             "#!/bin/sh\n"
-            "printf '%s:%s\\n' \"$BRANCH\" \"$F_SKIP_UPDATE\" "
+            "printf '%s:%s:%s\\n' \"$BRANCH\" \"$F_SKIP_UPDATE\" \"$SKIP_UPDATE\" "
             ">\"$TEST_LOG/reexec\"\n",
         )
         reexec.chmod(0o755)
@@ -344,7 +344,7 @@ class TestInstallSh(unittest.TestCase):
         self.assertIn("[update_manager other]\nprimary_branch: other-main", moonraker)
         self.assertIn("[update_manager happy-hare]\nprimary_branch: v3", moonraker)
         self.assertEqual((log_dir / "self-update").read_text().strip(), "v3")
-        self.assertEqual((log_dir / "reexec").read_text().strip(), "v3:force")
+        self.assertEqual((log_dir / "reexec").read_text().strip(), "v3:force:YES")
 
     def test_v3_red_choice_backs_up_v3_and_cleans_for_v4(self):
         config_home = self.make_v3_install()

--- a/test/installer/test_install_sh.py
+++ b/test/installer/test_install_sh.py
@@ -1,0 +1,299 @@
+"""Integration tests for install.sh recovery and v3 migration paths."""
+
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+
+class TestInstallSh(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def write(self, path, text=""):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def run_shell(self, body, *, stdin="", env=None, argv0="install-sh-test"):
+        shell_env = os.environ.copy()
+        shell_env.update({
+            "INSTALL_SH_SOURCE_ONLY": "y",
+            "INSTALL_SH_SCRIPT_DIR": str(REPO_ROOT),
+        })
+        if env:
+            shell_env.update({key: str(value) for key, value in env.items()})
+
+        script = "\n".join((
+            ". {}".format(shlex.quote(str(INSTALL_SH))),
+            "C_OFF= C_INFO= C_NOTICE= C_WARNING= C_ERROR=",
+            body,
+        ))
+        result = subprocess.run(
+            ["/bin/sh", "-c", script, str(argv0)],
+            cwd=REPO_ROOT,
+            env=shell_env,
+            input=stdin,
+            text=True,
+            capture_output=True,
+        )
+        if result.returncode:
+            self.fail(
+                "install.sh subprocess failed with status {}\nstdout:\n{}\nstderr:\n{}"
+                .format(result.returncode, result.stdout, result.stderr)
+            )
+        return result
+
+    def make_mmu_config(self, directory, *extra_names):
+        self.write(directory / ".mmu_config", "CONFIG_SENTINEL=y\n")
+        for name in extra_names:
+            self.write(directory / name, name + "\n")
+
+    def test_last_recovers_current_kconfig_without_moving_current(self):
+        config_home = self.root / "printer_data" / "config"
+        current = config_home / "mmu"
+        repo_dest = self.root / "happy-hare"
+        repo_dest.mkdir()
+        self.make_mmu_config(
+            current,
+            ".mmu_config_unit0",
+            ".mmu_config.old",
+            "current-marker",
+        )
+
+        self.run_shell("""
+            SCRIPT_DIR={repo}
+            CONFIG_KLIPPER_CONFIG_HOME={config}
+            TESTDIR=
+            recover_last_config
+        """.format(
+            repo=shlex.quote(str(repo_dest)),
+            config=shlex.quote(str(config_home)),
+        ))
+
+        self.assertTrue((current / "current-marker").exists())
+        self.assertTrue((repo_dest / ".mmu_config").exists())
+        self.assertTrue((repo_dest / ".mmu_config_unit0").exists())
+        self.assertFalse((repo_dest / ".mmu_config.old").exists())
+        self.assertEqual(list(config_home.glob("mmu.old-*")), [])
+
+    def test_last_without_current_restores_newest_backup(self):
+        config_home = self.root / "printer_data" / "config"
+        older = config_home / "mmu.old-20260101-010203"
+        newer = config_home / "mmu.old-20260830-120000"
+        repo_dest = self.root / "happy-hare"
+        repo_dest.mkdir()
+        self.make_mmu_config(older, "older-marker")
+        self.make_mmu_config(newer, ".mmu_config_unit1", "newer-marker")
+
+        self.run_shell("""
+            SCRIPT_DIR={repo}
+            CONFIG_KLIPPER_CONFIG_HOME={config}
+            TESTDIR=
+            recover_last_config
+        """.format(
+            repo=shlex.quote(str(repo_dest)),
+            config=shlex.quote(str(config_home)),
+        ))
+
+        current = config_home / "mmu"
+        self.assertTrue((current / "newer-marker").exists())
+        self.assertFalse((current / "older-marker").exists())
+        self.assertTrue((repo_dest / ".mmu_config_unit1").exists())
+
+    def test_prev_lists_newest_first_and_preserves_current_before_restore(self):
+        config_home = self.root / "printer_data" / "config"
+        current = config_home / "mmu"
+        older = config_home / "mmu.old-20260101-010203"
+        newer = config_home / "mmu.old-20260830-120000"
+        repo_dest = self.root / "happy-hare"
+        repo_dest.mkdir()
+        self.make_mmu_config(current, "current-marker")
+        self.make_mmu_config(older, "older-marker")
+        self.make_mmu_config(
+            newer,
+            ".mmu_config_unit0",
+            ".mmu_config.old",
+            "newer-marker",
+        )
+
+        result = self.run_shell("""
+            SCRIPT_DIR={repo}
+            CONFIG_KLIPPER_CONFIG_HOME={config}
+            TESTDIR=
+            recover_previous_config
+        """.format(
+            repo=shlex.quote(str(repo_dest)),
+            config=shlex.quote(str(config_home)),
+        ), stdin="2\n")
+
+        self.assertIn("1) mmu (current config)", result.stdout)
+        self.assertIn(
+            "2) mmu.old-20260830-120000 (2026-08-30 12:00:00)",
+            result.stdout,
+        )
+        self.assertIn(
+            "3) mmu.old-20260101-010203 (2026-01-01 01:02:03)",
+            result.stdout,
+        )
+        self.assertIn("Choose backup to restore from (1-3)?", result.stderr)
+        self.assertTrue((current / "newer-marker").exists())
+        self.assertFalse((current / "current-marker").exists())
+        self.assertTrue((repo_dest / ".mmu_config_unit0").exists())
+        self.assertFalse((repo_dest / ".mmu_config.old").exists())
+
+        preserved = [
+            path for path in config_home.glob("mmu.old-*")
+            if (path / "current-marker").exists()
+        ]
+        self.assertEqual(len(preserved), 1)
+
+    def test_test_mode_recovers_kconfig_into_testdir(self):
+        testdir = self.root / "mmu_test"
+        current = testdir / "printer_data" / "config" / "mmu"
+        repo_dest = self.root / "happy-hare"
+        repo_dest.mkdir()
+        self.make_mmu_config(current, ".mmu_config_unit0")
+
+        self.run_shell("""
+            SCRIPT_DIR={repo}
+            TESTDIR={testdir}
+            CONFIG_KLIPPER_CONFIG_HOME=
+            recover_last_config
+        """.format(
+            repo=shlex.quote(str(repo_dest)),
+            testdir=shlex.quote(str(testdir)),
+        ))
+
+        self.assertTrue((testdir / ".mmu_config").exists())
+        self.assertTrue((testdir / ".mmu_config_unit0").exists())
+        self.assertFalse((repo_dest / ".mmu_config").exists())
+
+    def make_v3_install(self):
+        config_home = self.root / "printer_data" / "config"
+        self.write(
+            config_home / "mmu" / "base" / "mmu_parameters.cfg",
+            "happy_hare_version: 3.2.1\n",
+        )
+        self.write(config_home / "mmu" / "v3-marker", "v3\n")
+        self.write(
+            config_home / "printer.cfg",
+            "[include mmu/base/*.cfg]\n[include other.cfg]\n",
+        )
+        self.write(
+            config_home / "moonraker.conf",
+            "[update_manager other]\n"
+            "primary_branch: other-main\n\n"
+            "[update_manager happy-hare]\n"
+            "primary_branch: main\n"
+            "path: /tmp/happy-hare\n\n"
+            "[mmu_server]\n"
+            "enable_file_preprocessor: True\n\n"
+            "[server]\n"
+            "port: 7125\n",
+        )
+        return config_home
+
+    def test_v3_blue_choice_pins_v3_branch_and_reexecs(self):
+        config_home = self.make_v3_install()
+        fake_checkout = self.root / "checkout"
+        log_dir = self.root / "log"
+        log_dir.mkdir()
+
+        self_update = self.write(
+            fake_checkout / "installer" / "self_update.sh",
+            "#!/bin/sh\nprintf '%s\\n' \"$BRANCH\" >\"$TEST_LOG/self-update\"\n",
+        )
+        self_update.chmod(0o755)
+        reexec = self.write(
+            self.root / "reexec.sh",
+            "#!/bin/sh\n"
+            "printf '%s:%s\\n' \"$BRANCH\" \"$F_SKIP_UPDATE\" "
+            ">\"$TEST_LOG/reexec\"\n",
+        )
+        reexec.chmod(0o755)
+
+        self.run_shell("""
+            SCRIPT_DIR={checkout}
+            CONFIG_KLIPPER_CONFIG_HOME={config}
+            KCONFIG_CONFIG={missing}
+            TESTDIR=
+            v3_detected
+            offer_v3_v4_choice
+        """.format(
+            checkout=shlex.quote(str(fake_checkout)),
+            config=shlex.quote(str(config_home)),
+            missing=shlex.quote(str(self.root / "missing-kconfig")),
+        ), stdin="1\n", env={"TEST_LOG": log_dir}, argv0=reexec)
+
+        moonraker = (config_home / "moonraker.conf").read_text(encoding="utf-8")
+        self.assertIn("[update_manager other]\nprimary_branch: other-main", moonraker)
+        self.assertIn("[update_manager happy-hare]\nprimary_branch: v3", moonraker)
+        self.assertEqual((log_dir / "self-update").read_text().strip(), "v3")
+        self.assertEqual((log_dir / "reexec").read_text().strip(), "v3:force")
+
+    def test_v3_red_choice_backs_up_v3_and_cleans_for_v4(self):
+        config_home = self.make_v3_install()
+        kconfig = self.root / ".mmu_config"
+        kconfig.write_text(
+            'CONFIG_KLIPPER_CONFIG_HOME="{}"\n'
+            'CONFIG_PRINTER_CONFIG_FILE="printer.cfg"\n'
+            'CONFIG_MOONRAKER_CONFIG_FILE="moonraker.conf"\n'.format(config_home),
+            encoding="utf-8",
+        )
+        make_log = self.root / "make-log"
+
+        self.run_shell("""
+            SCRIPT_DIR={repo}
+            CONFIG_KLIPPER_CONFIG_HOME={config}
+            KCONFIG_CONFIG={missing}
+            TESTDIR=
+            unset BRANCH
+            v3_detected
+            offer_v3_v4_choice
+            [ "$F_V3_UPGRADE" = y ]
+            [ -z "${{BRANCH:-}}" ]
+
+            KCONFIG_CONFIG={kconfig}
+            INSTALLER_PY={python}
+            run_make() {{ printf '%s\\n' "$*" >{make_log}; }}
+            time_elapsed() {{ "$@"; }}
+            v3_upgrade_cleanup
+        """.format(
+            repo=shlex.quote(str(REPO_ROOT)),
+            config=shlex.quote(str(config_home)),
+            missing=shlex.quote(str(self.root / "missing-kconfig")),
+            kconfig=shlex.quote(str(kconfig)),
+            python=shlex.quote(sys.executable),
+            make_log=shlex.quote(str(make_log)),
+        ), stdin="2\n")
+
+        self.assertFalse((config_home / "mmu").exists())
+        self.assertTrue((config_home / "mmu.V3" / "v3-marker").exists())
+
+        printer = (config_home / "printer.cfg").read_text(encoding="utf-8")
+        self.assertNotIn("include mmu/", printer)
+        self.assertIn("[include other.cfg]", printer)
+
+        moonraker = (config_home / "moonraker.conf").read_text(encoding="utf-8")
+        self.assertNotIn("[update_manager happy-hare]", moonraker)
+        self.assertNotIn("[mmu_server]", moonraker)
+        self.assertIn("[update_manager other]", moonraker)
+        self.assertIn("[server]", moonraker)
+        self.assertEqual(make_log.read_text().strip(), "F_NO_SERVICE=y fix_links")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/installer/test_install_sh.py
+++ b/test/installer/test_install_sh.py
@@ -11,6 +11,7 @@ import unittest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INSTALL_SH = REPO_ROOT / "install.sh"
+SELF_UPDATE_SH = REPO_ROOT / "installer" / "self_update.sh"
 MAKEFILE = REPO_ROOT / "Makefile"
 
 
@@ -345,6 +346,55 @@ class TestInstallSh(unittest.TestCase):
         self.assertIn("[update_manager happy-hare]\nprimary_branch: v3", moonraker)
         self.assertEqual((log_dir / "self-update").read_text().strip(), "v3")
         self.assertEqual((log_dir / "reexec").read_text().strip(), "v3:force:YES")
+
+    def test_self_update_switches_before_checking_current_branch(self):
+        remote = self.root / "remote.git"
+        checkout = self.root / "checkout"
+
+        subprocess.run(["git", "init", "--bare", str(remote)], check=True,
+                       capture_output=True, text=True)
+        subprocess.run(["git", "init", str(checkout)], check=True,
+                       capture_output=True, text=True)
+        for key, value in (("user.name", "Installer Test"),
+                           ("user.email", "installer@example.invalid")):
+            subprocess.run(["git", "-C", str(checkout), "config", key, value],
+                           check=True)
+        self.write(checkout / "marker", "v3\n")
+        subprocess.run(["git", "-C", str(checkout), "add", "marker"], check=True)
+        subprocess.run(["git", "-C", str(checkout), "commit", "-m", "v3"],
+                       check=True, capture_output=True, text=True)
+        subprocess.run(["git", "-C", str(checkout), "branch", "-M", "v3"],
+                       check=True)
+        subprocess.run(["git", "-C", str(checkout), "tag", "v3-test"], check=True)
+        subprocess.run(["git", "-C", str(checkout), "remote", "add", "origin",
+                        str(remote)], check=True)
+        subprocess.run(["git", "-C", str(checkout), "push", "-u", "origin", "v3",
+                        "--tags"], check=True, capture_output=True, text=True)
+        subprocess.run(["git", "-C", str(checkout), "checkout", "-b",
+                        "codex/local-only"], check=True, capture_output=True, text=True)
+
+        env = os.environ.copy()
+        env.update({
+            "BRANCH": "v3",
+            "C_OFF": "",
+            "C_NOTICE": "",
+            "C_WARNING": "",
+            "C_ERROR": "",
+        })
+        result = subprocess.run(
+            ["/bin/sh", str(SELF_UPDATE_SH)], cwd=checkout, env=env,
+            text=True, capture_output=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        current = subprocess.run(
+            ["git", "-C", str(checkout), "branch", "--show-current"],
+            check=True, text=True, capture_output=True,
+        ).stdout.strip()
+        self.assertEqual(current, "v3")
+        self.assertIn("Switching to 'v3' branch", result.stdout)
+        self.assertNotIn("Running on 'codex/local-only' branch", result.stdout)
+        self.assertNotIn("Found a new version", result.stdout)
 
     def test_v3_red_choice_backs_up_v3_and_cleans_for_v4(self):
         config_home = self.make_v3_install()

--- a/test/installer/test_install_sh.py
+++ b/test/installer/test_install_sh.py
@@ -181,6 +181,38 @@ class TestInstallSh(unittest.TestCase):
         self.assertTrue((testdir / ".mmu_config_unit0").exists())
         self.assertFalse((repo_dest / ".mmu_config").exists())
 
+    def test_recovery_options_are_noops_on_first_install(self):
+        config_home = self.root / "printer_data" / "config"
+        repo_dest = self.root / "happy-hare"
+        repo_dest.mkdir()
+
+        result = self.run_shell("""
+            SCRIPT_DIR={repo}
+            CONFIG_KLIPPER_CONFIG_HOME={config}
+            TESTDIR=
+            recover_last_config
+            recover_previous_config
+        """.format(
+            repo=shlex.quote(str(repo_dest)),
+            config=shlex.quote(str(config_home)),
+        ))
+
+        self.assertEqual(result.stdout.count("No MMU configuration containing"), 2)
+        self.assertFalse(config_home.exists())
+        self.assertEqual(list(repo_dest.iterdir()), [])
+
+    def test_v3_choice_precedes_recovery_in_installer_main(self):
+        script = INSTALL_SH.read_text(encoding="utf-8")
+        v3_choice = script.index(
+            'if [ "${F_SKIP_UPDATE}" != "force" ] && [ ! "${F_YES}" ] '
+            '&& v3_detected; then'
+        )
+        recovery = script.index(
+            'if { [ "${F_RECOVER_LAST}" ] || [ "${F_RECOVER_PREVIOUS}" ]; } '
+            '&& [ ! "${F_CONFIG_RECOVERED}" ]; then'
+        )
+        self.assertLess(v3_choice, recovery)
+
     def make_v3_install(self):
         config_home = self.root / "printer_data" / "config"
         self.write(

--- a/test/installer/test_install_sh.py
+++ b/test/installer/test_install_sh.py
@@ -11,6 +11,7 @@ import unittest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INSTALL_SH = REPO_ROOT / "install.sh"
+MAKEFILE = REPO_ROOT / "Makefile"
 
 
 class TestInstallSh(unittest.TestCase):
@@ -78,6 +79,7 @@ class TestInstallSh(unittest.TestCase):
             CONFIG_KLIPPER_CONFIG_HOME={config}
             TESTDIR=
             recover_last_config
+            [ -z "${{F_NO_MMU_BACKUP:-}}" ]
         """.format(
             repo=shlex.quote(str(repo_dest)),
             config=shlex.quote(str(config_home)),
@@ -134,6 +136,7 @@ class TestInstallSh(unittest.TestCase):
             CONFIG_KLIPPER_CONFIG_HOME={config}
             TESTDIR=
             recover_previous_config
+            [ "$F_NO_MMU_BACKUP" = y ]
         """.format(
             repo=shlex.quote(str(repo_dest)),
             config=shlex.quote(str(config_home)),
@@ -201,17 +204,59 @@ class TestInstallSh(unittest.TestCase):
         self.assertFalse(config_home.exists())
         self.assertEqual(list(repo_dest.iterdir()), [])
 
-    def test_v3_choice_precedes_recovery_in_installer_main(self):
+    def test_v3_choice_precedes_recovery_and_is_not_bypassed_by_yes(self):
         script = INSTALL_SH.read_text(encoding="utf-8")
         v3_choice = script.index(
-            'if [ "${F_SKIP_UPDATE}" != "force" ] && [ ! "${F_YES}" ] '
-            '&& v3_detected; then'
+            'if [ "${F_SKIP_UPDATE}" != "force" ] && v3_detected; then'
         )
         recovery = script.index(
             'if { [ "${F_RECOVER_LAST}" ] || [ "${F_RECOVER_PREVIOUS}" ]; } '
             '&& [ ! "${F_CONFIG_RECOVERED}" ]; then'
         )
         self.assertLess(v3_choice, recovery)
+
+    def test_make_skips_only_requested_mmu_backup(self):
+        mmu = self.root / "mmu"
+        self.write(mmu / "marker", "current\n")
+        recipe = (
+            f"include {MAKEFILE}\n"
+            ".PHONY: installer-backup-test\n"
+            "installer-backup-test:\n"
+            "\t$(Q)$(call backup,$(BACKUP_TEST_PATH),$(F_NO_MMU_BACKUP))"
+        )
+        test_makefile = self.write(self.root / "backup-test.mk", recipe)
+        common = [
+            "make",
+            "--no-print-directory",
+            "-f", str(test_makefile),
+            "installer-backup-test",
+            "Q=",
+            "KCONFIG_CONFIG={}".format(self.root / "missing-kconfig"),
+            "BACKUP_TEST_PATH={}".format(mmu),
+        ]
+
+        skipped = subprocess.run(
+            common + ["F_NO_MMU_BACKUP=y"],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        self.assertIn("recovery already preserved it", skipped.stdout)
+        self.assertEqual(list(self.root.glob("mmu.old-*")), [])
+
+        subprocess.run(
+            common,
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        self.assertEqual(len(list(self.root.glob("mmu.old-*"))), 1)
+        self.assertIn(
+            "$(call backup,$(basename $@),$(F_NO_MMU_BACKUP))",
+            MAKEFILE.read_text(encoding="utf-8"),
+        )
 
     def make_v3_install(self):
         config_home = self.root / "printer_data" / "config"
@@ -293,6 +338,7 @@ class TestInstallSh(unittest.TestCase):
             KCONFIG_CONFIG={missing}
             TESTDIR=
             unset BRANCH
+            F_YES=y
             v3_detected
             offer_v3_v4_choice
             [ "$F_V3_UPGRADE" = y ]

--- a/test/installer/test_install_sh.py
+++ b/test/installer/test_install_sh.py
@@ -283,6 +283,31 @@ class TestInstallSh(unittest.TestCase):
         )
         return config_home
 
+    def test_v3_detection_accepts_separator_and_whitespace_variants(self):
+        config_home = self.root / "printer_data" / "config"
+        parameters = config_home / "mmu" / "base" / "mmu_parameters.cfg"
+        variants = (
+            "happy_hare_version: 3.2.1\n",
+            "happy_hare_version = 3.2.1\n",
+            "  happy_hare_version  :  3.2.1\n",
+            "\thappy_hare_version\t=\t3.2.1\n",
+        )
+
+        for value in variants:
+            with self.subTest(value=value.strip()):
+                self.write(parameters, value)
+                self.run_shell("""
+                    SCRIPT_DIR={repo}
+                    CONFIG_KLIPPER_CONFIG_HOME={config}
+                    KCONFIG_CONFIG={missing}
+                    TESTDIR=
+                    v3_detected
+                """.format(
+                    repo=shlex.quote(str(REPO_ROOT)),
+                    config=shlex.quote(str(config_home)),
+                    missing=shlex.quote(str(self.root / "missing-kconfig")),
+                ))
+
     def test_v3_blue_choice_pins_v3_branch_and_reexecs(self):
         config_home = self.make_v3_install()
         fake_checkout = self.root / "checkout"


### PR DESCRIPTION
## Summary

- add `-y`/`--yes`, `-l`/`--last`, and `-p`/`--prev` installer options
- recover current or timestamped MMU configurations, including test-mode destinations and clean backup history
- add the mandatory v3/v4 migration choice, preserve v3 configurations, and update Moonraker branch tracking
- switch to explicitly requested Git branches before updating them and avoid a redundant v3 update
- improve installer guidance, v3 detection compatibility, Kiauh v4 detection, and pathname quoting
- add integration coverage for recovery, v3 migration, Makefile backup behavior, and branch switching

## Validation

- `venv/bin/python -m unittest test.installer.test_install_sh` (11 tests)
- `/bin/dash -n install.sh`
- `/bin/dash -n installer/self_update.sh`
- `git diff --check origin/main...HEAD`