### PR TITLE
Handle ASCII-only menuconfig terminals

### DIFF
--- a/installer/lib/kconfiglib/menuconfig.py
+++ b/installer/lib/kconfiglib/menuconfig.py
@@ -247,6 +247,14 @@ _SUBMENU_INDENT = 4
 # Number of steps for Page Up/Down to jump
 _PG_JUMP = 6
 
+# Readable substitutions for terminals limited to ASCII. Any other character
+# unsupported by the curses window encoding is replaced with "?".
+_ENCODING_FALLBACKS = str.maketrans({
+    "─": "-",
+    "→": ">",
+    "°": "^",
+})
+
 # Height of the help window in show-help mode
 _SHOW_HELP_HEIGHT = 7
 _ALWAYS_SHOW_HELP_WINDOW = True
@@ -3791,14 +3799,28 @@ def _safe_addstr(win, *args):
     maxlen = _width(win) - x
     s = s.expandtabs()
 
-    try:
+    def addnstr(text):
         # The 'curses' module uses wattr_set() internally if you pass 'attr',
         # overwriting the background style, so setting 'attr' to 0 in the first
         # case won't do the right thing
         if attr is None:
-            win.addnstr(y, x, s, maxlen)
+            win.addnstr(y, x, text, maxlen)
         else:
-            win.addnstr(y, x, s, maxlen, attr)
+            win.addnstr(y, x, text, maxlen, attr)
+
+    try:
+        addnstr(s)
+    except UnicodeEncodeError as e:
+        # Minimal embedded distributions might not provide any UTF-8 locale,
+        # leaving curses configured for ASCII despite the locale repair above.
+        # Preserve common UI glyphs where possible, replace everything else
+        # unsupported with "?", and retry instead of aborting menuconfig.
+        safe_s = s.translate(_ENCODING_FALLBACKS)
+        safe_s = safe_s.encode(e.encoding, errors="replace").decode(e.encoding)
+        try:
+            addnstr(safe_s)
+        except curses.error:
+            pass
     except curses.error:
         pass
 

--- a/test/installer/test_menuconfig.py
+++ b/test/installer/test_menuconfig.py
@@ -23,6 +23,20 @@ class FakeWindow:
         return 10, 80
 
 
+class FakeAsciiWindow(FakeWindow):
+    def __init__(self):
+        self.writes = []
+
+    def getyx(self):
+        return 0, 0
+
+    def addnstr(self, y, x, text, maxlen, *args):
+        # Match an ASCII-configured curses window on embedded systems without
+        # an installed UTF-8 locale.
+        text.encode("ascii")
+        self.writes.append(text[:maxlen])
+
+
 class TestMenuCursorSkipsComments(unittest.TestCase):
 
     def setUp(self):
@@ -87,6 +101,18 @@ class TestMenuCursorSkipsComments(unittest.TestCase):
         with patch.object(menuconfig, "_shown_nodes",
                           return_value=[comment(), comment()]):
             self.assertFalse(menuconfig._enter_menu(submenu))
+
+
+class TestMenuRendering(unittest.TestCase):
+
+    def test_non_ascii_text_has_readable_ascii_fallbacks(self):
+        win = FakeAsciiWindow()
+
+        menuconfig._safe_addstr(
+            win, 0, 0, "─────── → FANS (°C); other arrows: ← ↑ ↓", 1)
+
+        self.assertEqual(
+            win.writes, ["------- > FANS (^C); other arrows: ? ? ?"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- recover when curses cannot encode Unicode on minimal ASCII-only systems such as Creality K1 firmware
- transliterate menu glyphs as: line to hyphen, right arrow to greater-than, and degree to caret
- replace any other character unsupported by the active curses encoding with a question mark
- add regression coverage for styled writes through an ASCII curses window

## Testing
- PYTHONPATH=installer/lib/kconfiglib venv/bin/python -m unittest test.installer.test_menuconfig
- PYTHONPATH=installer/lib/kconfiglib venv/bin/python -m unittest discover -s test/installer (79 tests)