### PR TITLE
Fix LED swatch colour tests on truecolor terminals

### DIFF
--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -1132,8 +1132,9 @@ class TestLedSwatches(unittest.TestCase):
     row read as "some default-coloured thing I do not recognise".
     """
 
-    def swatches(self, data, per_gate, color=False):
-        console = console_mod.Console(console_mod.parse_args(['--plain', '--no-log']))
+    def swatches(self, data, per_gate, color=False, mode='auto'):
+        console = console_mod.Console(
+            console_mod.parse_args(['--plain', '--no-log', '--color', mode]))
         console.color = color
         return console._swatches(data, per_gate)
 
@@ -1181,14 +1182,25 @@ class TestLedSwatches(unittest.TestCase):
 
     def test_a_bright_led_is_left_exactly_as_it_is(self):
         """The floor is for the bottom of the range only - it must not touch anything else."""
-        self.assertEqual(self.swatches([(0.25, 0.25, 0.25, 0.)], 1, color=True),
-                         console_mod.paint(self.ON, console_mod.fg(64, 64, 64, '256')[2:-1]))
+        # Each depth pinned: 'auto' would resolve through the runner's $COLORTERM,
+        # and a truecolor terminal once turned this test red on CI-green code.
+        for mode in ('256', 'truecolor'):
+            with self.subTest(mode=mode):
+                self.assertEqual(
+                    self.swatches([(0.25, 0.25, 0.25, 0.)], 1, color=True, mode=mode),
+                    console_mod.paint(self.ON, console_mod.fg(64, 64, 64, mode)[2:-1]))
 
     def test_a_lit_led_is_painted_in_its_own_colour(self):
-        got = self.swatches([(1., 0., 0., 0.), (0., 0., 0., 0.)], 1, color=True)
-        self.assertIn('\x1b[38;5;', got, 'the lit LED lost its colour')
-        self.assertIn('\x1b[90m', got, 'the unlit LED should be grey')
-        check_no_line_leaks(self, got)
+        # As above: assert each depth rather than whichever one the ambient
+        # $COLORTERM happens to pick, and cover the truecolor paint path too.
+        for mode in ('256', 'truecolor'):
+            with self.subTest(mode=mode):
+                got = self.swatches([(1., 0., 0., 0.), (0., 0., 0., 0.)], 1,
+                                    color=True, mode=mode)
+                sgr = '2' if mode == 'truecolor' else '5'
+                self.assertIn('\x1b[38;%s;' % sgr, got, 'the lit LED lost its colour')
+                self.assertIn('\x1b[90m', got, 'the unlit LED should be grey')
+                check_no_line_leaks(self, got)
 
     def test_a_degenerate_group_size_still_terminates(self):
         self.assertEqual(self.swatches([(0., 0., 0., 0.)] * 2, 0), self.OFF + ' ' + self.OFF)


### PR DESCRIPTION
 Two TestLedSwatches assertions hard-coded 256-colour escapes while Console resolves --color auto from the ambient $COLORTERM, so on any truecolor terminal the test fails.

 The swatch helper now pins the depth via --color, and both tests assert in 256 and truecolor subsests with expectations derived from the same mode.

 Test-only change to test/test_mmu_console.py. Verified in a manual `make test` on a truecolor terminal, and real world CI verification is about to happen when I submit.

:robot: Disclosure: This change was generated with LLM assistance. All output has been human-reviewed and tested to the best of my abilities.