### PR TITLE
Add per-gear UART address configuration

### DIFF
--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -320,6 +320,9 @@ extra_endstops:
 [% if PARAM_GEAR_TMC != "" %]
 [[ "[" ~ PARAM_GEAR_TMC ~ " mmu_stepper " ~ UNIT_NAME ~ "_gear_" ~ i ~ "]" ]]
 uart_pin                 : [[ (PIN_GEAR_UART_|d)[i] ]]
+[% if BOARD_TYPE_EASY_BRD or BOARD_TYPE_SKR_PICO_1 or BOARD_TYPE_OTHER %]
+uart_address             : [[ (PARAM_GEAR_UART_ADDRESS_|d)[i] ]]
+[% endif %]
 [% if PIN_GEAR_DIAG != "" and (PIN_GEAR_DIAG_|d)[i] != "" %]
 diag_pin                 : [[ (PIN_GEAR_DIAG_|d)[i] ]]
 driver_SGTHRS            : 60

--- a/installer/Kconfig.gear_stepper
+++ b/installer/Kconfig.gear_stepper
@@ -5,7 +5,6 @@
 #   PARAM_GEAR_ROTATION_DISTANCE
 #   PARAM_GEAR_RUN_CURRENT
 #   PARAM_GEAR_HOLD_CURRENT
-#   PARAM_GEAR_UART_ADDRESS (for boards with addressable shared UART)
 #   PARAM_GEAR_FULL_STEPS_PER_ROTATION
 
 menu "Gear stepper"
@@ -25,12 +24,6 @@ menu "Gear stepper"
   config PARAM_GEAR_HOLD_CURRENT
     float "Gear hold current      "
     default 0.1
-
-  config PARAM_GEAR_UART_ADDRESS
-    int "Gear UART address      "
-    default 0
-    range 0 3
-    depends on BOARD_TYPE_EASY_BRD || BOARD_TYPE_SKR_PICO_1 || BOARD_TYPE_OTHER
 
   config PARAM_GEAR_MICROSTEPS
     int "Microsteps             "

--- a/installer/Kconfig.pins
+++ b/installer/Kconfig.pins
@@ -1,7 +1,7 @@
 # This defines the symbol types, pins menu layout and changes to defaults.
 # The defaults are set in the Kconfig.board_type under the boards directory.
 #
-# Responsible for defining all "PIN_*" parameters
+# Responsible for defining all "PIN_*" parameters and board-specific UART addresses
 # Note types must always be defined, the prompts are based on MMU capabilities
 #
 # Assumed that max gates:
@@ -60,6 +60,12 @@ menu "Pins / TMC"
     config PIN_GEAR_UART
       string
       prompt "Gear UART pin    " if PARAM_GEAR_TMC != ""
+    config PARAM_GEAR_UART_ADDRESS
+      int
+      prompt "Gear UART address" if PARAM_GEAR_TMC != ""
+      default 0
+      range 0 3
+      depends on BOARD_TYPE_EASY_BRD || BOARD_TYPE_SKR_PICO_1 || BOARD_TYPE_OTHER
     config PIN_GEAR_STEP
       string "Gear step pin    "
     config PIN_GEAR_DIR
@@ -69,6 +75,14 @@ menu "Pins / TMC"
     config PIN_GEAR_DIAG
       string
       prompt "Gear diag pin    " if PARAM_GEAR_TMC != ""
+
+    @repeat var=i min=1 max=11@
+      config PARAM_GEAR_UART_ADDRESS_$(i)
+        int
+        default 0
+        range 0 3
+        depends on BOARD_TYPE_EASY_BRD || BOARD_TYPE_SKR_PICO_1 || BOARD_TYPE_OTHER
+    @endrepeat@
 
     @repeat var=i min=1 max=11@
       config PIN_GEAR_UART_$(i)
@@ -89,6 +103,8 @@ menu "Pins / TMC"
           comment "_"
           config PIN_GEAR_UART_$(i)
             prompt "Gear $(i) UART pin  " if PARAM_GEAR_TMC != ""
