### PR TITLE
Fix Bowden and ViViD test coverage

### DIFF
--- a/test/installer/test_low_rider.py
+++ b/test/installer/test_low_rider.py
@@ -77,14 +77,6 @@ class TestLowRiderProfile(unittest.TestCase):
         customized.syms["PARAM_SERVO_GATE_ANGLES"].set_value("26,58,90,118")
         self.assertFalse(customized.is_enabled("W20"))
 
-    def test_extruder_gate_endstop_forces_no_bowden_move(self):
-        bowden = self.kconfig.syms["PARAM_REQUIRE_BOWDEN_MOVE"]
-        self.assertEqual(bowden.str_value, "0")
-        self.assertEqual(bowden.visibility, 0)
-
-        bowden.set_value("1")
-        self.assertEqual(bowden.str_value, "0")
-
     def test_extruder_gate_keeps_bowden_and_toolhead_defaults_hidden(self):
         hidden_defaults = {
             "PARAM_BOWDEN_LOAD_HOMING_BUFFER": "20",

--- a/test/installer/test_mmx.py
+++ b/test/installer/test_mmx.py
@@ -63,26 +63,5 @@ class TestMmxDesignAttributes(unittest.TestCase):
         self.assertGreater(
             released.syms["PARAM_FILAMENT_ALWAYS_GRIPPED"].visibility, 0)
 
-    def test_mmx_requires_bowden_move_for_non_extruder_gate_endstop(self):
-        with cfg._env(cfg._SINGLE_UNIT_ENV):
-            kconfig = cfg._kconfig(
-                "mmx_shared_exit_bowden",
-                {
-                    "MMU_TYPE_MMX_1_0": True,
-                    "MMU_HAS_SENSOR_SHARED_EXIT": True,
-                },
-            )
-
-        self.assertEqual(
-            kconfig.get("PARAM_GATE_HOMING_ENDSTOP"), "mmu_shared_exit")
-        bowden = kconfig.syms["PARAM_REQUIRE_BOWDEN_MOVE"]
-        self.assertEqual(bowden.str_value, "1")
-        self.assertEqual(bowden.visibility, 0)
-        self.assertEqual(bowden.assignable, ())
-
-        bowden.set_value("0")
-        self.assertEqual(bowden.str_value, "1")
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/installer/test_qidi_box.py
+++ b/test/installer/test_qidi_box.py
@@ -75,19 +75,6 @@ class TestQidiBoxProfile(unittest.TestCase):
         self.assertEqual(customized.get("PARAM_VARIABLE_ROTATION_DISTANCES"), "1")
         self.assertEqual(customized.get("PARAM_HAS_BYPASS"), "1")
 
-    def test_shared_exit_requires_bowden_move(self):
-        bowden = self.kconfig.syms["PARAM_REQUIRE_BOWDEN_MOVE"]
-        self.assertEqual(bowden.str_value, "1")
-        self.assertEqual(bowden.visibility, 0)
-        self.assertEqual(bowden.assignable, ())
-        self.assertGreater(
-            self.kconfig.syms["PARAM_BOWDEN_UNLOAD_HOMING_BUFFER"].visibility,
-            0,
-        )
-
-        bowden.set_value("0")
-        self.assertEqual(bowden.str_value, "1")
-
     def test_toolhead_without_forced_homing_hides_extruder_method(self):
         with cfg._env(cfg._SINGLE_UNIT_ENV):
             kconfig = cfg._kconfig(

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -2410,7 +2410,7 @@ class TestTheDefaultProfile(unittest.TestCase):
         self.assertGreater(len(set(seen)), 50, 'the filament did not move between updates')
         self.assertEqual(seen, sorted(seen), 'a load should only ever feed filament forwards')
 
-    def test_gate9_compression_rises_only_during_extruder_home(self):
+    def test_gate9_compression_rises_only_during_forced_extruder_home(self):
         """ViViD's buffer must stay uncompressed throughout its Bowden move."""
         from extras.mmu.mmu_constants import (
             FILAMENT_POS_HOMED_ENTRY,
@@ -2420,6 +2420,13 @@ class TestTheDefaultProfile(unittest.TestCase):
         console = self.console
         hh = console.hh
         hh.set_pacing(1.)
+        # The shared toolhead sensor now disables extruder homing by default. Opt in
+        # explicitly so this test continues to exercise ViViD's compression-home path.
+        hh.run_gcode(
+            'MMU_TEST_CONFIG UNIT=1 QUIET=1 '
+            'extruder_force_homing=1 '
+            'extruder_homing_endstop=filament_compression'
+        )
         compression = hh.sensor('unit1:filament_compression')
         previous = [compression.present]
         rising_reasons = []


### PR DESCRIPTION
## Summary
- remove three redundant promptless Kconfig override tests that emitted expected warnings
- explicitly enable forced compression homing in the paced ViViD test
- align the ViViD scenario with the new toolhead-sensor default

## Testing
- venv/bin/python -m unittest test.installer.test_qidi_box test.installer.test_low_rider test.installer.test_mmx
- venv/bin/python -m unittest test.test_mmu_console