### PR TITLE
Fix indexed UART address defaults

### DIFF
--- a/installer/Kconfig.pins
+++ b/installer/Kconfig.pins
@@ -81,7 +81,6 @@ menu "Pins / TMC"
         int
         default 0
         range 0 3
-        depends on BOARD_TYPE_EASY_BRD || BOARD_TYPE_SKR_PICO_1 || BOARD_TYPE_OTHER
     @endrepeat@
 
     @repeat var=i min=1 max=11@
@@ -104,7 +103,7 @@ menu "Pins / TMC"
           config PIN_GEAR_UART_$(i)
             prompt "Gear $(i) UART pin  " if PARAM_GEAR_TMC != ""
           config PARAM_GEAR_UART_ADDRESS_$(i)
-            prompt "Gear $(i) UART addr " if PARAM_GEAR_TMC != ""
+            prompt "Gear $(i) UART addr " if PARAM_GEAR_TMC != "" && (BOARD_TYPE_EASY_BRD || BOARD_TYPE_SKR_PICO_1 || BOARD_TYPE_OTHER)
           config PIN_GEAR_STEP_$(i)
             prompt "Gear $(i) step pin  "
           config PIN_GEAR_DIR_$(i)

--- a/test/installer/test_uart_address.py
+++ b/test/installer/test_uart_address.py
@@ -121,6 +121,23 @@ class TestUartAddressConfiguration(unittest.TestCase):
             with self.subTest(symbol=symbol):
                 self.assertEqual(kconfig.get(symbol), "0")
 
+    def test_unsupported_multigear_board_hides_addresses_with_valid_defaults(self):
+        with cfg._env(cfg._SINGLE_UNIT_ENV):
+            kconfig = cfg._kconfig(
+                "unsupported_multigear_uart_addresses",
+                {
+                    "MMU_CUSTOM_TYPE_EVERYTHING": True,
+                    "BOARD_TYPE_MMB_2_0": True,
+                    "PARAM_NUM_GATES": 5,
+                },
+            )
+
+        for gear in range(1, 5):
+            symbol = "PARAM_GEAR_UART_ADDRESS_%d" % gear
+            with self.subTest(symbol=symbol):
+                self.assertEqual(kconfig.get(symbol), "0")
+                self.assertEqual(kconfig.syms[symbol].visibility, 0)
+
     def test_skr_pico_selector_shares_uart_pin_and_uses_driver_address(self):
         kconfig = self.kconfigs["skr_pico"]
         self.assertEqual(


### PR DESCRIPTION
## Summary

- keep indexed gear UART address parameters on a valid default of 0 for every board
- show per-gear UART address prompts only on Easy-BRD, SKR Pico, and custom boards
- cover an unsupported five-gate multigear MMB configuration that previously saved empty integer assignments

This prevents generated configurations from containing `CONFIG_PARAM_GEAR_UART_ADDRESS_n=` and removes the invalid-integer warnings on reload.

## Testing

- `PYTHONPATH=installer/lib/kconfiglib venv/bin/python -m unittest test.installer.test_uart_address` (10 tests passed)
- full installer suite before branch isolation (107 tests passed)