### PR TITLE
Fix load and unload sequences for no-Bowden MMUs

### DIFF
--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -757,8 +757,37 @@ class MmuController(MmuFilamentMovement):
         gate = self.gate_selected
         pos = self.filament_pos
         direction = self.filament_direction
-        gate_homing_endstop = self.mmu_unit().p.gate_homing_endstop
+        unit = self.mmu_unit()
+        gate_homing_endstop = unit.p.gate_homing_endstop
         gate_status = self.gate_status[gate] if gate >= 0 else GATE_UNKNOWN
+
+        # A no-Bowden unit aliases mmu_shared_exit to its extruder-entry sensor so
+        # generic gate homing can use it. That is one physical switch, not two
+        # landmarks in the visual path.
+        gate_sensor_sets = getattr(self.sensor_manager, 'gate_sensors', ())
+        selected_gate_sensors = (
+            gate_sensor_sets[gate]
+            if 0 <= gate < len(gate_sensor_sets)
+            else {}
+        )
+        shared_exit_is_extruder_alias = (
+            selected_gate_sensors.get(SENSOR_SHARED_EXIT) is not None
+            and selected_gate_sensors.get(SENSOR_SHARED_EXIT)
+                is selected_gate_sensors.get(SENSOR_EXTRUDER_ENTRY)
+        )
+
+        # UNLOADED normally means parked near the gate. For the aliased no-Bowden
+        # topology the dedicated lane itself runs to the extruder sensor, so render
+        # the parked filament through that lane and stop before the one real sensor.
+        render_pos = (
+            FILAMENT_POS_END_BOWDEN
+            if (
+                pos == FILAMENT_POS_UNLOADED
+                and gate_status != GATE_EMPTY
+                and shared_exit_is_extruder_alias
+            )
+            else pos
+        )
 
         status = self.get_status(0)
         if status['filament_remaining']:
@@ -797,19 +826,19 @@ class MmuController(MmuFilamentMovement):
             # A genuinely empty gate has nothing to show as "already passed"
             if pos <= FILAMENT_POS_UNLOADED and _gate_empty():
                 return space
-            return arrow if pos >= target_pos else space
+            return arrow if render_pos >= target_pos else space
 
         def homed_segment(target_pos, label):
-            if pos > target_pos:
+            if render_pos > target_pos:
                 return arrow + label + arrow
-            if pos == target_pos:
+            if render_pos == target_pos:
                 return home + label + space
             return space + label + space
 
         def pad(target_pos, length):
-            if pos > target_pos:
+            if render_pos > target_pos:
                 return arrow * length
-            if pos == target_pos:
+            if render_pos == target_pos:
                 left = length - length // 2
                 right = length // 2
                 return arrow * left + space * right
@@ -834,7 +863,11 @@ class MmuController(MmuFilamentMovement):
         # here, so its reading is real evidence for THIS gate specifically
         # (unlike _gate_empty()'s at-rest presence check below, which excludes it
         # since a stale cross-gate reading is a real risk there).
-        PER_GATE_SENSORS = (SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT)
+        PER_GATE_SENSORS = (
+            (SENSOR_EXIT_PREFIX,)
+            if shared_exit_is_extruder_alias
+            else (SENSOR_EXIT_PREFIX, SENSOR_SHARED_EXIT)
+        )
 
         def _furthest_triggered_gate_sensor_index():
             index = -1
@@ -853,6 +886,8 @@ class MmuController(MmuFilamentMovement):
             if self.sensor_manager.check_sensor(SENSOR_ENTRY_PREFIX) is False:
                 return -1
             for i, s in enumerate(GATE_SENSOR_ORDER):
+                if s == SENSOR_SHARED_EXIT and shared_exit_is_extruder_alias:
+                    continue
                 if self.sensor_manager.has_sensor(s):
                     return i - 1
             return len(GATE_SENSOR_ORDER) - 1
@@ -945,6 +980,8 @@ class MmuController(MmuFilamentMovement):
             return gate_presence_marker()
 
         def gate_sensor_marker(sensor):
