### PR TITLE
Restore MMU_DUMP_VARS in simulator

### DIFF
--- a/extras/mmu/commands/mmu_help.py
+++ b/extras/mmu/commands/mmu_help.py
@@ -157,6 +157,16 @@ class MmuHelpCommand(BaseCommand):
         # Fast lookup of registered names
         registered = {rc["name"].upper() for rc in BaseCommand._registered_commands}
 
+        # A command outside BaseCommand is not necessarily a gcode macro. Some subsystems
+        # (notably the RFID readers) register Python handlers directly with Klipper's gcode
+        # dispatcher. Only show the macro superscript when a matching gcode_macro object
+        # actually exists.
+        macro_commands = {
+            obj_name.split(" ", 1)[1].upper()
+            for obj_name, _obj in mmu.printer.lookup_objects("gcode_macro")
+            if " " in obj_name
+        }
+
         def categorize(c):
             cu = c.upper()
             if cu in ["MMU_COLD_PULL"]:
@@ -205,7 +215,7 @@ class MmuHelpCommand(BaseCommand):
                     "help_supplement": "",
                     "category": category,
                     "per_unit": False,
-                    "not_registered": True,
+                    "not_registered": name in macro_commands,
                 }
                 other_cmds.append(metadata)
 

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -471,7 +471,21 @@ class Session:
         # but it TAKES TIME on a real machine, and a paced session that skips it in an instant
         # reads as if the operation were over when it is not. Time only; no movement.
         effects.setdefault('_MMU_PURGE', self._effect_spend_time)
+        # This read-only utility is useful specifically in the interactive console. Run its
+        # real Jinja body so it can enumerate the harness's live get_status() dictionaries;
+        # ordinary choreography macros remain recorded no-ops.
+        effects.setdefault('MMU_DUMP_VARS', self._effect_dump_vars)
         return effects
+
+    def _effect_dump_vars(self, macro, gcmd):
+        gcode_macro = self.printer.lookup_object('gcode_macro')
+        context = gcode_macro.create_template_context()
+        context.update({
+            'params': dict(gcmd.get_command_parameters()),
+            'rawparams': gcmd.get_raw_command_parameters(),
+            'action_respond_info': lambda msg: gcmd.respond_info(str(msg)),
+        })
+        macro.template.run_gcode_from_command(context)
 
     # What a macro whose body never runs would nonetheless COST, at pace 1. Tip forming and
     # purging are both a sequence of ramming, cooling and wiping moves that the harness does not

--- a/test/hh/klippy_root/extras/gcode_macro.py
+++ b/test/hh/klippy_root/extras/gcode_macro.py
@@ -116,6 +116,11 @@ class _StatusWrapper:
     def __contains__(self, key):
         return self.printer.lookup_object(key, None) is not None
 
+    def __iter__(self):
+        # Klipper's status wrapper is iterable, which reporting macros such as
+        # MMU_DUMP_VARS rely on to discover matching printer objects.
+        return iter(name for name, _obj in self.printer.lookup_objects())
+
 
 class GCodeMacro:
     def __init__(self, config):

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -360,6 +360,36 @@ class TestOutputHandler(unittest.TestCase):
         self.assertEqual(len(hh.gcode.console), before + 1)
 
 
+class TestDumpVarsMacro(unittest.TestCase):
+    """MMU_DUMP_VARS is a read-only macro whose output is useful in the simulator."""
+
+    def test_dump_vars_renders_live_status(self):
+        hh = session('boxturtle')
+        self.addCleanup(hh.close)
+        hh.boot()
+        before = len(hh.console)
+
+        hh.run_gcode('MMU_DUMP_VARS')
+
+        output = '\n'.join(hh.console[before:])
+        self.assertIn("printer['mmu'].num_gates = 4", output)
+        self.assertIn("printer['mmu_machine'].happy_hare_version =", output)
+        self.assertNotIn("printer['mmu_stepper ", output)
+        self.assertEqual(hh.errors, [])
+
+    def test_verbose_dump_includes_stepper_status(self):
+        hh = session('boxturtle')
+        self.addCleanup(hh.close)
+        hh.boot()
+        before = len(hh.console)
+
+        hh.run_gcode('MMU_DUMP_VARS VERBOSE=1')
+
+        output = '\n'.join(hh.console[before:])
+        self.assertIn("printer['mmu_stepper ", output)
+        self.assertEqual(hh.errors, [])
+
+
 class TestRenderer(unittest.TestCase):
     """html_to_ansi - HH emits HTML, not ANSI (extras/mmu/mmu_logger.py:96)."""
 
@@ -1821,6 +1851,17 @@ class TestConsoleScript(unittest.TestCase):
         self.assertNotIn('ready_gcode_handlers', out)
         self.assertIn('Happy Hare MMU commands', out)
         self.assertIn('MMU_CHANGE_TOOL', out)
+
+    def test_mmu_help_only_marks_actual_gcode_macros(self):
+        rc, out = self._run(
+            ['MMU_HELP'],
+            ['--header', 'off', '--profile', 'nfc_per_gate'])
+        self.assertEqual(rc, 0, out[-2000:])
+        self.assertIn('MMU_RFID_INIT', out)
+        self.assertNotIn('MMU_RFID_INIT²', out)
+        self.assertIn('MMU_RFID_READ', out)
+        self.assertNotIn('MMU_RFID_READ²', out)
+        self.assertIn('MMU_COLD_PULL²', out)
 
     def test_vars_reports_both_status_objects(self):
         rc, out = self._run(['/vars'], ['--header', 'off'])


### PR DESCRIPTION
## Summary
- execute the read-only MMU_DUMP_VARS Jinja body in the simulator
- make the fake printer status wrapper iterable so the macro can discover status objects
- support normal and VERBOSE=1 dump output
- mark commands with the MMU_HELP macro superscript only when a matching gcode_macro object exists
- leave directly registered Python commands such as MMU_RFID_INIT and MMU_RFID_READ unmarked

## Testing
- ./venv/bin/python -m unittest test.test_mmu_console
- 202 tests passed