### PR TITLE
Fix environment sensor fan generation

### DIFF
--- a/config/base/mmu_macro_vars.cfg
+++ b/config/base/mmu_macro_vars.cfg
@@ -941,7 +941,7 @@ variable_fans                               : "[[VAR_FAN_FANS]]" # Comma-separat
 [% set env_sensors = [] %]
 [% set env_fans = [] %]
 [% for i in range(0, PARAM_NUM_GATES|int) %]
-[% if (PARAM_ENVIRONMENT_SENSOR_NAME_|d)[i] and (PIN_FAN_|d)[i] != "" %]
+[% if (PARAM_ENVIRONMENT_SENSOR_|d)[i] and (PIN_FAN_|d)[i] != "" %]
 [% set _ = env_sensors.append(('_' if BOOL_HIDE_MCU_ENVIRONMENT_SENSORS else '') ~ UNIT_NAME ~ '_mcu' ~ i) %]
 [% set _ = env_fans.append('_' ~ UNIT_NAME ~ '_fan' ~ i) %]
 [% endif %]


### PR DESCRIPTION
## Summary

- use the configured environment sensor value when deciding whether to create per-gate fan mappings
- prevent template rendering from referencing the nonexistent PARAM_ENVIRONMENT_SENSOR_NAME_ value

## Testing

- make UT=test_mmu_config.py test (40 tests passed)