+            if sensor == SENSOR_SHARED_EXIT and shared_exit_is_extruder_alias:
+                return arrow if _passed_gate_sensor(sensor) else space
             # A fitted sensor's own reading is always shown; only an unfitted
             # one falls back to inferring passage from a further-along trigger.
             if self.sensor_manager.has_sensor(sensor):

--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -93,6 +93,18 @@ class MmuFilamentMovement:
         )
 
 
+    def _set_gate_homed_state(self, profile):
+        """Publish the physical state represented by a gate homing datum."""
+        self.set_filament_pos_state(
+            FILAMENT_POS_HOMED_ENTRY
+            if (
+                profile.endstop == SENSOR_EXTRUDER_ENTRY
+                and not self.mmu_unit().require_bowden_move
+            )
+            else FILAMENT_POS_HOMED_GATE
+        )
+
+
     def _shared_gate_path_occupied(self, endstop, gate):
         """
         True if 'endstop' is a per-UNIT resource shared by every gate on that unit (not
@@ -423,7 +435,10 @@ class MmuFilamentMovement:
                     # Don't reset if filament is buffered
                     self.gate_maps.set_gate_status(
                         gate, max(self.gate_status[gate], GATE_AVAILABLE))
-                    self.set_filament_pos_state(FILAMENT_POS_HOMED_GATE)
+                    # On a no-Bowden design the gate datum is the extruder-entry
+                    # sensor itself, so publish the physical location rather than
+                    # pretending that a separate gate/Bowden boundary was reached.
+                    self._set_gate_homed_state(profile)
                     self.log_trace_exit(f"_home_to_gate() => (overshoot={overshoot})")
                     return overshoot, tag_read
 
@@ -450,9 +465,10 @@ class MmuFilamentMovement:
 
     def _park_at_gate(self, profile, label="unload"):
         """
-        Primitive: park the filament when it is already standing ON the gate datum, having
-        just homed forward onto it. There is nothing to search for, so this is the parking
-        move and nothing else.
+        Primitive: park the filament when it is already standing at a known gate datum.
+        This may be the trigger point after homing forward or, for a no-bowden layout, the
+        release point after homing backward from the same sensor. There is nothing to
+        search for, so this is the parking move and nothing else.
 
         Encoder "homing" has no datum - it stops an unknown distance past the point motion
         was first detected - so there is nothing to park from and that case delegates to
@@ -530,7 +546,7 @@ class MmuFilamentMovement:
                 endstop_name=endstop_name,
             )
             if homed:
-                self.set_filament_pos_state(FILAMENT_POS_HOMED_GATE)
+                self._set_gate_homed_state(profile)
                 self.move_filament("Final parking", profile.parking_distance)
                 self.set_filament_pos_state(FILAMENT_POS_UNLOADED)
                 self.log_trace_exit(f"_park_from_gate() => (homing_movement={homing_movement})")
@@ -1226,11 +1242,11 @@ class MmuFilamentMovement:
                 # This can easily happen when your parking distance is configured to park the filament past the
                 # gate sensor instead of behind the gate sensor and the filament position is determined to be
                 # "somewhere in the bowden tube"
-                # NOT _park_at_gate(): that one's precondition is a FORWARD home onto the
-                # datum, and this arrived at the switch RELEASE point coming backward.
-                # Direction and validation already ran at the top of this block.
+                # Keep this recovery inline because it owns the early return and preserves
+                # the measured homing movement. Direction and validation already ran at
+                # the top of this block.
                 if homed:
-                    self.set_filament_pos_state(FILAMENT_POS_HOMED_GATE)
+                    self._set_gate_homed_state(profile)
                     self.move_filament("Final parking", profile.parking_distance)
                     self.set_filament_pos_state(FILAMENT_POS_UNLOADED)
                     self.log_trace_exit(f"_unload_gate() => (homing_movement={homing_movement})")
@@ -1303,8 +1319,9 @@ class MmuFilamentMovement:
 
         full = (length == bowden_length or length is None)
 
-        # Compensate for distance already moved for gate homing endstop (e.g. overshoot after encoder based gate homing)
-        length -= start_pos
+        # Compensate for distance already moved for gate homing endstop (e.g. overshoot after encoder based gate homing).
+        # A homing overshoot can consume the entire requested move, but can never leave a negative physical move.
+        length = max(length - start_pos, 0.)
 
         try:
             # Do we need to reduce bowden move by buffer amount to ensure we don't overshoot homing sensor