+          config PARAM_GEAR_UART_ADDRESS_$(i)
+            prompt "Gear $(i) UART addr " if PARAM_GEAR_TMC != ""
           config PIN_GEAR_STEP_$(i)
             prompt "Gear $(i) step pin  "
           config PIN_GEAR_DIR_$(i)
@@ -164,17 +180,22 @@ menu "Pins / TMC"
 
     if MMU_HAS_SELECTOR_STEPPER
       config PIN_SELECTOR_UART
-        prompt "Selector UART pin   "
+        prompt "Selector UART pin    "
+      config PARAM_SELECTOR_UART_ADDRESS
+        int "Selector UART address"
+        default 1
+        range 0 3
+        depends on BOARD_TYPE_EASY_BRD || BOARD_TYPE_SKR_PICO_1 || BOARD_TYPE_OTHER
       config PIN_SELECTOR_STEP
-        prompt "Selector step pin   "
+        prompt "Selector step pin    "
       config PIN_SELECTOR_DIR
-        prompt "Selector dir pin    "
+        prompt "Selector dir pin     "
       config PIN_SELECTOR_ENABLE
-        prompt "Selector enable pin "
+        prompt "Selector enable pin  "
       config PIN_SELECTOR_DIAG
-        prompt "Selector diag pin   "
+        prompt "Selector diag pin    "
       config PIN_SELECTOR_ENDSTOP
-        prompt "Selector endstop pin"
+        prompt "Selector endstop pin "
     endif
 
     if INDEXED_SELECTOR
@@ -187,7 +208,7 @@ menu "Pins / TMC"
 
     config PIN_SELECTOR_SERVO
       string
-      prompt "Servo pin           " if MMU_HAS_SELECTOR_SERVO
+      prompt "Servo pin            " if MMU_HAS_SELECTOR_SERVO
   endmenu
 
 # -------------------------------------

--- a/installer/Kconfig.selector_stepper
+++ b/installer/Kconfig.selector_stepper
@@ -6,7 +6,6 @@
 #   PARAM_SELECTOR_ROTATION_DISTANCE
 #   PARAM_SELECTOR_RUN_CURRENT
 #   PARAM_SELECTOR_HOLD_CURRENT
-#   PARAM_SELECTOR_UART_ADDRESS (for boards with addressable shared UART)
 #   PARAM_SELECTOR_ENDSTOP_NAME
 #   PARAM_SELECTOR_FULL_STEPS_PER_ROTATION
 #   PARAM_STARTUP_HOME_SELECTOR
@@ -39,12 +38,6 @@ if MMU_HAS_SELECTOR_STEPPER
     config PARAM_SELECTOR_HOLD_CURRENT
       float "Selector hold current           "
       default 0.2
-
-    config PARAM_SELECTOR_UART_ADDRESS
-      int "Selector UART address           "
-      default 1
-      range 0 3
-      depends on BOARD_TYPE_EASY_BRD || BOARD_TYPE_SKR_PICO_1 || BOARD_TYPE_OTHER
 
     config PARAM_SELECTOR_ENDSTOP_NAME
       string

--- a/installer/boards/Kconfig.skr_pico_1
+++ b/installer/boards/Kconfig.skr_pico_1
@@ -15,6 +15,8 @@ if BOARD_TYPE_SKR_PICO_1
   # MMU Type B
   config PIN_GEAR_UART 
     default "$(MCU_NAME):gpio9" 
+  config PARAM_GEAR_UART_ADDRESS
+    default 0
   config PIN_GEAR_STEP
     default "$(MCU_NAME):gpio11" 
   config PIN_GEAR_DIR
@@ -25,6 +27,10 @@ if BOARD_TYPE_SKR_PICO_1
     default "$(MCU_NAME):gpio4" 
 
   if MULTIGEAR
+    config PIN_GEAR_UART_1
+      default PIN_GEAR_UART
+    config PARAM_GEAR_UART_ADDRESS_1
+      default 1
     config PIN_GEAR_STEP_1
       default "$(MCU_NAME):gpio6" 
     config PIN_GEAR_DIR_1
