### PR TITLE
Add configurable TMC UART addresses

### DIFF
--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -272,8 +272,8 @@ show_bypass                 : [[PARAM_HAS_BYPASS]]		# 1 = Force showing of bypas
 [% if PARAM_GEAR_TMC != "" %]
 [[ "[" ~ PARAM_GEAR_TMC ~ " mmu_stepper " ~ UNIT_NAME ~ "_gear]" ]]
 uart_pin                 : [[PIN_GEAR_UART]]
-[% if BOARD_TYPE_EASY_BRD %]
-uart_address             : 0		# Only for old EASY-BRD mcu
+[% if BOARD_TYPE_EASY_BRD or BOARD_TYPE_SKR_PICO_1 or BOARD_TYPE_OTHER %]
+uart_address             : [[PARAM_GEAR_UART_ADDRESS]]
 [% endif %]
 run_current              : [[PARAM_GEAR_RUN_CURRENT]]
 hold_current             : [[PARAM_GEAR_HOLD_CURRENT]]		# Recommend to be small if not using "touch" or move (TMC stallguard)
@@ -363,8 +363,8 @@ extra_endstops:
 #
 [[ "[" ~ PARAM_SELECTOR_TMC ~ " mmu_stepper " ~ UNIT_NAME ~ "_selector]" ]]
 uart_pin                 : [[PIN_SELECTOR_UART]]
-[% if BOARD_TYPE_EASY_BRD %]
-uart_address             : 1 # Only for old EASY-BRD mcu
+[% if BOARD_TYPE_EASY_BRD or BOARD_TYPE_SKR_PICO_1 or BOARD_TYPE_OTHER %]
+uart_address             : [[PARAM_SELECTOR_UART_ADDRESS]]
 [% endif %]
 run_current              : [[PARAM_SELECTOR_RUN_CURRENT]]
 hold_current             : [[PARAM_SELECTOR_HOLD_CURRENT]]		# Can be small if not using "touch" movement (TMC stallguard)

--- a/installer/Kconfig.gear_stepper
+++ b/installer/Kconfig.gear_stepper
@@ -5,6 +5,7 @@
 #   PARAM_GEAR_ROTATION_DISTANCE
 #   PARAM_GEAR_RUN_CURRENT
 #   PARAM_GEAR_HOLD_CURRENT
+#   PARAM_GEAR_UART_ADDRESS (for boards with addressable shared UART)
 #   PARAM_GEAR_FULL_STEPS_PER_ROTATION
 
 menu "Gear stepper"
@@ -24,6 +25,12 @@ menu "Gear stepper"
   config PARAM_GEAR_HOLD_CURRENT
     float "Gear hold current      "
     default 0.1
+
+  config PARAM_GEAR_UART_ADDRESS
+    int "Gear UART address      "
+    default 0
+    range 0 3
+    depends on BOARD_TYPE_EASY_BRD || BOARD_TYPE_SKR_PICO_1 || BOARD_TYPE_OTHER
 
   config PARAM_GEAR_MICROSTEPS
     int "Microsteps             "

--- a/installer/Kconfig.selector_stepper
+++ b/installer/Kconfig.selector_stepper
@@ -6,6 +6,7 @@
 #   PARAM_SELECTOR_ROTATION_DISTANCE
 #   PARAM_SELECTOR_RUN_CURRENT
 #   PARAM_SELECTOR_HOLD_CURRENT
+#   PARAM_SELECTOR_UART_ADDRESS (for boards with addressable shared UART)
 #   PARAM_SELECTOR_ENDSTOP_NAME
 #   PARAM_SELECTOR_FULL_STEPS_PER_ROTATION
 #   PARAM_STARTUP_HOME_SELECTOR
@@ -38,6 +39,12 @@ if MMU_HAS_SELECTOR_STEPPER
     config PARAM_SELECTOR_HOLD_CURRENT
       float "Selector hold current           "
       default 0.2
+
+    config PARAM_SELECTOR_UART_ADDRESS
+      int "Selector UART address           "
+      default 1
+      range 0 3
+      depends on BOARD_TYPE_EASY_BRD || BOARD_TYPE_SKR_PICO_1 || BOARD_TYPE_OTHER
 
     config PARAM_SELECTOR_ENDSTOP_NAME
       string