@@ -1319,6 +1336,10 @@ class MmuFilamentMovement:
                     # (because the bowden length is always recorded as distance to extruder gear)
                     extruder_homing_buffer -= u.toolhead_wrapper.p.toolhead_entry_to_extruder
 
+                # A reserved buffer must only subtract from the remaining fast move. In
+                # particular, a large entry-to-extruder offset must not make the buffer
+                # negative and turn its subtraction into an unintended forward move.
+                extruder_homing_buffer = min(max(extruder_homing_buffer, 0.), length)
                 length -= extruder_homing_buffer # Reduce fast move distance
 
             ratio = None
@@ -1447,11 +1468,12 @@ class MmuFilamentMovement:
         if bowden_length > 0 and not self.calibrating:
             length = min(length, bowden_length) # Cannot exceed calibrated distance
 
-        # Compensate for distance already moved whilst unloading extruder
-        length -= start_pos
+        # Compensate for distance already moved whilst unloading extruder. An extruder
+        # overshoot can consume the entire requested move, but cannot leave a negative move.
+        length = max(length - start_pos, 0.)
 
         # Shorten move to provide gate unload buffer used to ensure we don't overshoot homing point
-        gate_homing_buffer = u.p.bowden_unload_homing_buffer
+        gate_homing_buffer = min(u.p.bowden_unload_homing_buffer, length)
         length -= gate_homing_buffer
 
         try:
@@ -2032,14 +2054,17 @@ class MmuFilamentMovement:
             validate: Whether encoder-based validation should be performed during unload.
 
         Returns:
-            tuple[bool, float]: Sync state, Overshoot
+            tuple[bool, float, bool]: Sync state, Overshoot, entry datum established
               Sync state: True when the unload finished in a synced state; otherwise False.
               Overshoot past the extruder reference point later stages should account for (positive value)
