### PR TITLE
Simulate MMU cold pull in console

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -624,9 +624,11 @@ leaves the gate-0 gear pins empty and fails with `Invalid pin description ''`.
 
 ### Three things that will look like bugs
 
-1. **Macro bodies do not run.** The fake `gcode_macro` records a call and never renders the
-   body, so `T1`, the print start/end and the park/cut/purge sequences produce **silence**.
-   Use `MMU_CHANGE_TOOL TOOL=1`. The console notices a bare `T<n>` and says so.
+1. **Most macro bodies do not run.** The fake `gcode_macro` records a call and normally never
+   renders the body, so `T1`, the print start/end and the park/cut/purge sequences produce
+   **silence**. Use `MMU_CHANGE_TOOL TOOL=1`. The console notices a bare `T<n>` and says so.
+   `MMU_COLD_PULL` is the deliberate exception: the console runs its body and simulates its
+   heater waits instantly so the complete maintenance workflow can be exercised.
 2. **A physical selector must be calibrated and homed before it can select a gate.** The
    console does that for you at startup (`boot(calibrate=True, pre_bootup=...)`);
    in a test, call `hh.boot(calibrate=True)`, or `hh.boot()` then `hh.calibrate()`, then

--- a/test/console.py
+++ b/test/console.py
@@ -525,6 +525,16 @@ class Console:
         self.hh.build()
         self.hh.gcode.register_output_handler(self._on_output)
 
+        # Macro bodies are no-ops in the general-purpose harness. Cold pull is deliberately
+        # executable in this interactive simulator: it is a self-contained maintenance
+        # workflow whose temperature checkpoints and extruder moves are useful to exercise.
+        # Keep the exception local so print-start/toolchange macros retain the established
+        # recorded-only behavior relied on by the unit tests.
+        effects = getattr(self.hh.printer, 'harness_macro_effects', None)
+        if effects is None:
+            effects = self.hh.printer.harness_macro_effects = {}
+        effects['MMU_COLD_PULL'] = self._run_macro_body
+
         if a.trace:
             self.hh.mmu.p.log_level = a.trace
         if a.plain:
@@ -596,6 +606,10 @@ class Console:
         self.wall_start = time.time()
         self.clock_epoch = self.hh.reactor.monotonic()
         return self
+
+    @staticmethod
+    def _run_macro_body(macro, gcmd):
+        macro.run_body(gcmd)
 
     def _preload_all(self):
         """Gates start empty (TIP_ABSENT), so a bare MMU_LOAD on a fresh session fails."""
@@ -907,10 +921,11 @@ class Console:
 
     def _warn_silent_macro(self, line, mark):
         """
-        The fake gcode_macro records a macro call but never renders or runs its BODY
-        (pinned by test_mmu_toolchange.py). So T1, print start/end and the park/cut/purge
-        sequences are REGISTERED - they do not show up as unknown commands - and simply do
-        nothing. Silence is the whole symptom, so key off "produced no output at all".
+        With the explicit MMU_COLD_PULL exception installed in boot(), the fake gcode_macro
+        otherwise records a macro call but never renders or runs its BODY (pinned by
+        test_mmu_toolchange.py). So T1, print start/end and the park/cut/purge sequences are
+        REGISTERED - they do not show up as unknown commands - and simply do nothing. Silence
+        is the whole symptom, so key off "produced no output at all".
         """
         if len(self.sink) > mark:
             return

--- a/test/hh/klippy_root/extras/gcode_macro.py
+++ b/test/hh/klippy_root/extras/gcode_macro.py
@@ -13,10 +13,11 @@
 #    _BLOBIFIER_VARS (:461).
 #
 # Macro bodies are registered as recorded no-ops at this tier - running ~2000 lines
-# of shipped Jinja macro is a later milestone, and HH reaches bootup without it.
+# of shipped Jinja macro is a later milestone, and HH reaches bootup without it. Callers may
+# explicitly opt one macro into run_body(); make console does that for MMU_COLD_PULL only.
 #
-# A macro whose MOTION Happy Hare measures is the exception: see cmd() and
-# printer.harness_macro_effects.
+# A macro whose MOTION Happy Hare measures may instead receive a smaller modeled effect: see
+# cmd() and printer.harness_macro_effects.
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -89,9 +90,13 @@ class PrinterGCodeMacro:
             'printer': _StatusWrapper(self.printer, eventtime),
             'action_emergency_stop': lambda msg='': None,
             'action_respond_info': lambda msg: None,
-            'action_raise_error': lambda msg: None,
+            'action_raise_error': self._action_raise_error,
             'action_call_remote_method': lambda method, **kw: None,
         }
+
+    def _action_raise_error(self, msg):
+        """Match Klipper's template helper when an opted-in macro rejects input."""
+        raise self.printer.command_error(msg)
 
 
 class _StatusWrapper:
