### PR TITLE
Fix HTLF runtime vendor validation

### DIFF
--- a/extras/mmu/mmu_constants.py
+++ b/extras/mmu/mmu_constants.py
@@ -37,6 +37,7 @@ VENDOR_KMS            = "KMS"
 VENDOR_EMU            = "EMU"
 VENDOR_LOW_RIDER      = "LowRider"
 VENDOR_QIDI           = "QIDI"
+VENDOR_HTLF           = "HTLF"
 VENDOR_OTHER          = "Other"
 
 UNIT_ALT_DISPLAY_NAMES = {
@@ -66,6 +67,7 @@ VENDORS = [
     VENDOR_EMU,
     VENDOR_LOW_RIDER,
     VENDOR_QIDI,
+    VENDOR_HTLF,
     VENDOR_OTHER,
 ]
 

--- a/test/installer/test_htlf.py
+++ b/test/installer/test_htlf.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+from extras.mmu.mmu_constants import VENDORS
 from test.hh import cfg, profiles
 
 
@@ -46,6 +47,9 @@ class TestHtlfProfile(unittest.TestCase):
 
         self.assertTrue(self.kconfig.is_enabled("PARAM_VARIABLE_ROTATION_DISTANCES"))
         self.assertTrue(self.kconfig.is_enabled("PARAM_FILAMENT_ALWAYS_GRIPPED"))
+
+    def test_vendor_is_accepted_by_runtime_config(self):
+        self.assertIn(self.kconfig.get("PARAM_VENDOR"), VENDORS)
 
 
 if __name__ == "__main__":

--- a/test/installer/test_vendor_choices.py
+++ b/test/installer/test_vendor_choices.py
@@ -1,0 +1,28 @@
+# Keep installer-generated MMU vendors in sync with Klipper runtime validation.
+
+import glob
+import re
+import unittest
+
+from extras.mmu.mmu_constants import VENDORS
+from test.hh import cfg
+
+
+class TestVendorChoices(unittest.TestCase):
+
+    def test_all_kconfig_mmu_vendors_are_runtime_choices(self):
+        vendor_defaults = set()
+        pattern = re.compile(
+            r"config PARAM_VENDOR\s+default \"([^\"]+)\"",
+            re.MULTILINE,
+        )
+        for path in glob.glob(cfg.REPO_ROOT + "/installer/mmu_types/Kconfig.*"):
+            with open(path, encoding="utf-8") as stream:
+                vendor_defaults.update(pattern.findall(stream.read()))
+
+        self.assertTrue(vendor_defaults, "no MMU vendor defaults found in Kconfig")
+        self.assertEqual(vendor_defaults - set(VENDORS), set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- add HTLF to the supported runtime MMU vendor choices
- verify the HTLF Kconfig vendor is accepted at runtime
- add a regression test covering every Kconfig MMU vendor

Tests:
- ./venv/bin/python -m unittest test.installer.test_htlf test.installer.test_vendor_choices
- env PYTHONPATH=installer/lib/kconfiglib ./venv/bin/python -m unittest test.installer.test_menuconfig test.installer.test_htlf test.installer.test_vendor_choices
- ./venv/bin/ruff check extras/mmu/mmu_constants.py test/installer/test_htlf.py test/installer/test_vendor_choices.py
- git diff --check