+              Entry datum established: True only when reverse homing physically cleared the
+              extruder-entry sensor; False when its position was assumed or not used.
         """
         u = self.mmu_unit()
         self.log_trace_entry(f"_unload_extruder(extruder_only={extruder_only}, validate={validate})")
 
         overshoot = 0.
+        entry_datum_established = False
         with self.wrap_action(ACTION_UNLOADING_EXTRUDER):
             self.log_debug("Extracting filament from extruder")
             self.set_filament_direction(DIRECTION_UNLOAD)
@@ -2098,6 +2123,7 @@ class MmuFilamentMovement:
                         homing_move=-1,
                         endstop_name=SENSOR_EXTRUDER_ENTRY,
                     )
+                    entry_datum_established = fhomed
 
                 if not fhomed:
                     raise MmuError("Failed to reach extruder entry sensor after moving %.1fmm" % actual)
@@ -2218,8 +2244,11 @@ class MmuFilamentMovement:
             self.movequeue_wait()
             self.log_debug("Filament should be out of extruder")
 
-            self.log_trace_exit(f"_unload_extruder() => (synced={synced}, overshoot={overshoot})")
-            return synced, overshoot
+            self.log_trace_exit(
+                f"_unload_extruder() => (synced={synced}, overshoot={overshoot}, "
+                f"entry_datum_established={entry_datum_established})"
+            )
+            return synced, overshoot, entry_datum_established
 
 
 # PAUL
@@ -2440,7 +2469,7 @@ class MmuFilamentMovement:
                     extruder_homing_buffer = 0.
                     bowden_move_ratio = None
 
-                    if start_filament_pos < FILAMENT_POS_END_BOWDEN:
+                    if u.require_bowden_move and start_filament_pos < FILAMENT_POS_END_BOWDEN:
                         # Homing buffer is the shortfall in desired bowden move
                         bowden_move_ratio, extruder_homing_buffer = self._load_bowden(bowden_move, start_pos=start_overshoot)
                         bowden_travel = bowden_move - extruder_homing_buffer
@@ -2650,7 +2679,11 @@ class MmuFilamentMovement:
 
             # Note: Conditionals deliberately coded this way to match macro alternative
             start_filament_pos = self.filament_pos
-            unload_to_buffer = (start_filament_pos >= FILAMENT_POS_END_BOWDEN and not extruder_only)
+            unload_to_buffer = (
+                u.require_bowden_move
+                and start_filament_pos >= FILAMENT_POS_END_BOWDEN
+                and not extruder_only
+            )
 
             if self.p.gcode_unload_sequence and calibrated:
                 self.log_debug("Calling external user defined unloading sequence macro")
@@ -2667,7 +2700,7 @@ class MmuFilamentMovement:
 
             elif extruder_only:
                 if start_filament_pos >= FILAMENT_POS_EXTRUDER_ENTRY:
-                    synced_extruder_unload,_ = self._unload_extruder(extruder_only=True, validate=do_form_tip == FORM_TIP_STANDALONE)
+                    synced_extruder_unload,_,_ = self._unload_extruder(extruder_only=True, validate=do_form_tip == FORM_TIP_STANDALONE)
                 else:
                     raise MmuError("Cannot unload extruder because filament not detected in extruder! (state: %s)" % start_filament_pos)
 
@@ -2676,18 +2709,42 @@ class MmuFilamentMovement:
 
             else:
                 ext_unload_overshoot = 0.
+                extruder_entry_datum_established = False
                 if start_filament_pos >= FILAMENT_POS_EXTRUDER_ENTRY:
                     # Exit extruder, fast unload of bowden, then slow unload to gate
-                    synced_extruder_unload, ext_unload_overshoot = self._unload_extruder(validate=do_form_tip == FORM_TIP_STANDALONE)
+                    (
+                        synced_extruder_unload,
+                        ext_unload_overshoot,
+                        extruder_entry_datum_established,
+                    ) = self._unload_extruder(
+                        validate=do_form_tip == FORM_TIP_STANDALONE
+                    )
 
                 if (
                     (start_filament_pos >= FILAMENT_POS_END_BOWDEN and calibrated) or
                     (start_filament_pos >= FILAMENT_POS_HOMED_GATE and not full)
                 ):
-                    # Fast unload of bowden, then unload gate
-                    bowden_move_ratio, gate_homing_buffer = self._unload_bowden(bowden_move, ext_unload_overshoot)
-                    homing_movement = self._unload_gate(gate_homing_buffer)
-                    bowden_travel = bowden_move - gate_homing_buffer - homing_movement
+                    if u.require_bowden_move:
+                        # Fast unload of bowden, then unload gate
+                        bowden_move_ratio, gate_homing_buffer = self._unload_bowden(bowden_move, ext_unload_overshoot)
+                        homing_movement = self._unload_gate(gate_homing_buffer)
+                        bowden_travel = bowden_move - gate_homing_buffer - homing_movement
+                    else:
+                        # No Bowden stage exists. If unloading the extruder just
+                        # reverse-homed off the same sensor used as the gate datum,
+                        # that release point is already the parking reference and a
+                        # second zero-distance home would only publish a false state.
+                        bowden_move_ratio = None
+                        gate_homing_buffer = 0.
+                        if (
+                            extruder_entry_datum_established
+                            and self.filament_pos == FILAMENT_POS_HOMED_ENTRY
+                            and u.p.gate_homing_endstop == SENSOR_EXTRUDER_ENTRY
+                        ):
+                            homing_movement = self._park_at_gate(self._gate_profile())
+                        else:
+                            homing_movement = self._unload_gate()
+                        bowden_travel = 0.
 
                     # Notify autotune manager
                     if full:
@@ -3439,6 +3496,13 @@ class MmuFilamentMovement:
                 elif prop_result is False:
                     self.log_info("Proportional sensor indicates no extruder grip - filament may not be fully loaded")
                     self.set_filament_pos_state(FILAMENT_POS_IN_BOWDEN, silent=silent)
+
+        # On a no-Bowden unit the extruder-entry sensor is also the gate datum. A
+        # triggered level proves filament reached the entrance but cannot distinguish
+        # that point from filament extending through the extruder to the nozzle. Recover
+        # conservatively for a safe unload, even when heated checks are not allowed now.
+        elif es and not u.require_bowden_move:
+            self.set_filament_pos_state(FILAMENT_POS_IN_EXTRUDER, silent=silent)
 
         # Somewhere in extruder
         elif filament_detected and can_heat and self.check_filament_in_extruder():

--- a/extras/mmu/unit/mmu_unit_parameters.py
+++ b/extras/mmu/unit/mmu_unit_parameters.py
@@ -277,8 +277,8 @@ class MmuUnitParameters(TunableParametersBase):
 
         # Bowden
         ParamSpec('bowden_homing_max',                'float',2000.0, section="BOWDEN MOVE", limits=dict(minval=100.0)),
-        ParamSpec('bowden_load_homing_buffer',        'float',  20.0, section="BOWDEN MOVE", limits=dict(minval=0, maxval=500)),
-        ParamSpec('bowden_unload_homing_buffer',      'float',  40.0, section="BOWDEN MOVE", limits=dict(minval=0, maxval=500)),
+        ParamSpec('bowden_load_homing_buffer',        'float',  20.0, section="BOWDEN MOVE", limits=dict(minval=0.0, maxval=500)),
+        ParamSpec('bowden_unload_homing_buffer',      'float',  40.0, section="BOWDEN MOVE", limits=dict(minval=0.0, maxval=500)),
         ParamSpec('bowden_apply_correction',          'int',       0, section="BOWDEN MOVE", limits=dict(minval=0, maxval=1),   guard=_guard_has_encoder),
         ParamSpec('bowden_allowable_encoder_delta',   'float',  20.0, section="BOWDEN MOVE", limits=dict(minval=1.0),           guard=_guard_has_encoder),
         ParamSpec('bowden_pre_unload_test',           'int',       0, section="BOWDEN MOVE", limits=dict(minval=0, maxval=1),   guard=_guard_has_encoder),

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -346,7 +346,17 @@ THREE_MS = Profile(
         'MMU_HAS_SENSOR_EXTRUDER': True,
         'PIN_EXTRUDER_SENSOR': 'mcu:PA7',
     },
-    description='3MS 1.0 - no-Bowden Type B homing at the extruder sensor')
+    description='3MS 1.0 - no-Bowden Type B homing at the extruder sensor',
+    # The console presents filament at -40 mm and 3MS parks 250 mm behind its
+    # extruder-entry datum. Put that datum at +210 mm so preload/load can reach it
+    # within gate_homing_max and unload returns to the exact presented position.
+    # Preserve the generic 40 mm extruder-to-toolhead spacing.
+    filament_layout={
+        'extruder_entry': 210.0,
+        'extruder': 210.0,
+        'toolhead': 250.0,
+        'filament_compression': 210.0,
+    })
 
 # 3D Chameleon: the ONLY profile with a RotarySelector, and the only machine where selecting a
 # gate is not a bijection with a carriage position. There is one gear motor for all four gates,

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -80,6 +80,10 @@ BOOTABLE = {
 # name them. Keep in step with TestSelectorCoverage.
 EXERCISED_BY_LATER_UNITS = {'IndexedSelector'}
 
+FILAMENT_POS_UNLOADED = 0
+FILAMENT_POS_LOADED = 10
+TIP_AT_GATE = -40.0
+
 
 class TestEveryBootableProfile(unittest.TestCase):
     """
