### PR TITLE
fix wrong UNSELECT symbol in environment sensor header comment

### DIFF
--- a/installer/Kconfig.environment_sensor
+++ b/installer/Kconfig.environment_sensor
@@ -30,7 +30,7 @@
 #   - i2c3_PB3_PB4    (alternative)
 #
 # Can be disabled and forced off with:
-#   select UNSELECT_MMU_HAS_NFC_READER
+#   select UNSELECT_MMU_HAS_ENVIRONMENT_SENSOR
 
 
 comment "_"


### PR DESCRIPTION
Tiny docs-only fix: The header comment in the environment sensor Kconfig names the NFC reader symbol, likely a scaffolding oopsie.
This changes it to the symbol actually used further down in a guard.