### PR TITLE
Make install.sh cwd-agnostic and improve self-update handling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,7 @@ usage() {
     echo "${C_OFF}"
     echo "${C_INFO}(no flags for safe re-install / upgrade)${C_OFF}"
     echo "${C_INFO}[config_file]${C_OFF} is optional, if not specified the default config filename (.mmu_config) will be used."
+    echo "  Relative paths are interpreted relative to the Happy-Hare checkout directory."
     echo "  -i for interactive install (open menuconfig)"
     echo "  -u, -d for uninstall"
     echo "  -b <branch> to switch to specified feature branch (sticky)"
@@ -324,6 +325,24 @@ set_moonraker_primary_branch() {
     fi
 }
 
+# Normalise KCONFIG_CONFIG so install.sh and the make Kconfig recipes (menuconfig,
+# olddefconfig, kconfig_needs_update) always refer to the same file. Absolute paths
+# pass through untouched; relative paths anchor to the project directory, because every make
+# invocation goes through run_make (`make -C $SCRIPT_DIR`) and kconfiglib uses
+# KCONFIG_CONFIG as-is against its own process cwd - which is the project dir, not the
+# caller's directory. Without this, e.g. `./Happy-Hare/install.sh -i`` from the parent
+# directory would have menuconfig save .mmu_config in the working directory while this script's
+# [ -e ]/source checks look in the caller's directory, aborting with "has not been
+# saved" even though the save succeeded.
+resolve_kconfig_config() {
+    KCONFIG_CONFIG=${KCONFIG_CONFIG:-.mmu_config}
+    case "${KCONFIG_CONFIG}" in
+    /*) ;;
+    *) KCONFIG_CONFIG=${SCRIPT_DIR}/${KCONFIG_CONFIG} ;;
+    esac
+    export KCONFIG_CONFIG
+}
+
 
 ##### V3 Upgrade support vvv ##################################################################
 
@@ -331,7 +350,8 @@ set_moonraker_primary_branch() {
 # on disk with a "happy_hare_version: 3.x" stamp (the value Happy Hare itself writes
 # and trusts for exactly this purpose).
 v3_detected() {
-    guessed_kconfig="${KCONFIG_CONFIG:-${SCRIPT_DIR}/.mmu_config}"
+    resolve_kconfig_config
+    guessed_kconfig="${KCONFIG_CONFIG}"
     v3_cfg="$(guess_klipper_config_home)/mmu/base/mmu_parameters.cfg"
     [ ! -e "${guessed_kconfig}" ] \
         && [ -f "${v3_cfg}" ] \
@@ -378,7 +398,10 @@ offer_v3_v4_choice() {
         "$SCRIPT_DIR/installer/self_update.sh" || exit 1
         # The branch switch above already fetched and pulled v3. Its installer uses
         # SKIP_UPDATE (rather than v4's F_SKIP_UPDATE) to suppress a redundant update.
-        SKIP_UPDATE=YES F_SKIP_UPDATE=force exec "$0" "$@"
+        # Absolute path, not "$0": the script has by now cd'd into the project
+        # directory, so a relatively typed $0 (e.g. ../Happy-Hare/install.sh)
+        # would no longer resolve.
+        SKIP_UPDATE=YES F_SKIP_UPDATE=force exec "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"
     else
         echo "${C_WARNING}Proceeding with the v4 upgrade. Your v3 'mmu' config directory will be${C_OFF}"
         echo "${C_WARNING}renamed to 'mmu.V3' for reference - nothing is deleted.${C_OFF}"
@@ -532,6 +555,12 @@ if [ "${INSTALL_SH_SOURCE_ONLY:-}" = y ]; then
 fi
 
 
+# Run the entire main flow with the project directory as the working directory.
+# install.sh itself is cwd-agnostic (its paths are absolute or project-anchored),
+# but its subprocesses are not - most visibly self_update.sh's git calls, which
+# fail with 'not a git repository' when launched from a non-repo directory.
+cd "${SCRIPT_DIR}"
+
 # Convert long options to short options
 for arg in "$@"; do
     shift
@@ -625,7 +654,7 @@ elif [ ! "${F_SKIP_UPDATE}" ] && [ ! "${F_UNINSTALL}" ]; then
     # -b <branch>") since self_update.sh never runs to consult BRANCH in that case either.
     [ -n "${BRANCH}" ] && set_moonraker_primary_branch "${BRANCH}"
     "$SCRIPT_DIR/installer/self_update.sh" || exit 1
-    F_SKIP_UPDATE=force exec "$0" "$@"
+    F_SKIP_UPDATE=force exec "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"
 else
     [ -t 1 ] && clear
     echo "${C_NOTICE}Skipping (git) self update${C_OFF}"
@@ -636,7 +665,7 @@ if [ "$1" ]; then
     KCONFIG_CONFIG="$1"
 fi
 
-export KCONFIG_CONFIG="${KCONFIG_CONFIG-.mmu_config}"
+resolve_kconfig_config
 export PATH="${SCRIPT_DIR}:${PATH}"
 
 case "${os_type}" in

--- a/installer/self_update.sh
+++ b/installer/self_update.sh
@@ -49,7 +49,15 @@ self_update() {
     else
         echo "${C_NOTICE}Running on '${current_branch}' branch" \
             "Checking for updates...${C_OFF}"
-        if ! git diff --quiet --exit-code "origin/${current_branch}"; then
+        # The remote branch may not be named like the local one: prefer this
+        # branch's tracking remote if set, otherwise assume the same name on
+        # origin.
+        upstream=$(git rev-parse --abbrev-ref "@{u}" 2>/dev/null) \
+            || upstream="origin/${current_branch}"
+        # A branch with no remote counterpart (e.g. a local-only branch) has
+        # nothing to update from; don't treat the missing ref as an update.
+        if git rev-parse --verify --quiet "${upstream}" \
+            && ! git diff --quiet --exit-code "${upstream}"; then
             echo "${C_NOTICE}Found a new version of Happy Hare on github, updating...${C_OFF}"
             if [ -n "$(git status --porcelain)" ]; then
                 git stash push -m 'local changes stashed before self update' --quiet

--- a/installer/self_update.sh
+++ b/installer/self_update.sh
@@ -8,6 +8,11 @@
 
 set -e # Exit immediately on error
 
+# Anchor the working directory to the project root (this script's parent):
+# every git call below needs a repo cwd, and install.sh (or a user running us
+# directly) may be standing anywhere else.
+cd "$(dirname -- "$0")/.."
+
 self_update() {
     git_cmd="git branch --show-current"
     if which timeout >/dev/null 2>&1; then

--- a/test/installer/test_install_sh.py
+++ b/test/installer/test_install_sh.py
@@ -321,7 +321,7 @@ class TestInstallSh(unittest.TestCase):
         )
         self_update.chmod(0o755)
         reexec = self.write(
-            self.root / "reexec.sh",
+            fake_checkout / "reexec.sh",
             "#!/bin/sh\n"
             "printf '%s:%s:%s\\n' \"$BRANCH\" \"$F_SKIP_UPDATE\" \"$SKIP_UPDATE\" "
             ">\"$TEST_LOG/reexec\"\n",
@@ -373,6 +373,13 @@ class TestInstallSh(unittest.TestCase):
         subprocess.run(["git", "-C", str(checkout), "checkout", "-b",
                         "codex/local-only"], check=True, capture_output=True, text=True)
 
+        # Run a copy of the script inside the throwaway checkout: the script
+        # re-anchors to its own location, so the original would act on the real
+        # repo (stash/checking out branches in the user's working tree).
+        script = self.write(checkout / "installer" / "self_update.sh",
+                            SELF_UPDATE_SH.read_text(encoding="utf-8"))
+        script.chmod(0o755)
+
         env = os.environ.copy()
         env.update({
             "BRANCH": "v3",
@@ -382,7 +389,7 @@ class TestInstallSh(unittest.TestCase):
             "C_ERROR": "",
         })
         result = subprocess.run(
-            ["/bin/sh", str(SELF_UPDATE_SH)], cwd=checkout, env=env,
+            ["/bin/sh", str(script)], cwd=checkout, env=env,
             text=True, capture_output=True,
         )
 

--- a/test/installer/test_install_sh.py
+++ b/test/installer/test_install_sh.py
@@ -14,6 +14,19 @@ INSTALL_SH = REPO_ROOT / "install.sh"
 SELF_UPDATE_SH = REPO_ROOT / "installer" / "self_update.sh"
 MAKEFILE = REPO_ROOT / "Makefile"
 
+# Environment for every git call on the scratch repos: the user's global and
+# system gitconfig are isolated (an alias like `tag = tag -a`, a hooks path or
+# an editor in there would otherwise make a test interactive), and no editor
+# is ever invoked. Tests must never depend on - or be stopped by - the
+# runner's own git setup.
+GIT_ENV = {
+    **os.environ,
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_NOSYSTEM": "1",
+    "GIT_EDITOR": "true",
+    "GIT_SEQUENCE_EDITOR": "true",
+}
+
 
 class TestInstallSh(unittest.TestCase):
 
@@ -352,27 +365,33 @@ class TestInstallSh(unittest.TestCase):
         checkout = self.root / "checkout"
 
         subprocess.run(["git", "init", "--bare", str(remote)], check=True,
-                       capture_output=True, text=True)
+                       capture_output=True, text=True, env=GIT_ENV)
         subprocess.run(["git", "init", str(checkout)], check=True,
-                       capture_output=True, text=True)
+                       capture_output=True, text=True, env=GIT_ENV)
         for key, value in (("user.name", "Installer Test"),
-                           ("user.email", "installer@example.invalid")):
+                           ("user.email", "installer@example.invalid"),
+                           ("commit.gpgsign", "false")):
             subprocess.run(["git", "-C", str(checkout), "config", key, value],
-                           check=True)
+                           check=True, env=GIT_ENV)
         self.write(checkout / "marker", "v3\n")
-        subprocess.run(["git", "-C", str(checkout), "add", "marker"], check=True)
-        subprocess.run(["git", "-C", str(checkout), "commit", "-m", "v3"],
-                       check=True, capture_output=True, text=True)
+        subprocess.run(["git", "-C", str(checkout), "add", "marker"], check=True,
+                       env=GIT_ENV)
+        subprocess.run(["git", "-C", str(checkout), "-c", "user.name=Installer Test",
+                        "-c", "user.email=installer@example.invalid",
+                        "-c", "commit.gpgsign=false", "commit", "-m", "v3"],
+                       check=True, capture_output=True, text=True, env=GIT_ENV)
         subprocess.run(["git", "-C", str(checkout), "branch", "-M", "v3"],
-                       check=True)
-        subprocess.run(["git", "-C", str(checkout), "tag", "v3-test"], check=True)
+                       check=True, env=GIT_ENV)
+        subprocess.run(["git", "-C", str(checkout), "tag", "-m", "v3-test",
+                        "v3-test"], check=True, env=GIT_ENV)
         subprocess.run(["git", "-C", str(checkout), "remote", "add", "origin",
-                        str(remote)], check=True)
+                        str(remote)], check=True, env=GIT_ENV)
         subprocess.run(["git", "-C", str(checkout), "push", "-u", "origin", "v3",
-                        "--tags"], check=True, capture_output=True, text=True)
+                        "--tags"], check=True, capture_output=True, text=True,
+                       env=GIT_ENV)
         subprocess.run(["git", "-C", str(checkout), "checkout", "-b",
-                        "codex/local-only"], check=True, capture_output=True, text=True)
-
+                        "codex/local-only"], check=True, capture_output=True,
+                       text=True, env=GIT_ENV)
         # Run a copy of the script inside the throwaway checkout: the script
         # re-anchors to its own location, so the original would act on the real
         # repo (stash/checking out branches in the user's working tree).
@@ -380,7 +399,7 @@ class TestInstallSh(unittest.TestCase):
                             SELF_UPDATE_SH.read_text(encoding="utf-8"))
         script.chmod(0o755)
 
-        env = os.environ.copy()
+        env = GIT_ENV.copy()
         env.update({
             "BRANCH": "v3",
             "C_OFF": "",
@@ -396,12 +415,115 @@ class TestInstallSh(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         current = subprocess.run(
             ["git", "-C", str(checkout), "branch", "--show-current"],
-            check=True, text=True, capture_output=True,
+            check=True, text=True, capture_output=True, env=GIT_ENV,
         ).stdout.strip()
         self.assertEqual(current, "v3")
         self.assertIn("Switching to 'v3' branch", result.stdout)
         self.assertNotIn("Running on 'codex/local-only' branch", result.stdout)
         self.assertNotIn("Found a new version", result.stdout)
+
+    def make_update_checkout(self, branch=None):
+        """A scratch checkout containing a copy of the real self_update.sh.
+
+        The script re-anchors itself to the parent of its own location, so
+        running a copy that lives inside this throwaway checkout keeps it from
+        ever touching the real repo (where an "update" would rewrite the
+        working tree).
+        """
+        remote = self.root / "remote.git"
+        checkout = self.root / "checkout"
+        subprocess.run(["git", "init", "--bare", str(remote)], check=True,
+                       capture_output=True, text=True, env=GIT_ENV)
+        # The bare's HEAD defaults to the runner's init.defaultBranch (often
+        # 'master'), which would leave a later clone with no checkout. Point
+        # it at the branch this helper publishes.
+        subprocess.run(["git", "-C", str(remote), "symbolic-ref", "HEAD",
+                        "refs/heads/main"], check=True, env=GIT_ENV)
+        subprocess.run(["git", "init", str(checkout)], check=True,
+                       capture_output=True, text=True, env=GIT_ENV)
+        for key, value in (("user.name", "Installer Test"),
+                           ("user.email", "installer@example.invalid"),
+                           ("commit.gpgsign", "false")):
+            subprocess.run(["git", "-C", str(checkout), "config", key, value],
+                           check=True, env=GIT_ENV)
+        self.write(checkout / "marker", "one\n")
+        subprocess.run(["git", "-C", str(checkout), "add", "marker"], check=True,
+                       env=GIT_ENV)
+        subprocess.run(["git", "-C", str(checkout), "-c", "user.name=Installer Test",
+                        "-c", "user.email=installer@example.invalid",
+                        "-c", "commit.gpgsign=false", "commit", "-m", "one"],
+                       check=True, capture_output=True, text=True, env=GIT_ENV)
+        subprocess.run(["git", "-C", str(checkout), "branch", "-M", "main"],
+                       check=True, env=GIT_ENV)
+        subprocess.run(["git", "-C", str(checkout), "tag", "-m", "baseline",
+                        "baseline"], check=True, env=GIT_ENV)
+        subprocess.run(["git", "-C", str(checkout), "remote", "add", "origin",
+                        str(remote)], check=True, env=GIT_ENV)
+        subprocess.run(["git", "-C", str(checkout), "push", "-u", "origin",
+                        "main", "--tags"], check=True, capture_output=True, text=True,
+                       env=GIT_ENV)
+        script = self.write(checkout / "installer" / "self_update.sh",
+                            SELF_UPDATE_SH.read_text(encoding="utf-8"))
+        script.chmod(0o755)
+        if branch is not None and branch != "main":
+            # (the helper ends on main; -b on the current branch would fatal)
+            subprocess.run(["git", "-C", str(checkout), "checkout", "-b",
+                            branch], check=True, capture_output=True, text=True,
+                           env=GIT_ENV)
+        return remote, checkout
+
+    def run_self_update(self, checkout):
+        env = GIT_ENV.copy()
+        env.pop("BRANCH", None)
+        for color in ("C_OFF", "C_NOTICE", "C_WARNING", "C_ERROR"):
+            env[color] = ""
+        return subprocess.run(
+            ["/bin/sh", str(checkout / "installer" / "self_update.sh")],
+            cwd=checkout, env=env, text=True, capture_output=True,
+        )
+
+    def test_self_update_skips_local_only_branch_without_remote(self):
+        _, checkout = self.make_update_checkout(branch="local-only")
+        result = self.run_self_update(checkout)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Running on 'local-only' branch", result.stdout)
+        self.assertNotIn("Found a new version", result.stdout)
+        self.assertIn("Already on the latest version: baseline", result.stdout)
+        current = subprocess.run(
+            ["git", "-C", str(checkout), "branch", "--show-current"],
+            check=True, text=True, capture_output=True, env=GIT_ENV,
+        ).stdout.strip()
+        self.assertEqual(current, "local-only")
+
+    def test_self_update_uses_tracking_remote_when_set(self):
+        _, checkout = self.make_update_checkout()
+        result = self.run_self_update(checkout)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("Found a new version", result.stdout)
+        self.assertIn("Already on the latest version: baseline", result.stdout)
+
+        # A new commit upstream must still be detected and pulled.
+        runner = self.root / "runner"
+        subprocess.run(["git", "clone", str(self.root / "remote.git"),
+                        str(runner)], check=True, capture_output=True, text=True,
+                       env=GIT_ENV)
+        self.write(runner / "marker", "two\n")
+        subprocess.run(["git", "-C", str(runner), "add", "marker"], check=True,
+                       env=GIT_ENV)
+        subprocess.run(["git", "-C", str(runner),
+                        "-c", "user.name=Installer Test",
+                        "-c", "user.email=installer@example.invalid",
+                        "-c", "commit.gpgsign=false",
+                        "commit", "-m", "two"], check=True, capture_output=True,
+                       text=True, env=GIT_ENV)
+        subprocess.run(["git", "-C", str(runner), "push", "origin", "main"],
+                       check=True, capture_output=True, text=True, env=GIT_ENV)
+
+        result = self.run_self_update(checkout)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Found a new version of Happy Hare on github", result.stdout)
+        self.assertIn("Now on git version:", result.stdout)
+        self.assertEqual((checkout / "marker").read_text().strip(), "two")
 
     def test_v3_red_choice_backs_up_v3_and_cleans_for_v4(self):
         config_home = self.make_v3_install()

--- a/test/test_mmu_install_sh.py
+++ b/test/test_mmu_install_sh.py
@@ -1,0 +1,70 @@
+# Happy Hare - regression test for install.sh's KCONFIG_CONFIG path anchoring.
+#
+# install.sh runs from the caller's cwd, but every make invocation it issues
+# goes through run_make (`make -C $SCRIPT_DIR`), so kconfiglib - which uses
+# KCONFIG_CONFIG as-is against its own process cwd - reads and writes the file
+# that lives next to the checkout, not next to the caller. Running e.g.
+# ../Happy-Hare/install.sh -i from the parent directory used to abort with
+# "Config '.mmu_config' has not been saved, exiting" even though menuconfig had
+# saved, because install.sh's [ -e ]/source checks looked in the caller's
+# directory instead of the checkout's.
+#
+# This test sources the real install.sh (its INSTALL_SH_SOURCE_ONLY hook is
+# designed for exactly this) with the cwd outside the repo, and asserts the
+# resolver anchors relative paths to the checkout.
+#
+# Requires no dependencies beyond /bin/sh - run with the repo venv:
+#   ./venv/bin/python -m unittest test.test_mmu_install_sh
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class TestKconfigConfigAnchoring(unittest.TestCase):
+    def _resolve(self, env_kconfig, cwd):
+        env = {
+            'PATH': os.environ['PATH'],
+            'INSTALL_SH_SCRIPT_DIR': REPO_ROOT,
+            'INSTALL_SH_SOURCE_ONLY': 'y',
+        }
+        if env_kconfig is not None:
+            env['KCONFIG_CONFIG'] = env_kconfig
+        # Note the printf format deliberately ends at the closing quote: a shell
+        # "%s\n" is fine, but the Python string would carry a literal newline
+        # that terminates the format early and swallows the value.
+        script = (
+            '. "%s/install.sh"; '
+            'resolve_kconfig_config; '
+            'printf "%%s\\n" "$KCONFIG_CONFIG"' % REPO_ROOT
+        )
+        result = subprocess.run(
+            ['sh', '-c', script], env=env, cwd=cwd,
+            capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0,
+                         'sh -c failed: %s' % result.stderr)
+        return result.stdout.strip()
+
+    def test_unset_defaults_to_checkout_dot_mmu_config(self):
+        with tempfile.TemporaryDirectory() as outside:
+            self.assertEqual(
+                self._resolve(None, outside),
+                REPO_ROOT + '/.mmu_config')
+
+    def test_relative_env_var_anchors_to_checkout_not_cwd(self):
+        with tempfile.TemporaryDirectory() as outside:
+            self.assertEqual(
+                self._resolve('custom.cfg', outside),
+                REPO_ROOT + '/custom.cfg')
+
+    def test_absolute_path_is_left_alone(self):
+        with tempfile.TemporaryDirectory() as outside:
+            absolute = outside + '/somewhere/mmu.cfg'
+            self.assertEqual(
+                self._resolve(absolute, outside),
+                absolute)


### PR DESCRIPTION
Split into two commits:

**Make install.sh cwd-agnostic**

Before: running Happy-Hare/install.sh from `~` broke the self-update: all its git calls ran in `~`, so the check died and reported the misleading "Error updating from github / old version of git", and a `-b <branch>` switch could never succeed. Same call with menuconfig also aborted with "Config … has not been saved": `install.sh` looked  at the config in `~`, while make read the one in the project dir.

Fixes: `install.sh` `cd`s into the project before running anything (not when sourced), `self_update.sh` anchors to its own location, both re-execs use the absolute script path, and a relative `KCONFIG_CONFIG` anchors to the checkout.

**self_update: use the branch's tracking remote for the update check**

Before: the update check diffed against `origin/<branch-name>`. On a local-only branch that ref doesn't exist, git diff was fatal, the error was misread as "new version found", and the pull then always failed.

Fixes: use the branch's tracking remote (@{u}, falling back to a same-named origin/ branch), verify the ref first, treat a branch with no remote counterpart as up to date. Tests now run a script copy in a throwaway checkout (the real one re-anchors to its own path and would act on your repo), cover both new cases, and isolate scratch-repo git from the runner's gitconfig so the suite stays non-interactive anywhere.

Incidentally fixes the issue that depending on the user's git configuration, the v3 checkout test could spawn an editor asking for a commit message.


:robot: Disclosure: Heavily LLM-assisted. Changes have been reviewed and tested to the best of my human abilitities.
Changes to existing code are kept minimally invasive, the only real wordy bit is the new tests.