### PR TITLE
Fix quoting in MMU variables path

### DIFF
--- a/installer/Kconfig.paths_services
+++ b/installer/Kconfig.paths_services
@@ -58,7 +58,7 @@ menu "Paths & Services"
 
   config PARAM_MMU_VARS_CFG
     string "save_variables path     "
-    default "$(CONFIG_KLIPPER_CONFIG_HOME)/mmu/mmu_vars.cfg" if $(nonempty,$(CONFIG_KLIPPER_CONFIG_HOME))
+    default "$(path-join,$(CONFIG_KLIPPER_CONFIG_HOME),mmu/mmu_vars.cfg)" if $(nonempty,$(CONFIG_KLIPPER_CONFIG_HOME))
     default "/usr/data/printer_data/config/mmu/mmu_vars.cfg" if $(path-exists,/usr/data/printer_data)
     default "~/printer_data/config/mmu/mmu_vars.cfg"
 

--- a/installer/lib/kconfiglib/kconfigfunctions.py
+++ b/installer/lib/kconfiglib/kconfigfunctions.py
@@ -32,6 +32,22 @@ def path_is_dir(_kconf, _name, path):
     return "y" if os.path.isdir(path) else "n"
 
 
+def _unquote_kconfig_string(value):
+    """Decode a string copied from Kconfig's ``CONFIG_FOO="..."`` format."""
+    match = _STRING_VALUE_RE.match(value)
+    return _UNESCAPE_RE.sub(r"\1", match.group(1)) if match else value
+
+
+def _escape_kconfig_string(value):
+    return value.replace("\\", r"\\").replace('"', r'\"')
+
+
+def path_join(_kconf, _name, base, suffix):
+    """Join paths after removing quotes inherited from a serialized Kconfig value."""
+    return _escape_kconfig_string(os.path.join(
+        _unquote_kconfig_string(base), suffix))
+
+
 def word_count(_kconf, _name, value):
     return str(len(value.split()))
 
@@ -181,19 +197,13 @@ def _saved_values(kconf):
             if value.endswith(HH_DEFAULT_TOKEN):
                 value = value[:-len(HH_DEFAULT_TOKEN)]
 
-            match = _STRING_VALUE_RE.match(value)
-            if match:
-                value = _UNESCAPE_RE.sub(r"\1", match.group(1))
+            value = _unquote_kconfig_string(value)
 
             values[name[len(prefix):]] = value
 
     _config_cache.clear()
     _config_cache[cache_key] = values
     return values
-
-
-def _escape_kconfig_string(value):
-    return value.replace("\\", r"\\").replace('"', r'\"')
 
 
 def saved_config_value(kconf, _, symbol):
@@ -220,6 +230,7 @@ functions = {
     "hh-pad": (pad, 2, 2),
     "path-exists": (path_exists, 1, 1),
     "path-is-dir": (path_is_dir, 1, 1),
+    "path-join": (path_join, 2, 2),
     "saved-config-value": (saved_config_value, 1, 1),
     "saved-interface": (saved_interface, 1, 1),
     "serial-device": (serial_device, 2, 3),

--- a/test/installer/test_kconfigfunctions.py
+++ b/test/installer/test_kconfigfunctions.py
@@ -30,6 +30,16 @@ class TestBasicFunctions(unittest.TestCase):
             self.assertEqual(funcs.path_is_dir(None, None, root), 'y')
             self.assertEqual(funcs.path_is_dir(None, None, filename), 'n')
 
+    def test_path_join_decodes_serialized_kconfig_value(self):
+        self.assertEqual(
+            funcs.path_join(None, None, '"~/printer_data/config"',
+                            'mmu/mmu_vars.cfg'),
+            '~/printer_data/config/mmu/mmu_vars.cfg')
+        self.assertEqual(
+            funcs.path_join(None, None, '~/printer_data/config',
+                            'mmu/mmu_vars.cfg'),
+            '~/printer_data/config/mmu/mmu_vars.cfg')
+
     def test_word_helpers_are_one_based(self):
         self.assertEqual(funcs.word_count(None, None, ' can0:a   can1:b '), '2')
         self.assertEqual(funcs.word_at(None, None, 'can0:a can1:b', '2'), 'can1:b')

--- a/test/test_mmu_config.py
+++ b/test/test_mmu_config.py
@@ -90,6 +90,21 @@ class TestBoxTurtleRender(unittest.TestCase):
         self.assertEqual(leds['entry_effect'], 'gate_status')
         self.assertEqual(leds['status_effect'], 'slicer_color')
 
+    def test_serialized_config_home_does_not_quote_save_variables_path(self):
+        env = dict(cfg._SINGLE_UNIT_ENV,
+                   CONFIG_KLIPPER_CONFIG_HOME='"~/printer_data/config"')
+        with cfg._env(env):
+            kconfig = cfg._kconfig(
+                'quoted_config_home', profiles.get('boxturtle').syms)
+
+        self.assertEqual(kconfig.get('PARAM_MMU_VARS_CFG'),
+                         '~/printer_data/config/mmu/mmu_vars.cfg')
+        rendered = cfg._render_templates(
+            (MACRO_VARS,), kconfig, {'PARAM_TOTAL_NUM_GATES': 4})
+        self.assertIn(
+            'filename: ~/printer_data/config/mmu/mmu_vars.cfg\n',
+            rendered[MACRO_VARS])
+
     def test_mmu_sections(self):
         secs = cfg.sections(self.rendered[MMU])
         for expected in ('mmu_machine', 'mmu_parameters', 'mmu_toolhead default'):


### PR DESCRIPTION
## Summary

- decode serialized Kconfig quotes before joining the MMU variables path
- route PARAM_MMU_VARS_CFG through the new Python-backed path helper
- add helper and real-template regression coverage for quoted config paths

## Tests

- ./venv/bin/python -m unittest test.installer.test_kconfigfunctions test.test_mmu_config -v
- ./venv/bin/python -m unittest test.installer.test_kconfigfunctions test.test_mmu_config.TestBoxTurtleRender.test_serialized_config_home_does_not_quote_save_variables_path -v
- git diff --check