@@ -34,6 +40,10 @@ if BOARD_TYPE_SKR_PICO_1
     config PIN_GEAR_DIAG_1
       default "$(MCU_NAME):gpio3" 
 
+    config PIN_GEAR_UART_2
+      default PIN_GEAR_UART
+    config PARAM_GEAR_UART_ADDRESS_2
+      default 2
     config PIN_GEAR_STEP_2
       default "$(MCU_NAME):gpio19" 
     config PIN_GEAR_DIR_2
@@ -43,6 +53,10 @@ if BOARD_TYPE_SKR_PICO_1
     config PIN_GEAR_DIAG_2
       default "$(MCU_NAME):gpio25"
 
+    config PIN_GEAR_UART_3
+      default PIN_GEAR_UART
+    config PARAM_GEAR_UART_ADDRESS_3
+      default 3
     config PIN_GEAR_STEP_3
       default "$(MCU_NAME):gpio14" 
     config PIN_GEAR_DIR_3
@@ -54,6 +68,10 @@ if BOARD_TYPE_SKR_PICO_1
   endif
 
   if !MULTIGEAR
+    config PIN_SELECTOR_UART
+      default PIN_GEAR_UART
+    config PARAM_SELECTOR_UART_ADDRESS
+      default 2
     config PIN_SELECTOR_STEP
       default "$(MCU_NAME):gpio19" 
     config PIN_SELECTOR_DIR

--- a/test/installer/test_uart_address.py
+++ b/test/installer/test_uart_address.py
@@ -33,6 +33,14 @@ class TestUartAddressConfiguration(unittest.TestCase):
                 "PARAM_GEAR_UART_ADDRESS": 2,
                 "PARAM_SELECTOR_UART_ADDRESS": 3,
             },
+            "custom_multigear": {
+                "MMU_TYPE_BOX_TURTLE_1_0": True,
+                "BOARD_TYPE_OTHER": True,
+                "PARAM_GEAR_UART_ADDRESS": 0,
+                "PARAM_GEAR_UART_ADDRESS_1": 1,
+                "PARAM_GEAR_UART_ADDRESS_2": 2,
+                "PARAM_GEAR_UART_ADDRESS_3": 3,
+            },
         }
         cls.kconfigs = {}
         with cfg._env(cfg._SINGLE_UNIT_ENV):
@@ -66,7 +74,11 @@ class TestUartAddressConfiguration(unittest.TestCase):
             with self.subTest(board=board):
                 kconfig = self.kconfigs[board]
                 self.assertEqual(kconfig.get("PARAM_GEAR_UART_ADDRESS"), "0")
