### PR TITLE
Publish complete MMU status schema on first access

### DIFF
--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -59,8 +59,6 @@ class MmuController(MmuFilamentMovement):
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode_move = self.printer.load_object(config, 'gcode_move')
 
-        self._ready = False # Used to prevent early access to get_status() before everything is loaded
-
         self.num_gates = self.mmu_machine.num_gates
         self.toolchange_retract = 0.            # Set from mmu_macro_vars
         self.toolchange_purge_volume = 0.       # During toolchange, the total calculated purge volume
@@ -221,7 +219,6 @@ class MmuController(MmuFilamentMovement):
 
     def handle_disconnect(self):
         self.log_debug('Klipper disconnected!')
-        self._ready = False
 
 
     def handle_ready(self):
@@ -272,7 +269,6 @@ class MmuController(MmuFilamentMovement):
 
         # Send event to allow modules to finalize configuration now everything is loaded
         self.log_debug("MMU Initialization Complete -------------------------------\n")
-        self._ready = True
         self.printer.send_event("mmu:initialized")
 
 

--- a/extras/mmu/mmu_controller.py
+++ b/extras/mmu/mmu_controller.py
@@ -681,9 +681,6 @@ class MmuController(MmuFilamentMovement):
         # establish stable subscriptions before MMU initialization completes.
         status.update(self.mmu_unit().sync_feedback.get_status(eventtime))
 
-        if not self._ready:
-            return status
-
         # Adds status for gate map, ttg map, endless spool, etc
         status.update(self.gate_maps.get_status(eventtime))
 
@@ -726,8 +723,7 @@ class MmuController(MmuFilamentMovement):
             st = mgr.get_status(eventtime)
             if st['shared'] is not None or st['gates']:
                 nfc_status.append(st)
-        if nfc_status:
-            status['nfc'] = nfc_status
+        status['nfc'] = nfc_status
 
         # Development/testing hook
         if hasattr(self, "developer_status_update"):

--- a/test/test_mmu_bootup.py
+++ b/test/test_mmu_bootup.py
@@ -111,6 +111,28 @@ class TestConfigLoad(unittest.TestCase):
         self.assertEqual(self.hh.errors, [])
 
 
+class TestInitialStatusSchema(unittest.TestCase):
+    """The first status snapshot must establish every public subscription field."""
+
+    def test_top_level_fields_do_not_change_after_ready(self):
+        for profile in ('boxturtle', 'nfc_spoolman'):
+            with self.subTest(profile=profile):
+                hh = session(profile)
+                try:
+                    hh.build()
+                    initial = hh.mmu.get_status(hh.reactor.monotonic())
+
+                    hh.connect().ready()
+                    ready = hh.mmu.get_status(hh.reactor.monotonic())
+
+                    self.assertEqual(set(initial), set(ready))
+                    self.assertIn('nfc', initial)
+                    self.assertEqual(bool(initial['nfc']), profile == 'nfc_spoolman')
+                    self.assertEqual(hh.errors, [])
+                finally:
+                    hh.close()
+
+
 class TestVersionMismatch(unittest.TestCase):
     """
     extras/mmu_machine.py:44-47 is meant to turn a stale `happy_hare_version` into a

--- a/test/test_mmu_bootup.py
+++ b/test/test_mmu_bootup.py
@@ -293,7 +293,6 @@ class TestReady(BootedSessionMixin, unittest.TestCase):
     """A4: klippy:ready."""
 
     def test_mmu_is_ready(self):
-        self.assertTrue(self.hh.mmu._ready)
         self.assertTrue(self.hh.fired('mmu:initialized'))
 
     def test_pause_family_was_wrapped(self):


### PR DESCRIPTION
Summary:
- publish every public top-level MMU status field before klippy:ready
- return an empty NFC list when no readers are configured so the schema remains stable
- remove the now-obsolete internal ready flag
- add regression coverage comparing pre-ready and ready schemas for normal and NFC profiles

Why:
Klipper resolves null object subscriptions to the keys returned by the first get_status() call. The previous early return omitted fields until initialization, preventing those fields from being included in websocket subscriptions.

Tests:
- ./venv/bin/python -m unittest test.test_mmu_bootup
- stable initial/ready schemas verified across all 25 harness console profiles