### PR TITLE
Add Bambu X1 toolhead presets

### DIFF
--- a/installer/toolheads/Kconfig.stealthburner_clockwork2_bambu_x1
+++ b/installer/toolheads/Kconfig.stealthburner_clockwork2_bambu_x1
@@ -1,0 +1,15 @@
+config TOOLHEAD_TYPE_STEALTHBURNER_CLOCKWORK2_BAMBU_X1
+  bool "Stealthburner Clockwork2 Bambu X1"
+
+if TOOLHEAD_TYPE_STEALTHBURNER_CLOCKWORK2_BAMBU_X1
+  config PARAM_TOOLHEAD_TYPE
+    default "Stealthburner Clockwork2 Bambu X1"
+  config PARAM_TOOLHEAD_EXTRUDER_TO_NOZZLE
+    default 85
+  config PARAM_TOOLHEAD_SENSOR_TO_NOZZLE
+    default 75
+  config PARAM_TOOLHEAD_ENTRY_TO_EXTRUDER
+    default 13
+  config PARAM_TOOLHEAD_RESIDUAL_FILAMENT
+    default 22.5
+endif

--- a/installer/toolheads/Kconfig.stealthburner_g2e_bambu_x1
+++ b/installer/toolheads/Kconfig.stealthburner_g2e_bambu_x1
@@ -1,0 +1,15 @@
+config TOOLHEAD_TYPE_STEALTHBURNER_G2E_BAMBU_X1
+  bool "Stealthburner G2E Bambu X1"
+
+if TOOLHEAD_TYPE_STEALTHBURNER_G2E_BAMBU_X1
+  config PARAM_TOOLHEAD_TYPE
+    default "Stealthburner G2E Bambu X1"
+  config PARAM_TOOLHEAD_EXTRUDER_TO_NOZZLE
+    default 99.5
+  config PARAM_TOOLHEAD_SENSOR_TO_NOZZLE
+    default 79.5
+  config PARAM_TOOLHEAD_ENTRY_TO_EXTRUDER
+    default 13.3
+  config PARAM_TOOLHEAD_RESIDUAL_FILAMENT
+    default 22.5
+endif


### PR DESCRIPTION
## Summary

Add Happy Hare v4 toolhead presets for:

- Stealthburner Clockwork2 Bambu X1
- Stealthburner G2E Bambu X1

## Preset Values

| Toolhead | Extruder to nozzle | Sensor to nozzle | Entry sensor to extruder | Residual filament |
| --- | ---: | ---: | ---: | ---: |
| Stealthburner Clockwork2 Bambu X1 | 85 mm | 75 mm | 13 mm | 22.5 mm |
| Stealthburner G2E Bambu X1 | 99.5 mm | 79.5 mm | 13.3 mm | 22.5 mm |

The Bambu X1 designation covers stock Bambu X1 and P1 hotends, plus compatible replacements with the same geometry, such as TZ2 and Conch hotends.