### PR TITLE
Fix discrete FlowGuard clog and tangle dispatch

### DIFF
--- a/extras/mmu/unit/mmu_buffer.py
+++ b/extras/mmu/unit/mmu_buffer.py
@@ -65,6 +65,7 @@ class MmuBuffer:
             None,
             switch_pin,
             event_delay=event_delay,
+            events=("clog", "tangle"),
             button_handler=self.sync_compression_callback,
             register=register
         )
@@ -77,6 +78,7 @@ class MmuBuffer:
             None,
             switch_pin,
             event_delay=event_delay,
+            events=("clog", "tangle"),
             button_handler=self.sync_tension_callback,
             register=register
         )

--- a/test/test_mmu_sensor_enable.py
+++ b/test/test_mmu_sensor_enable.py
@@ -266,11 +266,8 @@ class FlowGuardSuppressionTestCase(unittest.TestCase):
     emu: the only shipped profile with an analog buffer sensor, so the only one with a real
     FlowGuard/proportional-sensor path to test against.
 
-    FlowGuard has no other test coverage (test/README.md's coverage map lists it as "none"),
-    and driving a real trip through the sync controller would mean modelling ADC behaviour
-    this suite has never exercised. _process_status is called directly instead, with a
-    minimal but real status shape, to test the one thing this change adds: the guard at its
-    note_clog_tangle dispatch site.
+    _process_status is called directly with a minimal but real status shape so the test can
+    target the dispatch guard without having to manufacture the preceding ADC history.
     """
 
     def setUp(self):
@@ -322,6 +319,63 @@ class FlowGuardSuppressionTestCase(unittest.TestCase):
 
         self._trip('clog')
         self.assertEqual(called, ['clog'])
+
+
+class DiscreteFlowGuardDispatchTestCase(unittest.TestCase):
+    """BoxTurtle's switch buffer must dispatch both FlowGuard event types."""
+
+    def setUp(self):
+        self.hh = session('boxturtle')
+        self.hh.boot()
+        self.assertEqual(self.hh.errors, [], 'bootup was not clean')
+        self.mmu = self.hh.mmu
+        self.sf = self.mmu.mmu_machine.units[0].sync_feedback
+        self.sf.flowguard_active = True
+
+    def tearDown(self):
+        self.hh.close()
+
+    def _trip(self, trigger):
+        calls = []
+
+        def capture_runout(**kwargs):
+            calls.append(kwargs)
+            self.mmu.pause_resume.send_resume_command()
+
+        self.mmu._runout = capture_runout
+        status = {
+            'output': {
+                'sensor_ui': 0.0,
+                'flowguard': {'trigger': trigger, 'reason': 'test'},
+                'autotune': {},
+                'rd_current': 1.0,
+                'rd_prev': 1.0,
+                'rd_tuned': 1.0,
+            }
+        }
+        pause_calls = self.mmu.pause_resume.pause_calls
+        resume_calls = self.mmu.pause_resume.resume_calls
+
+        self.sf._process_status(self.hh.reactor.monotonic(), status)
+        self.hh.reactor.advance(0.)
+
+        self.assertEqual(self.mmu.pause_resume.pause_calls, pause_calls + 1)
+        self.assertEqual(self.mmu.pause_resume.resume_calls, resume_calls + 1)
+        self.assertFalse(self.mmu.pause_resume.is_paused)
+        self.assertFalse(self.sf.flowguard_active)
+        return calls
+
+    def test_compression_sensor_dispatches_clog(self):
+        self.assertEqual(
+            self._trip('clog'),
+            [{'event_type': 'clog', 'sensor': 'unit0:filament_compression'}]
+        )
+
+    def test_tension_sensor_dispatches_tangle(self):
+        self.assertEqual(
+            self._trip('tangle'),
+            [{'event_type': 'tangle', 'sensor': 'unit0:filament_tension'}]
+        )
 
 
 class FlowGuardBufferStatusTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

- register clog and tangle command mappings on discrete compression and tension buffer sensors
- preserve the existing FlowGuard behavior where only a sustained extreme state triggers clog or tangle handling
- add end-to-end BoxTurtle coverage proving clog and tangle reach the normal MMU runout handler with the correct sensor attribution
- verify FlowGuard deactivation and balanced pre-pause handling after dispatch

## Why

FlowGuard already made the sustained-state decision and called note_clog_tangle, but discrete sensor helpers had empty command maps. They asserted the preliminary pause without invoking __MMU_SENSOR_CLOG or __MMU_SENSOR_TANGLE. Proportional sensors already registered these mappings.

## Validation

- 1,306 repository tests passed
- 105 focused FlowGuard, sensor, encoder, and EndlessSpool tests passed
- Ruff, compileall, and diff whitespace checks passed