### PR TITLE
Improve 3MS Kconfig filament path defaults

### DIFF
--- a/installer/mmu_types/Kconfig.3ms
+++ b/installer/mmu_types/Kconfig.3ms
@@ -4,6 +4,7 @@ config MMU_TYPE_3MS_1_0
     3MS is a popular simple and reliable type-B MMU design. It is an open
     framed minimalist design and easy to build with any number of gates.
   select VIRTUAL_SELECTOR
+  imply MMU_HAS_SENSOR_EXTRUDER
   select PARAM_VARIABLE_ROTATION_DISTANCES
   select PARAM_FILAMENT_ALWAYS_GRIPPED
 
@@ -38,8 +39,12 @@ if MMU_TYPE_3MS_1_0
 
   config PARAM_GATE_HOMING_MAX
     default 500
+  config PARAM_GATE_PRELOAD_HOMING_MAX
+    default 1500
   config PARAM_GATE_PARKING_DISTANCE
     default -250
+  config PARAM_GATE_FINAL_EJECT_DISTANCE
+    default 1500
 
   comment "_"
 

--- a/test/hh/profiles.py
+++ b/test/hh/profiles.py
@@ -343,7 +343,6 @@ THREE_MS = Profile(
     syms={
         'MMU_TYPE_3MS_1_0': True,
         'BOARD_TYPE_MMB_2_0': True,
-        'MMU_HAS_SENSOR_EXTRUDER': True,
         'PIN_EXTRUDER_SENSOR': 'mcu:PA7',
     },
     description='3MS 1.0 - no-Bowden Type B homing at the extruder sensor',

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -160,6 +160,13 @@ class TestEveryBootableProfile(unittest.TestCase):
         self.assertFalse(unit.require_bowden_move)
         self.assertEqual(unit.calibrator.get_bowden_length(), 0)
         self.assertEqual(unit.p.gate_homing_endstop, 'extruder')
+        # Preload must cover the complete gate-to-extruder path. Once parked,
+        # ordinary gate homing only has to cover the 250 mm parking offset.
+        self.assertEqual(unit.p.gate_homing_max, 500)
+        self.assertEqual(unit.p.gate_parking_distance, -250)
+        self.assertEqual(unit.p.gate_preload_homing_max, 1500)
+        self.assertEqual(unit.p.gate_preload_parking_distance, -250)
+        self.assertEqual(unit.p.gate_final_eject_distance, 1500)
         extruder_sensor = unit.toolhead_wrapper.sensors['extruder']
         self.assertIsNotNone(extruder_sensor)
         for gate_sensors in hh.mmu.sensor_manager.gate_sensors:


### PR DESCRIPTION
## Summary
- imply an extruder entry sensor for the 3MS profile
- increase preload homing distance to 1500 mm
- increase final eject distance to 1500 mm
- extend the 3MS profile regression coverage for sensor, homing, parking, preload, and eject defaults

## Testing
- ./venv/bin/python -m unittest test.test_mmu_profiles
- ./venv/bin/python -m unittest test.test_mmu_profiles.TestEveryBootableProfile.test_3ms_load_unload_round_trip