### PR TITLE
Fix WGB eSpooler enable pins

### DIFF
--- a/installer/boards/Kconfig.wgb_3_0
+++ b/installer/boards/Kconfig.wgb_3_0
@@ -7,6 +7,10 @@ if BOARD_TYPE_WGB_3_0
   config PARAM_BOARD_TYPE
     default "WGB v3"
 
+  # WGB N20 driver SLP pins must be asserted to enable each motor.
+  config HAS_ESPOOLER_ENABLE_PIN
+    default y
+
   choice CHOICE_MMU_CONNECTION_TYPE
     default CHOICE_MMU_CONNECTION_TYPE_SERIAL
   endchoice


### PR DESCRIPTION
## Summary

Enable WGB v3 eSpooler motor enable pins in the installer configuration.

The WGB board defines a per-gate `SLP`/enable signal for each N20 motor driver. These pins were already present in the board pin definitions, but the board did not declare `HAS_ESPOOLER_ENABLE_PIN`, so Happy Hare did not expose or generate the `enable_motor_pin_*` entries.

## Changes

- Set `HAS_ESPOOLER_ENABLE_PIN` for the WGB v3 board.
- Generate and expose the four eSpooler enable pins:
  - Gate 0: `PD11`
  - Gate 1: `PD10`
  - Gate 2: `PD9`
  - Gate 3: `PD8`

## Verification

Tested with Box Turtle + WGB v3 in menuconfig. The eSpooler configuration now displays the expected enable, rewind, and forward pins for all four gates.