### PR TITLE
Validate queued MMU sensor events

### DIFF
--- a/extras/mmu/commands/mmu_sensor_insert.py
+++ b/extras/mmu/commands/mmu_sensor_insert.py
@@ -67,28 +67,27 @@ class MmuSensorInsertCommand(BaseCommand):
         try:
             with mmu.wrap_sync_gear_to_extruder():
 
+                # Reject stale or bounced insert callbacks.
+                sensor_state = mmu.sensor_manager.check_event_sensor(raw_sensor, gate)
+                if sensor_state is not True:
+                    state = "no longer detects filament" if sensor_state is False else "cannot be read"
+                    mmu.log_assertion(
+                        "Insert handler suspects sensor malfunction on %s (%s). Ignored"
+                        % (raw_sensor, state)
+                    )
+                    return
+
                 if sensor.startswith(SENSOR_ENTRY_PREFIX) and gate is not None:
-                    # The entry sensor is upstream of the gear, so an insert here is ALWAYS
-                    # the user pushing filament in - the MMU cannot cause one. Record it.
+                    # Entry detection proves filament presence, but not a completed preload.
                     mmu.gate_maps.set_gate_status(gate, GATE_UNKNOWN)
 
-                    # Autoloading is a gate change, so never start one on top of an
-                    # operation already in flight. On real Klipper this is belt-and-braces
-                    # (gcode.run_script serialises the whole handler behind the running
-                    # command, so we normally arrive idle) - but a nested select_gate would
-                    # be bad enough to be worth the two lines. An insert raised by the very
-                    # operation we would be interrupting is suppressed at source instead,
-                    # by wrap_suspend_insert_events in _preload_gate / _jog_scan.
+                    # Never start autoload during another MMU operation.
                     if mmu.action != ACTION_IDLE:
-                        # Nothing else will consume a pending shared-NFC result for this gate.
                         mmu._check_pending_filament(gate)  # Have spool_id ready?
                         mmu.log_debug("Not autoloading gate %d: an MMU operation is already "
                                       "in progress" % gate)
                     elif not mmu.is_printing() and mmu.mmu_unit(gate).p.gate_autoload:
-                        # Leave any pending shared-NFC result live: MMU_PRELOAD already grabs
-                        # it up front (_grab_pending, before its own moves) so _preload_gate
-                        # can bypass its per-gate NFC reader and apply the resolved
-                        # spool_id/tag itself on success.
+                        # MMU_PRELOAD consumes pending NFC data before moving.
                         mmu.gcode.run_script_from_command("MMU_PRELOAD GATE=%d" % gate)
                     else:
                         mmu._check_pending_filament(gate)  # Have spool_id ready?

--- a/extras/mmu/commands/mmu_sensor_remove.py
+++ b/extras/mmu/commands/mmu_sensor_remove.py
@@ -68,16 +68,22 @@ class MmuSensorRemoveCommand(BaseCommand):
         try:
             with mmu.wrap_sync_gear_to_extruder():
 
+                # Removal callbacks are queued. Resolve the exact callback source
+                # before dispatch so a bounced or now-unreadable sensor cannot mutate state.
+                sensor_state = mmu.sensor_manager.check_event_sensor(raw_sensor, gate)
+                if sensor_state is not False:
+                    state = "still detects filament" if sensor_state is True else "cannot be read"
+                    mmu.log_assertion(
+                        "Remove handler suspects sensor malfunction on %s (%s). Ignored"
+                        % (raw_sensor, state)
+                    )
+                    return
+
                 if sensor.startswith(SENSOR_ENTRY_PREFIX) and gate is not None:
