### PR TITLE
Fix bowden homing distance signs

### DIFF
--- a/extras/mmu/mmu_filament_movement.py
+++ b/extras/mmu/mmu_filament_movement.py
@@ -530,6 +530,7 @@ class MmuFilamentMovement:
                     if measured > self.encoder().movement_min(): # We expect 0, but relax the test a little (allow one pulse)
                         self.log_warning("Warning: Possible encoder malfunction (free-spinning) during final filament parking")
                     self.set_filament_pos_state(FILAMENT_POS_UNLOADED)
+                    homing_movement = -homing_movement # Match signed reverse displacement from switch endstops
                     self.log_trace_exit(f"_park_from_gate() => (homing_movement={homing_movement})")
                     return homing_movement
 
@@ -1334,7 +1335,7 @@ class MmuFilamentMovement:
                 if self._must_home_to_extruder() and u.p.extruder_homing_endstop == SENSOR_EXTRUDER_ENTRY:
                     # If homing to extruder entry sensor, Further reduce to compensate for distance from sensor to extruder gear
                     # (because the bowden length is always recorded as distance to extruder gear)
-                    extruder_homing_buffer -= u.toolhead_wrapper.p.toolhead_entry_to_extruder
+                    extruder_homing_buffer += u.toolhead_wrapper.p.toolhead_entry_to_extruder
 
                 # A reserved buffer must only subtract from the remaining fast move. In
                 # particular, a large entry-to-extruder offset must not make the buffer


### PR DESCRIPTION
## Summary
- Return negative reverse-homing displacement from the encoder branch of `_park_from_gate()`, matching switch endstops. This prevents unload telemetry/autotuning from subtracting the extra reverse travel. The raw encoder helper and physical parking remain unchanged.
- Add the entry-to-gear offset to the Bowden homing buffer: the calibrated length ends at the gears, while the entry sensor is upstream. Preserve the buffer clamp and other homing modes.

Fixes #1184
Fixes #1185

## Validation
- 9 hardware-free regressions against the actual methods: upstream produced 10 failing subcases; this patch passes all 9 tests. Covers encoder/switch signs, manual-calibration contract, entry-only/dual/no-sensor modes, partial loads and buffer bounds. The external regression harness is intentionally not included in this minimal diff.
- Existing motion, toolchange, profiles and encoder suites: 166 tests passed.
- `git diff --check` passed.

The unload defect is supported by printer logs; the entry-buffer defect was reproduced in tests, not by claiming a physical failure in the current non-entry-homing configuration. No printer config or hardware behavior outside these calculations is changed.