--- a/test/installer/test_uart_address.py
+++ b/test/installer/test_uart_address.py
@@ -1,0 +1,101 @@
+# Board-specific TMC UART address Kconfig and rendering tests.
+
+import unittest
+
+from test.hh import cfg, profiles
+
+
+class TestUartAddressConfiguration(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.profile_syms = {
+            "unknown": {"MMU_TYPE_HTLF_1_0": True},
+            "easy_brd": {
+                "MMU_TYPE_HTLF_1_0": True,
+                "BOARD_TYPE_EASY_BRD": True,
+            },
+            "skr_pico": {
+                "MMU_TYPE_HTLF_1_0": True,
+                "BOARD_TYPE_SKR_PICO_1": True,
+            },
+            "mmb": {
+                "MMU_TYPE_HTLF_1_0": True,
+                "BOARD_TYPE_MMB_2_0": True,
+            },
+            "virtual_selector": {
+                "MMU_TYPE_BOX_TURTLE_1_0": True,
+                "BOARD_TYPE_SKR_PICO_1": True,
+            },
+            "custom": {
+                "MMU_TYPE_HTLF_1_0": True,
+                "BOARD_TYPE_SKR_PICO_1": True,
+                "PARAM_GEAR_UART_ADDRESS": 2,
+                "PARAM_SELECTOR_UART_ADDRESS": 3,
+            },
+        }
+        cls.kconfigs = {}
+        with cfg._env(cfg._SINGLE_UNIT_ENV):
+            for name, syms in cls.profile_syms.items():
+                cls.kconfigs[name] = cfg._kconfig(name, syms)
+
+    @staticmethod
+    def render_hardware(name, syms):
+        profile = profiles.Profile(name, syms=syms)
+        return cfg.render(profile)["config/base/mmu_hardware.cfg"]
+
+    def test_addresses_are_visible_only_for_supported_boards(self):
+        for board in ("unknown", "easy_brd", "skr_pico"):
+            with self.subTest(board=board):
+                kconfig = self.kconfigs[board]
+                self.assertGreater(
+                    kconfig.syms["PARAM_GEAR_UART_ADDRESS"].visibility, 0)
+                self.assertGreater(
+                    kconfig.syms["PARAM_SELECTOR_UART_ADDRESS"].visibility, 0)
+
+        kconfig = self.kconfigs["mmb"]
+        self.assertEqual(kconfig.syms["PARAM_GEAR_UART_ADDRESS"].visibility, 0)
+        self.assertEqual(kconfig.syms["PARAM_SELECTOR_UART_ADDRESS"].visibility, 0)
+
+        kconfig = self.kconfigs["virtual_selector"]
+        self.assertGreater(kconfig.syms["PARAM_GEAR_UART_ADDRESS"].visibility, 0)
+        self.assertEqual(kconfig.syms["PARAM_SELECTOR_UART_ADDRESS"].visibility, 0)
+
+    def test_addresses_have_expected_defaults_and_range(self):
+        for board in ("unknown", "easy_brd", "skr_pico"):
+            with self.subTest(board=board):
+                kconfig = self.kconfigs[board]
+                self.assertEqual(kconfig.get("PARAM_GEAR_UART_ADDRESS"), "0")
+                self.assertEqual(kconfig.get("PARAM_SELECTOR_UART_ADDRESS"), "1")
+
+        for symbol in (
+            "PARAM_GEAR_UART_ADDRESS",
+            "PARAM_SELECTOR_UART_ADDRESS",
+        ):
+            low, high, _condition = self.kconfigs["unknown"].syms[symbol].ranges[0]
+            self.assertEqual((low.str_value, high.str_value), ("0", "3"))
+
+    def test_supported_boards_render_uart_addresses(self):
+        for board in ("unknown", "easy_brd", "skr_pico"):
+            with self.subTest(board=board):
+                hardware = self.render_hardware(board, self.profile_syms[board])
+                self.assertIn("uart_address             : 0", hardware)
+                self.assertIn("uart_address             : 1", hardware)
+
+    def test_custom_addresses_are_rendered(self):
+        kconfig = self.kconfigs["custom"]
+        self.assertEqual(kconfig.get("PARAM_GEAR_UART_ADDRESS"), "2")
+        self.assertEqual(kconfig.get("PARAM_SELECTOR_UART_ADDRESS"), "3")
+
+        hardware = self.render_hardware("custom", self.profile_syms["custom"])
+        self.assertIn("uart_address             : 2", hardware)
+        self.assertIn("uart_address             : 3", hardware)
+
+    def test_other_boards_do_not_render_uart_addresses(self):
+        hardware = self.render_hardware("mmb", self.profile_syms["mmb"])
+        self.assertNotIn("uart_address", hardware)
+        self.assertNotIn("Only for old EASY-BRD mcu", hardware)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add configurable gear and selector TMC UART addresses for EASY-BRD, SKR Pico, and Not listed / Other boards
- constrain both Kconfig integer values to 0-3, defaulting gear to 0 and selector to 1
- render uart_address only for supported boards and remove the obsolete EASY-BRD comments
- add regression tests for visibility, defaults, range constraints, custom values, and template rendering

## Tests

- `./venv/bin/python -m unittest -v test.installer.test_uart_address`
- `./venv/bin/python -m unittest test.test_mmu_config`
- `git diff --check`