-                    # Ignore mmu entry runout if endless_spool_eject_gate feature is active
-                    # and we want filament to be consumed to clear gate
-                    if not (mmu.endless_spool_enabled and mmu.p.endless_spool_eject_gate > 0):
-                        mmu.gate_maps.set_gate_status(gate, GATE_EMPTY)
-                    else:
-                        mmu.log_trace(
-                            "Ignoring filament removal detected by %s because endless_spool_eject_gate is active"
-                            % raw_sensor
-                        )
+                    # A confirmed-clear entry sensor means this lane is empty regardless
+                    # of print state. EndlessSpool's waste-eject path also resets the gate
+                    # explicitly, so it needs no special exception here.
+                    mmu.gate_maps.set_gate_status(gate, GATE_EMPTY)
 
                 else:
                     mmu.log_assertion(

--- a/extras/mmu/commands/mmu_sensor_runout.py
+++ b/extras/mmu/commands/mmu_sensor_runout.py
@@ -81,12 +81,29 @@ class MmuSensorRunoutCommand(BaseCommand):
         try:
             with mmu.wrap_sync_gear_to_extruder():
 
-                if sensor and mmu.sensor_manager.check_sensor(sensor):
-                    mmu.log_assertion("Runout handler suspects sensor malfunction on %s. Ignored" % raw_sensor)
+                # Events may be delivered after another gate or unit was selected. Read
+                # the exact sensor named by the event, not a generic sensor in the active map.
+                sensor_state = mmu.sensor_manager.check_event_sensor(raw_sensor, gate)
+
+                if sensor and sensor_state is not False:
+                    state = "still detects filament" if sensor_state is True else "cannot be read"
+                    mmu.log_assertion(
+                        "Runout handler suspects sensor malfunction on %s (%s). Ignored"
+                        % (raw_sensor, state)
+                    )
 
                 else:
-                    # Always update gate map from mmu entry sensor, even if the event is stale
-                    if sensor.startswith(SENSOR_ENTRY_PREFIX) and gate != mmu.gate_selected:
+                    is_entry = sensor.startswith(SENSOR_ENTRY_PREFIX) and gate is not None
+                    is_eject_gate = (
+                        is_entry
+                        and mmu.endless_spool_enabled
+                        and mmu.p.endless_spool_eject_gate == gate
+                    )
+
+                    # Always update the gate map from a confirmed-clear entry sensor,
+                    # including the selected gate and stale/suspended events. The one
+                    # exception is a designated waste gate actively consuming filament.
+                    if is_entry and not is_eject_gate:
                         mmu.gate_maps.set_gate_status(gate, GATE_EMPTY)
 
                     if duplicate or suspended:
@@ -102,8 +119,8 @@ class MmuSensorRunoutCommand(BaseCommand):
                             mmu.log_debug(msg)
 
                     # Real runout to process...
-                    elif sensor.startswith(SENSOR_ENTRY_PREFIX) and gate == mmu.gate_selected:
-                        if mmu.endless_spool_enabled and mmu.p.endless_spool_eject_gate == gate:
+                    elif is_entry and gate == mmu.gate_selected:
+                        if is_eject_gate:
                             mmu.log_trace(
                                 "Ignoring filament runout detected by %s because endless_spool_eject_gate is active on that gate"
                                 % raw_sensor

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -3899,7 +3899,7 @@ class MmuController(MmuFilamentMovement):
                     self.log_error("A runout has been detected. Checking for alternative gates %s" % msg)
                     self.log_info("Remapping T%d to gate %d" % (self.tool_selected, next_gate))
 
-                    if self.p.endless_spool_eject_gate > 0:
+                    if self.p.endless_spool_eject_gate >= 0:
                         self.log_info("Ejecting filament remains to designated waste gate %d" % self.p.endless_spool_eject_gate)
                         self.select_gate(self.p.endless_spool_eject_gate)
                     self._unload_tool(form_tip=FORM_TIP_STANDALONE)

--- a/extras/mmu/mmu_sensor_manager.py
+++ b/extras/mmu/mmu_sensor_manager.py
@@ -515,6 +515,21 @@ class MmuSensorManager:
         return None
 
 
+    def check_event_sensor(self, name, gate=None):
+        """
+        Return the current state of the exact sensor named by a queued event.
+
+        Unlike check_sensor(), this resolves against the stable global registry rather
+        than active_sensors_map. Event delivery may lag behind a gate or unit selection,
+        so checking the active generic sensor can inspect a different physical switch.
+        """
+        mmu_unit = self.mmu.mmu_unit(gate) if gate is not None and gate >= 0 else None
+        _qualified, sensor, _error = self.resolve_sensor(name, mmu_unit=mmu_unit)
+        if sensor is not None and sensor.runout_helper.sensor_enabled:
+            return bool(sensor.runout_helper.filament_present)
+        return None
+
+
     def check_gate_sensor(self, name, gate):
         """
         Return per-gate sensor state or None if unavailable/disabled.

--- a/test/console.py
+++ b/test/console.py
@@ -1678,6 +1678,7 @@ class Console:
     def _meta_place(self, args):
         gate = int(args[0])
         pos = float(args[1]) if len(args) > 1 else TIP_AT_GATE
+        self.fil.refill(gate, sync=False)
         self.hh.place_filament(gate, position=pos)
 
     def _meta_insert(self, args):
@@ -1688,6 +1689,7 @@ class Console:
             raise ValueError('gate must be between 0 and %d' % (self.hh.mmu.num_gates - 1))
         pos = float(args[1]) if len(args) > 1 else TIP_AT_GATE
         mark = len(self.sink)
+        self.fil.refill(gate, sync=False)
         self.hh.place_filament(gate, position=pos, quiet=False)
         self._settle_moonraker()
         self._drain(mark)
@@ -1707,6 +1709,7 @@ class Console:
 
     def _meta_preload(self, args):
         gate = int(args[0])
+        self.fil.refill(gate, sync=False)
         self.hh.place_filament(gate, position=TIP_AT_GATE)
         self.run_command('MMU_PRELOAD GATE=%d' % gate)
 

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -689,6 +689,23 @@ class TestBootupOutput(unittest.TestCase):
         self.assertFalse(console.hh.sensor('mmu_exit_1').present)
         self.assertEqual(console.fil.tip[1], console_mod.TIP_AT_GATE)
 
+    def test_insert_after_exhaust_refills_and_fires_vivid_entry_sensor(self):
+        console = console_mod.Console(console_mod.parse_args(
+            ['--profile', 'ercf_vvd', '--no-log', '--plain']))
+        self.addCleanup(console.close)
+        console.boot()
+
+        with contextlib.redirect_stdout(io.StringIO()) as output:
+            console.meta('/exhaust 11')
+            self.assertFalse(console.hh.sensor('mmu_entry_11').present)
+            console.meta('/advance 0.51')  # Clear the entry sensor's event_delay window
+            console.meta('/insert 11')
+
+        self.assertIn('Preloading gate 11', output.getvalue())
+        self.assertEqual(console.fil.tail[11], float('-inf'))
+        self.assertTrue(console.hh.sensor('mmu_entry_11').present)
+        self.assertEqual(console.hh.mmu.gate_status[11], 1)
+
     def test_reset_rebuilds_the_profile_startup_state(self):
         console = console_mod.Console(console_mod.parse_args(
             ['--profile', 'boxturtle', '--no-log', '--plain']))

--- a/test/test_mmu_endless_spool.py
+++ b/test/test_mmu_endless_spool.py
@@ -144,6 +144,16 @@ class TestRunoutSwapsGate(EndlessSpoolTestCase):
         self.assertIn('runout', announced)
         self.assertIn('endlessspool', announced.replace(' ', ''))
 
+    def test_gate_zero_can_be_used_as_the_designated_waste_gate(self):
+        self.hh.mmu.p.endless_spool_eject_gate = 0
+
+        original = self.load_and_run_out(tool=1)
+
+        self.assertEqual(original, 1, 'test must run out a gate other than the waste gate')
+        self.assertTrue(any('designated waste gate 0' in msg for msg in self.hh.console))
+        self.assertNotEqual(self.hh.mmu.gate_selected, 0,
+                            'replacement filament must be selected after waste ejection')
+
     def test_successive_runouts_walk_through_the_group(self):
         """
         Three spools in a row. Each runout must find the next available gate rather than

--- a/test/test_mmu_sensor_runout.py
+++ b/test/test_mmu_sensor_runout.py
@@ -30,6 +30,7 @@ from test.hh import session
 logging.getLogger().setLevel(logging.CRITICAL)
 
 FILAMENT_POS_LOADED = 10
+GATE_UNKNOWN = -1
 GATE_EMPTY = 0
 GATE_AVAILABLE = 1
 TIP_AT_GATE = -40.0
@@ -65,6 +66,10 @@ class RunoutFilterTestCase(unittest.TestCase):
         """Put monitoring into the armed state and return the reactor time it happened."""
         self.mmu._enable_filament_monitoring()
         return self.hh.reactor.monotonic()
+
+    def set_sensor_state(self, name, present):
+        """Set the level used by direct delayed-handler delivery tests."""
+        self.hh.sensor(name).sensor.runout_helper.filament_present = bool(present)
 
 
 class TestDelayedDelivery(RunoutFilterTestCase):
@@ -158,9 +163,158 @@ class TestGateMap(RunoutFilterTestCase):
             self.hh.settle(1.0)
         self.hh.settle(1.0)
 
+        # deliver() intentionally bypasses the physical edge; model the clear level
+        # that the delayed remove/runout handler must re-check before trusting it.
+        self.set_sensor_state('mmu_entry_2', False)
         self.deliver(tripped, sensor='mmu_entry_2', gate=2)
         self.assertEqual(self.runouts, [], 'idle-lane event should not drive runout handling')
         self.assertEqual(self.mmu.gate_maps.gate_status[2], GATE_EMPTY)
+
+    def test_selected_entry_runout_marks_empty_before_processing(self):
+        gate = self.mmu.gate_selected
+        self.mmu.gate_maps.set_gate_status(gate, GATE_AVAILABLE)
+        self.mmu.endless_spool_enabled = False
+        self.set_sensor_state('mmu_entry_%d' % gate, False)
+
+        self.deliver(self.hh.reactor.monotonic(), sensor='mmu_entry_%d' % gate, gate=gate)
+
+        self.assertEqual(self.mmu.gate_maps.gate_status[gate], GATE_EMPTY)
+        self.assertEqual(len(self.runouts), 1, 'selected gate must still enter normal runout handling')
+
+    def test_bounced_idle_entry_runout_is_ignored_using_its_own_gate_sensor(self):
+        # Gate 0 is active and clear; gate 2, named by the delayed event, has bounced
+        # back to present. Reading the generic active sensor would accept this event.
+        self.mmu.gate_maps.set_gate_status(2, GATE_AVAILABLE)
+        self.set_sensor_state('mmu_entry_0', False)
+        self.set_sensor_state('mmu_entry_2', True)
+
+        self.deliver(self.hh.reactor.monotonic(), sensor='mmu_entry_2', gate=2)
+
+        self.assertEqual(self.mmu.gate_maps.gate_status[2], GATE_AVAILABLE)
+        self.assertEqual(self.runouts, [])
+        self.assertTrue(any('sensor malfunction' in error for error in self.hh.errors))
+
+    def test_unreadable_runout_sensor_is_ignored(self):
+        sensor = self.hh.sensor('mmu_entry_2').sensor
+        sensor.runout_helper.sensor_enabled = False
+        self.mmu.gate_maps.set_gate_status(2, GATE_AVAILABLE)
+
+        self.deliver(self.hh.reactor.monotonic(), sensor='mmu_entry_2', gate=2)
+
+        self.assertEqual(self.mmu.gate_maps.gate_status[2], GATE_AVAILABLE)
+        self.assertEqual(self.runouts, [])
+        self.assertTrue(any('cannot be read' in error for error in self.hh.errors))
+
+
+class TestInsertRemoveHandlers(RunoutFilterTestCase):
+
+    def run_insert(self, gate):
+        self.hh.run_gcode('__MMU_SENSOR_INSERT SENSOR=mmu_entry_%d GATE=%d' % (gate, gate))
+
+    def run_remove(self, gate):
+        self.hh.run_gcode('__MMU_SENSOR_REMOVE SENSOR=mmu_entry_%d GATE=%d' % (gate, gate))
+
+    def test_insert_marks_empty_gate_unknown_before_every_autoload_guard(self):
+        gate = 1
+        unit = self.mmu.mmu_unit(gate)
+        self.set_sensor_state('mmu_entry_%d' % gate, True)
+
+        cases = (
+            ('autoload disabled', False, 0, 0),
+            ('printing', True, 0, 1),
+            ('action busy', False, 1, 1),
+        )
+        for label, printing, action, autoload in cases:
+            with self.subTest(label=label):
+                self.mmu.gate_maps.set_gate_status(gate, GATE_EMPTY)
+                self.mmu.is_printing = lambda value=printing: value
+                self.mmu.action = action
+                unit.p.gate_autoload = autoload
+
+                self.run_insert(gate)
+
+                self.assertEqual(self.mmu.gate_maps.gate_status[gate], GATE_UNKNOWN)
+
+    def test_bounced_insert_is_ignored(self):
+        gate = 1
+        self.mmu.gate_maps.set_gate_status(gate, GATE_EMPTY)
+        self.set_sensor_state('mmu_entry_%d' % gate, False)
+
+        self.run_insert(gate)
+
+        self.assertEqual(self.mmu.gate_maps.gate_status[gate], GATE_EMPTY)
+        self.assertTrue(any('sensor malfunction' in error for error in self.hh.errors))
+
+    def test_remove_marks_gate_empty(self):
+        gate = 1
+        self.mmu.gate_maps.set_gate_status(gate, GATE_AVAILABLE)
+        self.set_sensor_state('mmu_entry_%d' % gate, False)
+
+        self.run_remove(gate)
+
+        self.assertEqual(self.mmu.gate_maps.gate_status[gate], GATE_EMPTY)
+
+    def test_remove_from_unrelated_gate_is_not_hidden_by_eject_gate(self):
+        gate = 1
+        self.mmu.endless_spool_enabled = True
+        self.mmu.p.endless_spool_eject_gate = 2
+        self.mmu.gate_maps.set_gate_status(gate, GATE_AVAILABLE)
+        self.set_sensor_state('mmu_entry_%d' % gate, False)
+
+        self.run_remove(gate)
+
+        self.assertEqual(self.mmu.gate_maps.gate_status[gate], GATE_EMPTY)
+
+    def test_remove_marks_designated_eject_gate_empty_too(self):
+        self.mmu.endless_spool_enabled = True
+        for gate in (0, 2):
+            with self.subTest(gate=gate):
+                self.mmu.p.endless_spool_eject_gate = gate
+                self.mmu.gate_maps.set_gate_status(gate, GATE_AVAILABLE)
+                self.set_sensor_state('mmu_entry_%d' % gate, False)
+
+                self.run_remove(gate)
+
+                self.assertEqual(self.mmu.gate_maps.gate_status[gate], GATE_EMPTY)
+
+    def test_bounced_remove_is_ignored(self):
+        gate = 1
+        self.mmu.gate_maps.set_gate_status(gate, GATE_AVAILABLE)
+        self.set_sensor_state('mmu_entry_%d' % gate, True)
+
+        self.run_remove(gate)
+
+        self.assertEqual(self.mmu.gate_maps.gate_status[gate], GATE_AVAILABLE)
+        self.assertTrue(any('sensor malfunction' in error for error in self.hh.errors))
+
+
+class TestNonGateInsertValidation(unittest.TestCase):
+
+    def setUp(self):
+        self.hh = session('3ms')
+        self.hh.boot()
+        self.assertEqual(self.hh.errors, [], 'bootup was not clean')
+        self.sensor_name = 'default:extruder'
+
+    def tearDown(self):
+        self.hh.close()
+
+    def set_sensor_state(self, present):
+        self.hh.sensor(self.sensor_name).sensor.runout_helper.filament_present = bool(present)
+
+    def test_bounced_extruder_insert_is_rejected_before_bypass_dispatch(self):
+        self.set_sensor_state(False)
+
+        self.hh.run_gcode('__MMU_SENSOR_INSERT SENSOR=%s' % self.sensor_name)
+
+        self.assertTrue(any('sensor malfunction' in error for error in self.hh.errors))
+
+    def test_current_extruder_insert_reaches_bypass_dispatch(self):
+        self.set_sensor_state(True)
+
+        self.hh.run_gcode('__MMU_SENSOR_INSERT SENSOR=%s' % self.sensor_name)
+
+        self.assertEqual(self.hh.errors, [])
 
 
 class TestRunoutArming(RunoutFilterTestCase):
@@ -211,10 +365,14 @@ class TestRunoutArming(RunoutFilterTestCase):
         self.hh.settle(1.0)
         now = self.hh.reactor.monotonic()
 
+        # Direct delivery bypasses the physical switch edge, so publish the clear
+        # levels the delayed callbacks are expected to confirm.
+        self.set_sensor_state('mmu_entry_2', False)
         self.deliver(now, sensor='mmu_entry_2', gate=2)
         self.assertEqual(self.hh.errors, [])
         self.assertEqual(self.mmu.gate_maps.gate_status[2], GATE_EMPTY)
 
+        self.set_sensor_state('mmu_exit_2', False)
         self.deliver(now, sensor='mmu_exit_2', gate=2)
         self.assertEqual(self.hh.errors, [])
         self.assertEqual(self.runouts, [], 'an idle lane must not drive runout handling')


### PR DESCRIPTION
## Summary

- validate the exact sensor state before processing queued insert, remove, and runout callbacks
- keep entry gate status synchronized while preserving EndlessSpool waste-gate behavior
- support gate 0 as the designated EndlessSpool eject gate
- refill simulated filament before place, insert, and preload operations
- add regression coverage for bounced, delayed, unreadable, multi-gate, and simulator event handling

## Validation

- 1,290 repository tests passed
- 254 focused sensor, console, and EndlessSpool tests passed
- Ruff, compileall, and diff whitespace checks passed