@@ -150,16 +154,231 @@ class TestEveryBootableProfile(unittest.TestCase):
         hh = self._check('tradrack')
         self.assertTrue(hasattr(hh.mmu.mmu_unit(0).selector, 'selector_stepper'))
 
-    def test_3ms(self):
+    def test_3ms_load_unload_round_trip(self):
         hh = self._check('3ms')
         unit = hh.mmu.mmu_unit(0)
         self.assertFalse(unit.require_bowden_move)
+        self.assertEqual(unit.calibrator.get_bowden_length(), 0)
         self.assertEqual(unit.p.gate_homing_endstop, 'extruder')
         extruder_sensor = unit.toolhead_wrapper.sensors['extruder']
         self.assertIsNotNone(extruder_sensor)
         for gate_sensors in hh.mmu.sensor_manager.gate_sensors:
             self.assertIs(gate_sensors['extruder'], extruder_sensor)
             self.assertIs(gate_sensors['mmu_shared_exit'], extruder_sensor)
+
+        # Exercise the complete zero-Bowden choreography, not just construction of
+        # the alias: preload parks behind the extruder sensor, load homes straight
+        # back to it and enters the toolhead, then unload returns to the same park.
+        # A zero load buffer is deliberately smaller than the 8 mm entry-to-extruder
+        # offset. It used to make the adjusted buffer negative and turn subtracting
+        # that buffer into an unintended positive "fast Bowden" move.
+        unit.p.bowden_load_homing_buffer = 0.
+        load_bowden_results = []
+        unload_bowden_results = []
+        load_telemetry = []
+        unload_telemetry = []
+        unload_extruder_results = []
+        state_transitions = []
+        original_load_bowden = hh.mmu._load_bowden
+        original_unload_bowden = hh.mmu._unload_bowden
+        original_unload_extruder = hh.mmu._unload_extruder
+
+        def record_load_bowden(*args, **kwargs):
+            result = original_load_bowden(*args, **kwargs)
+            load_bowden_results.append(result)
+            return result
+
+        def record_unload_bowden(*args, **kwargs):
+            result = original_unload_bowden(*args, **kwargs)
+            unload_bowden_results.append(result)
+            return result
+
+        def record_unload_extruder(*args, **kwargs):
+            result = original_unload_extruder(*args, **kwargs)
+            unload_extruder_results.append(result)
+            return result
+
+        hh.mmu._load_bowden = record_load_bowden
+        hh.mmu._unload_bowden = record_unload_bowden
+        hh.mmu._unload_extruder = record_unload_extruder
+        unit.calibrator.note_load_telemetry = lambda *args: load_telemetry.append(args)
+        unit.calibrator.note_unload_telemetry = lambda *args: unload_telemetry.append(args)
+
+        model = hh.filament()
+        hh.place_filament(0, position=TIP_AT_GATE)
+        hh.run_gcode('MMU_PRELOAD GATE=0')
+        self.assertAlmostEqual(model.tip[0], TIP_AT_GATE)
+
+        from extras.mmu.mmu_constants import (
+            FILAMENT_POS_HOMED_ENTRY,
+            FILAMENT_POS_HOMED_EXTRUDER,
+            FILAMENT_POS_IN_EXTRUDER,
+            GATE_AVAILABLE,
+        )
+        original_set_filament_pos_state = hh.mmu.set_filament_pos_state
+
+        def record_filament_pos_state(state, *args, **kwargs):
+            changed = hh.mmu.filament_pos != state
+            result = original_set_filament_pos_state(state, *args, **kwargs)
+            if changed:
+                state_transitions.append(state)
+            return result
+
+        hh.mmu.set_filament_pos_state = record_filament_pos_state
+
+        hh.heat_extruder(220)
+        hh.mmu.select_gate(0)
+        hh.run_gcode('MMU_LOAD')
+        self.assertEqual(hh.mmu.filament_pos, FILAMENT_POS_LOADED)
+        self.assertGreater(model.tip[0], model.layout['extruder'])
+        self.assertEqual(state_transitions, [
+            FILAMENT_POS_HOMED_ENTRY,
+            FILAMENT_POS_HOMED_EXTRUDER,
+            FILAMENT_POS_LOADED,
+        ])
+
+        state_transitions.clear()
+        hh.run_gcode('MMU_UNLOAD')
+        self.assertEqual(hh.mmu.filament_pos, FILAMENT_POS_UNLOADED)
+        self.assertAlmostEqual(model.tip[0], TIP_AT_GATE, places=3)
+        self.assertEqual(state_transitions, [
+            FILAMENT_POS_IN_EXTRUDER,
+            FILAMENT_POS_HOMED_ENTRY,
+            FILAMENT_POS_UNLOADED,
+        ])
+        self.assertEqual(load_bowden_results, [])
+        self.assertEqual(unload_bowden_results, [])
+        self.assertEqual(len(unload_extruder_results), 1)
+        self.assertIs(unload_extruder_results[0][2], True)
+        self.assertGreaterEqual(load_telemetry[0][2], 0.)
+        self.assertEqual(unload_telemetry[0][2], 0.)
+        self.assertEqual(hh.mmu.gate_status[0], GATE_AVAILABLE)
+
+        # mmu_shared_exit is an implementation alias for the extruder sensor,
+        # not a second physical switch. The parked filament should occupy its
+        # dedicated lane up to one clear sensor in the visual representation.
+        unloaded_visual = hh.mmu.get_filament_position_string()
+        self.assertEqual(unloaded_visual.count('◯'), 1)
+        self.assertGreater(unloaded_visual.split('◯', 1)[0].count('■'), 20)
+        self.assertEqual(hh.errors, [])
+
+    def test_3ms_unload_rehomes_when_extruder_datum_was_not_observed(self):
+        hh = self._check('3ms')
+        model = hh.filament()
+        hh.place_filament(0, position=TIP_AT_GATE)
+        hh.run_gcode('MMU_PRELOAD GATE=0')
+        hh.heat_extruder(220)
+        hh.mmu.select_gate(0)
+        hh.run_gcode('MMU_LOAD')
+
+        # Model the defensive path in _unload_extruder(): the entry sensor is
+        # already reported clear, so HOMED_ENTRY is only an assumption and must
+        # not be used as a precise reference for a direct parking move.
+        check_sensor = hh.mmu.sensor_manager.check_sensor
+
+        def report_extruder_clear(sensor):
+            if sensor == 'extruder':
+                return False
+            return check_sensor(sensor)
+
+        direct_parks = []
+        fallback_homes = []
+        fallback_homed_states = []
+        park_at_gate = hh.mmu._park_at_gate
+        unload_gate = hh.mmu._unload_gate
+        set_gate_homed_state = hh.mmu._set_gate_homed_state
+
+        def record_direct_park(*args, **kwargs):
+            direct_parks.append((args, kwargs))
+            return park_at_gate(*args, **kwargs)
+
+        def record_fallback_home(*args, **kwargs):
+            fallback_homes.append((args, kwargs))
+            return unload_gate(*args, **kwargs)
+
+        def record_fallback_homed_state(*args, **kwargs):
+            result = set_gate_homed_state(*args, **kwargs)
+            fallback_homed_states.append(hh.mmu.filament_pos)
+            return result
+
+        hh.mmu.sensor_manager.check_sensor = report_extruder_clear
+        hh.mmu._park_at_gate = record_direct_park
+        hh.mmu._unload_gate = record_fallback_home
+        hh.mmu._set_gate_homed_state = record_fallback_homed_state
+        hh.run_gcode('MMU_UNLOAD')
+
+        from extras.mmu.mmu_constants import FILAMENT_POS_HOMED_ENTRY
+        self.assertEqual(direct_parks, [])
+        self.assertEqual(len(fallback_homes), 1)
+        self.assertEqual(fallback_homed_states, [FILAMENT_POS_HOMED_ENTRY])
+        self.assertEqual(hh.mmu.filament_pos, FILAMENT_POS_UNLOADED)
+        self.assertAlmostEqual(model.tip[0], TIP_AT_GATE, places=3)
+        self.assertEqual(hh.errors, [])
+
+    def test_3ms_recovery_uses_extruder_state_for_shared_entry_sensor(self):
+        hh = self._check('3ms')
+        model = hh.filament()
+        hh.mmu.select_gate(0)
+
+        from extras.mmu.mmu_constants import (
+            FILAMENT_POS_IN_EXTRUDER,
+            FILAMENT_POS_UNKNOWN,
+        )
+
+        # The shared entry sensor cannot prove how far filament extends into the
+        # toolhead. Treat a trigger conservatively so a subsequent unload starts
+        # with extraction, even when recovery is not permitted to heat and probe.
+        hh.place_filament(0, position=model.layout['extruder_entry'])
+        hh.mmu.set_filament_pos_state(FILAMENT_POS_UNKNOWN, silent=True)
+        hh.mmu.recover_filament_pos(strict=True, can_heat=False, silent=True)
+        self.assertEqual(hh.mmu.filament_pos, FILAMENT_POS_IN_EXTRUDER)
+
+        # A clear shared entry sensor, with no other filament detection, is the
+        # normal parked state and must still recover as fully unloaded.
+        hh.place_filament(0, position=TIP_AT_GATE)
+        hh.mmu.set_filament_pos_state(FILAMENT_POS_UNKNOWN, silent=True)
+        hh.mmu.recover_filament_pos(strict=True, can_heat=False, silent=True)
+        self.assertEqual(hh.mmu.filament_pos, FILAMENT_POS_UNLOADED)
+        self.assertEqual(hh.errors, [])
+
+    def test_extruder_gate_datum_does_not_change_bowden_unit_state(self):
+        hh = self._check('3ms')
+        unit = hh.mmu.mmu_unit(0)
+        unit.require_bowden_move = True
+        hh.place_filament(0, position=TIP_AT_GATE)
+        hh.mmu.select_gate(0)
+        hh.mmu._load_gate()
+
+        from extras.mmu.mmu_constants import (
+            FILAMENT_POS_HOMED_ENTRY,
+            FILAMENT_POS_HOMED_GATE,
+            FILAMENT_POS_UNKNOWN,
+        )
+        self.assertEqual(hh.mmu.filament_pos, FILAMENT_POS_HOMED_GATE)
+
+        # The no-Bowden recovery override must not leak into a conventional
+        # Bowden unit: the same triggered sensor retains the pre-change
+        # HOMED_ENTRY result when a heated extruder check is unavailable.
+        hh.mmu.set_filament_pos_state(FILAMENT_POS_UNKNOWN, silent=True)
+        hh.mmu.recover_filament_pos(strict=True, can_heat=False, silent=True)
+        self.assertEqual(hh.mmu.filament_pos, FILAMENT_POS_HOMED_ENTRY)
+
+    def test_bowden_homing_buffers_reject_negative_config(self):
+        from test.hh import profiles
+
+        for parameter in (
+                'PARAM_BOWDEN_LOAD_HOMING_BUFFER',
+                'PARAM_BOWDEN_UNLOAD_HOMING_BUFFER'):
+            with self.subTest(parameter=parameter):
+                profile = profiles.get('3ms').derive(
+                    '3ms_negative_%s' % parameter.lower(),
+                    syms={parameter: -1})
+                hh = session(profile)
+                self.addCleanup(hh.close)
+                with self.assertRaisesRegex(
+                        Exception,
+                        r"must have minimum of 0"):
+                    hh.boot()
 
     def test_chameleon(self):
         """

--- a/test/test_mmu_toolchange.py
+++ b/test/test_mmu_toolchange.py
@@ -172,6 +172,22 @@ class TestUnload(ToolchangeTestCase):
         self.assertAlmostEqual(self.fil.tip[0], park, places=1)
         self.assertEqual(self.hh.errors, [])
 
+    def test_full_unload_preserves_explicit_bowden_helper_length(self):
+        requests = []
+        original_unload_bowden = self.hh.mmu._unload_bowden
+
+        def record_unload_bowden(length=None, *args, **kwargs):
+            requests.append(length)
+            return original_unload_bowden(length, *args, **kwargs)
+
+        self.hh.mmu._unload_bowden = record_unload_bowden
+        self.hh.run_gcode('MMU_UNLOAD')
+
+        self.assertEqual(requests, [
+            self.hh.mmu.mmu_unit().calibrator.get_bowden_length(),
+        ])
+        self.assertEqual(self.hh.errors, [])
+
     def test_unload_clears_the_path_sensors(self):
         """
         Everything downstream of the gate goes clear. The ENTRY switch does not, and must


### PR DESCRIPTION
## Summary

- skip fast Bowden stages when the selected MMU unit does not require Bowden movement
- keep load, unload, parking, and recovery filament states aligned with the physical extruder-entry datum
- track whether extruder unload established a real reverse-home datum before using the direct parking path
- prevent reserved homing buffers and overshoot compensation from producing negative move distances
- render aliased shared-exit/extruder sensors as one physical landmark, including the parked 3MS state
- enforce non-negative Bowden homing buffer configuration and add regression coverage for both no-Bowden and conventional paths

## Validation

- 132 targeted profile, load/unload, motion, toolchange, and filament-rendering tests pass
- repository-wide Ruff checks pass
- git diff whitespace checks pass