### PR TITLE
Make LCD menu gate selection dynamic using printer.mmu.num_gates

### DIFF
--- a/config/optional/mmu_menu.cfg
+++ b/config/optional/mmu_menu.cfg
@@ -49,7 +49,7 @@ type: input
 name: Change Tool: {'%2d' % (menu.input|int)}
 input: 0
 input_min: 0
-input_max: 8
+input_max: {printer.mmu.num_gates - 1}
 input_step: 1
 index: 5
 gcode:
@@ -60,7 +60,7 @@ type: input
 name: Select Tool: {'%2d' % (menu.input|int)}
 input: 0
 input_min: 0
-input_max: 8
+input_max: {printer.mmu.num_gates - 1}
 input_step: 1
 index: 6
 gcode:
@@ -71,7 +71,7 @@ type: input
 name: Preload Tool: {'%1d' % (menu.input|int)}
 input: 0
 input_min: 0
-input_max: 8
+input_max: {printer.mmu.num_gates - 1}
 input_step: 1
 index: 7
 gcode:


### PR DESCRIPTION
Hi! This PR replaces the hardcoded `input_max: 8` limits in `mmu_menu.cfg` with a dynamic calculation: `{printer.mmu.num_gates - 1}`. 

Currently, the hardcoded value allows users to select a non-existent gate on configurations with fewer gates, causing Klipper errors. It also requires manual editing for users with 4, 9, or 12-gate MMU setups. Using the existing Happy Hare variable makes the menu file plug-and-play for everyone.