@@ -157,6 +162,14 @@ class GCodeMacro:
         effect = (getattr(self.printer, 'harness_macro_effects', None) or {}).get(self.alias)
         if effect is not None:
             effect(self, gcmd)
+
+    def run_body(self, gcmd):
+        """Render and dispatch this macro body when the harness explicitly opts it in."""
+        gcode_macro = self.printer.lookup_object('gcode_macro')
+        context = gcode_macro.create_template_context()
+        context['params'] = gcmd.get_command_parameters()
+        context['rawparams'] = gcmd.get_raw_command_parameters()
+        self.template.run_gcode_from_command(context)
 
     def get_status(self, eventtime=None):
         return dict(self.variables)

--- a/test/hh/klippy_root/extras/heaters.py
+++ b/test/hh/klippy_root/extras/heaters.py
@@ -48,6 +48,9 @@ class PrinterHeaters:
         self.available_heaters = []
         self.available_sensors = []
         self.available_monitors = []
+        self.printer.lookup_object('gcode').register_command(
+            'TEMPERATURE_WAIT', self._cmd_TEMPERATURE_WAIT,
+            desc='Wait for a temperature sensor')
 
     def setup_heater(self, config, gcode_id=None):
         name = config.get_name().split()[-1]
@@ -75,6 +78,31 @@ class PrinterHeaters:
 
     def set_temperature(self, heater, temp, wait=False):
         heater.set_temp(temp)
+
+    def _cmd_TEMPERATURE_WAIT(self, gcmd):
+        """Complete a thermal wait instantly while preserving its observable stages."""
+        sensor = gcmd.get('SENSOR')
+        heater = self.lookup_heater(sensor)
+        minimum = gcmd.get_float('MINIMUM', None)
+        maximum = gcmd.get_float('MAXIMUM', None)
+        if minimum is None and maximum is None:
+            raise gcmd.error("TEMPERATURE_WAIT requires MINIMUM and/or MAXIMUM")
+        if minimum is not None and maximum is not None and minimum > maximum:
+            raise gcmd.error("TEMPERATURE_WAIT MINIMUM exceeds MAXIMUM")
+
+        # There is deliberately no thermal time model in the harness. Move the reading to
+        # the first boundary this wait would encounter so a cooling ramp still exposes every
+        # intermediate temperature instead of teleporting straight to its final target.
+        current = heater.smoothed_temp
+        target = heater.target_temp
+        if minimum is not None and current < minimum:
+            current = min(target, maximum) if maximum is not None else max(minimum, target)
+            current = max(current, minimum)
+        if maximum is not None and current > maximum:
+            current = max(target, minimum) if minimum is not None else min(maximum, target)
+            current = min(current, maximum)
+        heater.smoothed_temp = current
+        heater.can_extrude = current >= heater.min_extrude_temp
 
     def lookup_heater(self, heater_name):
         if heater_name not in self.heaters:

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -1810,6 +1810,22 @@ class TestConsoleScript(unittest.TestCase):
         self.assertIn('does not run macro bodies', out)
         self.assertIn('MMU_CHANGE_TOOL TOOL=1', out)
 
+    def test_mmu_cold_pull_runs_its_macro_body(self):
+        rc, out = self._run(
+            ['MMU_COLD_PULL MATERIAL=PLA HOT_TEMP=180 COLD_TEMP=170 '
+             'PULL_TEMP=175 MIN_EXTRUDE_TEMP=175 CLEAN_LENGTH=2'],
+            ['--header', 'off'])
+        self.assertEqual(rc, 0, out[-2000:])
+        self.assertIn('Cold Pull based on PLA profile', out)
+        self.assertIn('Heating extruder to 180', out)
+        self.assertIn('>>>>> PULL NOW <<<<<', out)
+        self.assertIn('Cold pull is successful', out)
+
+    def test_mmu_cold_pull_rejects_an_unknown_material(self):
+        rc, out = self._run(['MMU_COLD_PULL MATERIAL=WOOD'], ['--header', 'off'])
+        self.assertEqual(rc, 1, out[-2000:])
+        self.assertIn('Unknown material', out)
+
     def test_mmu_help_works(self):
         """
         MMU_HELP enumerates gcode.ready_gcode_handlers (mmu_help.py:155). The fake dispatch


### PR DESCRIPTION
## Summary
- opt MMU_COLD_PULL into macro-body execution in make console
- simulate TEMPERATURE_WAIT checkpoints without adding a thermal time model
- preserve recorded no-op behavior for other macro bodies
- document the exception and cover successful and invalid-material paths

## Testing
- make test UT=test_mmu_console.py (201 tests)
- make test UT=test_mmu_console.py ARGS='-k cold_pull -v'
- make lint ARGS='test/console.py test/hh/klippy_root/extras/gcode_macro.py test/hh/klippy_root/extras/heaters.py test/test_mmu_console.py'
- git diff --check