### PR TITLE
Fix 3MS extruder sensor alias setup

### DIFF
--- a/extras/mmu/mmu_sensor_manager.py
+++ b/extras/mmu/mmu_sensor_manager.py
@@ -99,9 +99,9 @@ class MmuSensorManager:
                 if (
                     not mmu_unit.require_bowden_move
                     and gate_sensors.get(SENSOR_EXTRUDER_ENTRY)
-                    and SENSOR_SHARED_EXIT not in self.gate_sensors
+                    and SENSOR_SHARED_EXIT not in gate_sensors
                 ):
-                    self.gate_sensors.update(collect_sensors([(mmu_unit.toolhead_wrapper.extruder_sensor, SENSOR_SHARED_EXIT)]))
+                    gate_sensors[SENSOR_SHARED_EXIT] = gate_sensors[SENSOR_EXTRUDER_ENTRY]
 
                 suffixed_gate_sensors = collect_sensors([
                     (mmu_unit.sensors.entry_sensors.get(gate), self.get_gate_sensor_name(SENSOR_ENTRY_PREFIX, gate)),

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -335,6 +335,19 @@ TRADRACK = Profile(
     syms={'MMU_TYPE_TRADRACK_1_0': True},
     description='Tradrack 1.0 - physical LinearServoSelector')
 
+# 3MS has no Bowden move: each gate feeds directly to the extruder-entry sensor. This
+# exercises MmuSensorManager's alias from that sensor to mmu_shared_exit, which lets the
+# otherwise generic gate-loading code use the toolhead sensor as its homing point.
+THREE_MS = Profile(
+    '3ms',
+    syms={
+        'MMU_TYPE_3MS_1_0': True,
+        'BOARD_TYPE_MMB_2_0': True,
+        'MMU_HAS_SENSOR_EXTRUDER': True,
+        'PIN_EXTRUDER_SENSOR': 'mcu:PA7',
+    },
+    description='3MS 1.0 - no-Bowden Type B homing at the extruder sensor')
+
 # 3D Chameleon: the ONLY profile with a RotarySelector, and the only machine where selecting a
 # gate is not a bijection with a carriage position. There is one gear motor for all four gates,
 # reversed on half of them (selector_gate_directions), and no servo - so "release the filament"
@@ -670,7 +683,7 @@ run_current: 0.6
 # also the startup picker's source, so its list and the accepted profile objects stay one
 # thing. The buffered and dual-extruder ERCF variants below are registered for tests but are
 # deliberately absent: one is synthetic and the other needs EXTRA_EXTRUDER_STUB.
-CONSOLE_PROFILES = (ERCF_VVD, BOXTURTLE, TRADRACK, CHAMELEON, PICO_MMU, MMX, KMS, QIDI,
+CONSOLE_PROFILES = (ERCF_VVD, BOXTURTLE, TRADRACK, THREE_MS, CHAMELEON, PICO_MMU, MMX, KMS, QIDI,
                     EMU, EMU_EBB, ENCODER,
                     NFC_SINGLE, NFC_PER_GATE, NFC_NEIGHBOR_CHECK, NFC_NEIGHBOR_EVICT,
                     NFC_GATE_CLEAR,

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -10,6 +10,8 @@
 #   boxturtle  4 gates,  VirtualSelector       - Type B, the default everywhere else
 #   tradrack  10 gates,  LinearServoSelector   - a PHYSICAL selector, so the suite is not
 #                                                shaped around one selector type
+#   3ms        4 gates,  VirtualSelector       - zero-length Bowden; gate homing aliases the
+#                                                extruder-entry sensor as mmu_shared_exit
 #   chameleon  4 gates,  RotarySelector        - a fourth selector class, and the only one
 #                                                with no servo: releasing drives the carriage
 #                                                to the OPPOSING gate's offset
@@ -58,6 +60,7 @@ logging.getLogger().setLevel(logging.CRITICAL)
 BOOTABLE = {
     'boxturtle': (4, 'VirtualSelector'),
     'tradrack': (10, 'LinearServoSelector'),
+    '3ms': (4, 'VirtualSelector'),
     # Needs two symbols the vendor Kconfig leaves open (a board and a gate homing sensor) or it
     # does not render at all - see the profile's own comment in test/hh/profiles.py.
     'chameleon': (4, 'RotarySelector'),
@@ -146,6 +149,17 @@ class TestEveryBootableProfile(unittest.TestCase):
         """
         hh = self._check('tradrack')
         self.assertTrue(hasattr(hh.mmu.mmu_unit(0).selector, 'selector_stepper'))
+
+    def test_3ms(self):
+        hh = self._check('3ms')
+        unit = hh.mmu.mmu_unit(0)
+        self.assertFalse(unit.require_bowden_move)
+        self.assertEqual(unit.p.gate_homing_endstop, 'extruder')
+        extruder_sensor = unit.toolhead_wrapper.sensors['extruder']
+        self.assertIsNotNone(extruder_sensor)
+        for gate_sensors in hh.mmu.sensor_manager.gate_sensors:
+            self.assertIs(gate_sensors['extruder'], extruder_sensor)
+            self.assertIs(gate_sensors['mmu_shared_exit'], extruder_sensor)
 
     def test_chameleon(self):
         """


### PR DESCRIPTION
## Summary
- fix the no-Bowden sensor alias path updating the gate sensor list instead of the per-gate map
- alias mmu_shared_exit directly to the resolved extruder-entry sensor
- add a bootable 3MS regression profile covering every gate

## Testing
- ./venv/bin/python -m unittest test.test_mmu_profiles
- 39 tests passed