-                self.assertEqual(kconfig.get("PARAM_SELECTOR_UART_ADDRESS"), "1")
+                selector_address = "2" if board == "skr_pico" else "1"
+                self.assertEqual(
+                    kconfig.get("PARAM_SELECTOR_UART_ADDRESS"),
+                    selector_address,
+                )
 
         for symbol in (
             "PARAM_GEAR_UART_ADDRESS",
@@ -75,12 +87,58 @@ class TestUartAddressConfiguration(unittest.TestCase):
             low, high, _condition = self.kconfigs["unknown"].syms[symbol].ranges[0]
             self.assertEqual((low.str_value, high.str_value), ("0", "3"))
 
+    def test_skr_pico_multigear_uses_shared_uart_pin_and_indexed_addresses(self):
+        kconfig = self.kconfigs["virtual_selector"]
+        uart_pin = kconfig.get("PIN_GEAR_UART")
+        self.assertEqual(uart_pin, "unit0:gpio9")
+        for gear, expected in enumerate((0, 1, 2, 3)):
+            suffix = "" if gear == 0 else "_%d" % gear
+            address_symbol = "PARAM_GEAR_UART_ADDRESS%s" % suffix
+            pin_symbol = "PIN_GEAR_UART%s" % suffix
+            with self.subTest(gear=gear):
+                self.assertEqual(kconfig.get(pin_symbol), uart_pin)
+                self.assertEqual(kconfig.get(address_symbol), str(expected))
+
+        hardware = self.render_hardware(
+            "virtual_selector", self.profile_syms["virtual_selector"])
+        sections = hardware.split("[tmc2209 mmu_stepper unit0_gear")
+        self.assertEqual(len(sections), 5)
+        for gear, expected in enumerate(range(4)):
+            with self.subTest(rendered_gear=gear):
+                self.assertIn(
+                    "uart_pin                 : unit0:gpio9",
+                    sections[gear + 1],
+                )
+                self.assertIn(
+                    "uart_address             : %d" % expected,
+                    sections[gear + 1],
+                )
+
+    def test_non_skr_indexed_gear_addresses_still_default_to_zero(self):
+        kconfig = self.kconfigs["easy_brd"]
+        for gear in range(1, 4):
+            symbol = "PARAM_GEAR_UART_ADDRESS_%d" % gear
+            with self.subTest(symbol=symbol):
+                self.assertEqual(kconfig.get(symbol), "0")
+
+    def test_skr_pico_selector_shares_uart_pin_and_uses_driver_address(self):
+        kconfig = self.kconfigs["skr_pico"]
+        self.assertEqual(
+            kconfig.get("PIN_SELECTOR_UART"),
+            kconfig.get("PIN_GEAR_UART"),
+        )
+        self.assertEqual(kconfig.get("PARAM_SELECTOR_UART_ADDRESS"), "2")
+
     def test_supported_boards_render_uart_addresses(self):
         for board in ("unknown", "easy_brd", "skr_pico"):
             with self.subTest(board=board):
                 hardware = self.render_hardware(board, self.profile_syms[board])
                 self.assertIn("uart_address             : 0", hardware)
-                self.assertIn("uart_address             : 1", hardware)
+                selector_address = 2 if board == "skr_pico" else 1
+                self.assertIn(
+                    "uart_address             : %d" % selector_address,
+                    hardware,
+                )
 
     def test_custom_addresses_are_rendered(self):
         kconfig = self.kconfigs["custom"]
@@ -90,6 +148,26 @@ class TestUartAddressConfiguration(unittest.TestCase):
         hardware = self.render_hardware("custom", self.profile_syms["custom"])
         self.assertIn("uart_address             : 2", hardware)
         self.assertIn("uart_address             : 3", hardware)
+
+    def test_multigear_addresses_are_configurable_and_rendered_per_gear(self):
+        kconfig = self.kconfigs["custom_multigear"]
+        for gear, expected in enumerate((0, 1, 2, 3)):
+            suffix = "" if gear == 0 else "_%d" % gear
+            symbol = "PARAM_GEAR_UART_ADDRESS%s" % suffix
+            with self.subTest(symbol=symbol):
+                self.assertEqual(kconfig.get(symbol), str(expected))
+                self.assertGreater(kconfig.syms[symbol].visibility, 0)
+
+        hardware = self.render_hardware(
+            "custom_multigear", self.profile_syms["custom_multigear"])
+        sections = hardware.split("[tmc2209 mmu_stepper unit0_gear")
+        self.assertEqual(len(sections), 5)
+        for gear, expected in enumerate((0, 1, 2, 3)):
+            with self.subTest(gear=gear):
+                self.assertIn(
+                    "uart_address             : %d" % expected,
+                    sections[gear + 1],
+                )
 
     def test_other_boards_do_not_render_uart_addresses(self):
         hardware = self.render_hardware("mmb", self.profile_syms["mmb"])


### PR DESCRIPTION
## Summary

- move gear and selector UART address settings into the Pins / TMC menus
- support independent UART addresses for every gear stepper in multi-gear configurations
- configure SKR Pico gear drivers to share gpio9 with addresses 0 through 3, and preserve its shared selector UART mapping
- render per-gear UART addresses in the generated hardware config

## Tests

- `PYTHONPATH=installer/lib/kconfiglib ./venv/bin/python -m unittest discover -s test/installer -t . -p "test_*.py" -q` (97 tests)
- `./venv/bin/python -m unittest -q test.test_mmu_config` (30 tests)
- `git diff --check`