### PR TITLE
Suppress sensor callbacks during gate checks

### DIFF
--- a/extras/mmu/commands/mmu_check_gate.py
+++ b/extras/mmu/commands/mmu_check_gate.py
@@ -159,20 +159,26 @@ class MmuCheckGateCommand(BaseCommand):
                                 for gate, tool in gates_tools:
                                     try:
                                         mmu.select_gate(gate)
-                                        mmu.log_info("Checking gate %d..." % gate)
-                                        _ = mmu._load_gate(allow_retry=False)
-                                        if tool >= 0:
-                                            mmu.log_info("Tool T%d - Filament detected. Gate %d marked available" % (tool, gate))
-                                        else:
-                                            mmu.log_info("Gate %d - Filament detected. Marked available" % gate)
-                                        mmu.gate_maps.set_gate_status(gate, max(mmu.gate_status[gate], GATE_AVAILABLE))
-                                        try:
-                                            # Encoder unload may need a little more homing distance
-                                            u = mmu.mmu_unit(gate)
-                                            extra_homing = u.p.gate_homing_max if u.p.gate_homing_endstop == SENSOR_ENCODER else 0
-                                            mmu._unload_gate(extra_homing)
-                                        except MmuError as ee:
-                                            raise MmuError("Failure during check gate %d %s:\n%s" % (gate, "(T%d)" % tool if tool >= 0 else "", str(ee)))
+                                        # Keep live sensor readings available for homing, but do
+                                        # not let this command's owned motion (or switch chatter
+                                        # during it) queue insert/remove callbacks itself.
+                                        # This must follow select_gate(): event suspension snapshots
+                                        # the active sensors for the newly selected gate.
+                                        with mmu.wrap_suspend_insert_events():
+                                            mmu.log_info("Checking gate %d..." % gate)
+                                            _ = mmu._load_gate(allow_retry=False)
+                                            if tool >= 0:
+                                                mmu.log_info("Tool T%d - Filament detected. Gate %d marked available" % (tool, gate))
+                                            else:
+                                                mmu.log_info("Gate %d - Filament detected. Marked available" % gate)
+                                            mmu.gate_maps.set_gate_status(gate, max(mmu.gate_status[gate], GATE_AVAILABLE))
+                                            try:
+                                                # Encoder unload may need a little more homing distance
+                                                u = mmu.mmu_unit(gate)
+                                                extra_homing = u.p.gate_homing_max if u.p.gate_homing_endstop == SENSOR_ENCODER else 0
+                                                mmu._unload_gate(extra_homing)
+                                            except MmuError as ee:
+                                                raise MmuError("Failure during check gate %d %s:\n%s" % (gate, "(T%d)" % tool if tool >= 0 else "", str(ee)))
                                     except MmuError as ee:
                                         mmu.gate_maps.set_gate_status(gate, GATE_EMPTY)
                                         mmu.set_filament_pos_state(FILAMENT_POS_UNLOADED, silent=True)

--- a/test/test_mmu_motion.py
+++ b/test/test_mmu_motion.py
@@ -430,6 +430,47 @@ class TestLoadGate(MotionTestCase):
         self.assertEqual(self.hh.mmu.gate_status[0], GATE_EMPTY)
 
 
+class TestCheckGate(MotionTestCase):
+
+    def test_entry_bounce_is_suppressed_for_each_selected_gate(self):
+        """
+        MMU_CHECK_GATE owns the selected gate's filament motion. An electrical
+        open/closed bounce during that motion must update the readable switch state
+        without queuing a stale REMOVE handler after the command completes.
+
+        Exercise two gates so the event suspension has to follow select_gate(); an
+        outer snapshot would protect only whichever gate happened to start active.
+        """
+        mmu = self.hh.mmu
+        gates = (0, 1)
+        for gate in gates:
+            self.hh.place_filament(gate, position=TIP_AT_GATE)
+        self.hh.settle(1.0) # Clear the sensors' event-delay window
+
+        load_gate = mmu._load_gate
+
+        def load_gate_with_entry_bounce(*args, **kwargs):
+            sensor = self.hh.sensor('mmu_entry_%d' % mmu.gate_selected)
+            sensor.set(False, settle=False)
+            sensor.set(True, settle=False)
+            return load_gate(*args, **kwargs)
+
+        mmu._load_gate = load_gate_with_entry_bounce
+        self.hh.run_gcode('MMU_CHECK_GATE GATES=0,1')
+
+        self.assertEqual(self.hh.errors, [])
+        self.assertEqual([mmu.gate_status[gate] for gate in gates],
+                         [GATE_AVAILABLE, GATE_AVAILABLE])
+        self.assertTrue(all(self.hh.sensor('mmu_entry_%d' % gate).present
+                            for gate in gates))
+
+        # The protection is scoped to the check; a genuine later removal must
+        # still update the gate map normally.
+        self.hh.sensor('mmu_entry_1').set(False)
+        self.assertEqual(mmu.gate_status[1], GATE_EMPTY)
+        self.assertEqual(self.hh.errors, [])
+
+
 class TestKmsEncoderUnload(unittest.TestCase):
     """KMS must not skip its extruder-exit phase when a secondary probe is unavailable."""
 


### PR DESCRIPTION
## Problem

A noisy entry switch can queue an INSERT or REMOVE callback while MMU_CHECK_GATE owns the filament motion. The callback runs after the command and correctly rejects the stale sensor state, but emits a misleading Happy Hare assertion even though the gate check completed correctly.

## Solution

- Keep the existing command-wide runout, FlowGuard, and tangle-prevention suspension.
- Suppress insert, remove, and runout G-code callbacks around each selected gate load/unload operation while preserving live sensor reads for homing.
- Enter the event-suppression scope after each gate selection so multi-gate checks protect the correct active sensor set.
- Verify event handling is restored after the check.

## Testing

- Added a two-gate regression that injects an entry open/closed bounce during each load. It failed before the fix with one stale REMOVE assertion per gate.
- 92 focused motion, sensor-event, and shared-endstop occupancy tests pass.
- Full suite: 1,344 tests pass across 47 files.
- git diff --check passes.