### PR TITLE
Allow explicit per-gate LED counts

### DIFF
--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -791,9 +791,9 @@ color_order   : [[PARAM_COLOR_ORDER]]
 #
 # Note the use of separate lines for each part of the definition,
 #
-# By default the exit and entry virtual chains are divided equally between gates. To use
-# different counts, provide one positive count per gate; the values consume the virtual chain
-# in gate order and must total its length. For example, 10 exit LEDs split over four gates:
+# Normally leave entry_led_counts and exit_led_counts unset for equal distribution. For an
+# uneven split, the number of entries MUST equal num_gates and their sum MUST equal the number
+# of LEDs in the corresponding virtual chain. Counts consume that chain in gate order. Example:
 #
 #   exit_led_counts: 1, 1, 2, 6
 #

--- a/config/base/mmu_hardware.cfg
+++ b/config/base/mmu_hardware.cfg
@@ -791,6 +791,12 @@ color_order   : [[PARAM_COLOR_ORDER]]
 #
 # Note the use of separate lines for each part of the definition,
 #
+# By default the exit and entry virtual chains are divided equally between gates. To use
+# different counts, provide one positive count per gate; the values consume the virtual chain
+# in gate order and must total its length. For example, 10 exit LEDs split over four gates:
+#
+#   exit_led_counts: 1, 1, 2, 6
+#
 # ADVANCED: Happy Hare provides a convenience wrapper [mmu_led_effect] that not only creates an effect on each of the
 # [mmu_leds] specified segments as a whole but also each individual LED for atomic control. See mmu_leds.cfg for examples
 #
@@ -800,11 +806,17 @@ entry_leds    : [[parts[0].strip()]]
 [% for part in parts[1:] %]
                 [[part.strip()]]
 [% endfor %]
+[% if PARAM_ENTRY_LED_COUNTS %]
+entry_led_counts: [[PARAM_ENTRY_LED_COUNTS]]
+[% endif %]
 [% set parts = PARAM_EXIT_LEDS.split(';') %]
 exit_leds     : [[parts[0].strip()]]
 [% for part in parts[1:] %]
                 [[part.strip()]]
 [% endfor %]
+[% if PARAM_EXIT_LED_COUNTS %]
+exit_led_counts: [[PARAM_EXIT_LED_COUNTS]]
+[% endif %]
 [% set parts = PARAM_STATUS_LEDS.split(';') %]
 status_leds   : [[parts[0].strip()]]
 [% for part in parts[1:] %]

--- a/extras/mmu/mmu_led_manager.py
+++ b/extras/mmu/mmu_led_manager.py
@@ -576,6 +576,8 @@ class MmuLedManager:
             num_leds = mmu_unit.leds.get_status()[segment]
             if gate is None or gate < 0:
                 return list(range(1, num_leds + 1))
+            if segment in MmuLeds.PER_GATE_SEGMENTS:
+                return mmu_unit.leds.gate_led_indexes(segment, gate)
             leds_per_gate = num_leds // mmu_unit.num_gates
             index0 = (gate - mmu_unit.first_gate) * leds_per_gate + 1
             return list(range(index0, index0 + leds_per_gate))

--- a/extras/mmu/unit/mmu_leds.py
+++ b/extras/mmu/unit/mmu_leds.py
@@ -97,9 +97,12 @@ class MmuLeds:
             config_chains = [self.parse_chain(line) for line in config.get(name, '').split('\n') if line.strip()]
             self.virtual_chains[segment] = VirtualMmuLedChain(config, self.mmu_unit.name, segment, config_chains)
 
-            num_leds = len(self.virtual_chains[segment].leds)
-            if segment in self.PER_GATE_SEGMENTS and num_leds > 0 and num_leds % self.num_gates:
-                raise config.error("Number of MMU '%s' LEDs (%d) cannot be spread over num_gates (%d)" % (segment, num_leds, self.num_gates))
+        # Decide the gate boundaries once so effect creation and runtime updates cannot
+        # disagree. Without an explicit count list this preserves the existing equal split.
+        self.gate_leds = {
+            segment: self._map_leds_to_gates(config, segment)
+            for segment in self.PER_GATE_SEGMENTS
+        }
 
         # Check for LED chain overlap or unavailable LEDs
         used = {}
@@ -165,6 +168,42 @@ class MmuLeds:
             self.effects[operation] = effect
             self.effect_duration[operation] = duration
         self.effect_rgb[''] = (0,0,0)
+
+    def _map_leds_to_gates(self, config, segment):
+        num_leds = len(self.virtual_chains[segment].leds)
+        option = "%s_led_counts" % segment
+        counts = list(config.getintlist(option, []))
+
+        if counts:
+            if len(counts) != self.num_gates:
+                raise config.error("'%s' must contain exactly num_gates (%d) values" % (option, self.num_gates))
+            if any(count <= 0 for count in counts):
+                raise config.error("'%s' values must all be positive integers" % option)
+            if sum(counts) != num_leds:
+                raise config.error("'%s' totals %d but the '%s' virtual chain contains %d LEDs" % (
+                    option, sum(counts), segment, num_leds))
+        else:
+            if num_leds > 0 and num_leds % self.num_gates:
+                raise config.error("Number of MMU '%s' LEDs (%d) cannot be spread over num_gates (%d)" % (
+                    segment, num_leds, self.num_gates))
+            counts = [num_leds // self.num_gates] * self.num_gates
+
+        gate_leds = []
+        index = 1 # LED indexes are 1-based within the virtual segment
+        for count in counts:
+            gate_leds.append(list(range(index, index + count)))
+            index += count
+        return gate_leds
+
+    def gate_led_indexes(self, segment, gate):
+        gate_leds = self.gate_leds.get(segment)
+        local_gate = gate - self.first_gate
+        if gate_leds is None or not 0 <= local_gate < len(gate_leds):
+            return []
+        return gate_leds[local_gate]
+
+    def gate_led_counts(self, segment):
+        return [len(leds) for leds in self.gate_leds.get(segment, [])]
 
     def parse_chain(self, chain):
         chain = chain.strip()

--- a/extras/mmu_led_effect.py
+++ b/extras/mmu_led_effect.py
@@ -85,7 +85,6 @@ class MmuLedEffect:
                     if not led_chain:
                         raise config.error("Led chain %s not found!" % led_chain)
                     num_leds = led_chain.led_helper.led_count
-                    leds_per_gate = num_leds // mmu_unit.num_gates
 
                     if num_leds > 0:
                         # Full segment effects
@@ -96,10 +95,10 @@ class MmuLedEffect:
                         # Per gate
                         if segment in MmuLeds.PER_GATE_SEGMENTS and (not define_on or 'gates' in define_on):
                             for idx in range(mmu_unit.first_gate, mmu_unit.first_gate + mmu_unit.num_gates):
-                                led0 = (idx - mmu_unit.first_gate) * leds_per_gate + 1
-                                led_spec = str(led0)
-                                if leds_per_gate > 1:
-                                    led_spec = "%d-%d" % (led0, led0 + leds_per_gate - 1)
+                                gate_leds = mmu_leds.gate_led_indexes(segment, idx)
+                                led_spec = str(gate_leds[0])
+                                if len(gate_leds) > 1:
+                                    led_spec = "%d-%d" % (gate_leds[0], gate_leds[-1])
                                 section_to = "_led_effect %s_%s_%d" % (led_effect_section, segment, idx)
                                 self._add_led_effect(config, section_to, "%s (%s)" % (led_segment_name, led_spec))
 

--- a/installer/Kconfig.leds
+++ b/installer/Kconfig.leds
@@ -211,10 +211,12 @@ if MMU_HAS_LEDS
 
     config PARAM_EXIT_LED_COUNTS
       string
+      array_editor "," PARAM_NUM_GATES
       default ""
 
     config PARAM_ENTRY_LED_COUNTS
       string
+      array_editor "," PARAM_NUM_GATES
       default ""
 
     config PARAM_STATUS_LEDS

--- a/installer/Kconfig.leds
+++ b/installer/Kconfig.leds
@@ -15,6 +15,8 @@
 #   PARAM_COLOR_ORDER
 #   PARAM_EXIT_LEDS
 #   PARAM_ENTRY_LEDS
+#   PARAM_EXIT_LED_COUNTS
+#   PARAM_ENTRY_LED_COUNTS
 #   PARAM_STATUS_LEDS
 #   PARAM_LOGO_LEDS
 #   PARAM_FRAME_RATE
@@ -207,6 +209,14 @@ if MMU_HAS_LEDS
       array_editor ";"
       default "" if CUSTOM_LED_SETUP
 
+    config PARAM_EXIT_LED_COUNTS
+      string
+      default ""
+
+    config PARAM_ENTRY_LED_COUNTS
+      string
+      default ""
+
     config PARAM_STATUS_LEDS
       string
       array_editor ";"
@@ -249,12 +259,28 @@ if MMU_HAS_LEDS
           chains can be entered in the array editor, and ranges may be reversed
           when the physical chain runs in the opposite gate order.
 
+      config PARAM_EXIT_LED_COUNTS
+        prompt "Exit led counts "
+        help
+          Optionally assign a different number of exit LEDs to each gate. Enter
+          one comma-separated positive integer per gate. The counts consume the
+          exit virtual chain in gate order and must total its number of LEDs.
+          Leave empty to distribute the LEDs equally between all gates.
+
       config PARAM_ENTRY_LEDS
         prompt "Entry leds      "
         help
           Assign the LEDs mounted at the filament entry for each gate. Use a
           virtual-chain specification such as "neopixel:my_leds (5-8)". Leave
           this empty when the unit has no entry LED segment.
+
+      config PARAM_ENTRY_LED_COUNTS
+        prompt "Entry led counts"
+        help
+          Optionally assign a different number of entry LEDs to each gate. Enter
+          one comma-separated positive integer per gate. The counts consume the
+          entry virtual chain in gate order and must total its number of LEDs.
+          Leave empty to distribute the LEDs equally between all gates.
 
       config PARAM_STATUS_LEDS
         prompt "Status leds     "

--- a/installer/Kconfig.leds
+++ b/installer/Kconfig.leds
@@ -265,10 +265,12 @@ if MMU_HAS_LEDS
         prompt "Exit led counts "
         depends on PARAM_EXIT_LEDS != ""
         help
-          Optionally assign a different number of exit LEDs to each gate. Enter
-          one comma-separated positive integer per gate. The counts consume the
-          exit virtual chain in gate order and must total its number of LEDs.
-          Leave empty to distribute the LEDs equally between all gates.
+          Normally leave this empty; LEDs are then distributed equally among
+          all gates. For an uneven split, enter one positive integer per gate.
+          The number of entries MUST equal num_gates, and the sum of the counts
+          MUST equal the number of LEDs specified by exit_leds. Counts consume
+          the virtual chain in gate order. Example for 10 LEDs over 4 gates:
+          "1, 1, 2, 6".
 
       config PARAM_ENTRY_LEDS
         prompt "Entry leds      "
@@ -281,10 +283,12 @@ if MMU_HAS_LEDS
         prompt "Entry led counts"
         depends on PARAM_ENTRY_LEDS != ""
         help
-          Optionally assign a different number of entry LEDs to each gate. Enter
-          one comma-separated positive integer per gate. The counts consume the
-          entry virtual chain in gate order and must total its number of LEDs.
-          Leave empty to distribute the LEDs equally between all gates.
+          Normally leave this empty; LEDs are then distributed equally among
+          all gates. For an uneven split, enter one positive integer per gate.
+          The number of entries MUST equal num_gates, and the sum of the counts
+          MUST equal the number of LEDs specified by entry_leds. Counts consume
+          the virtual chain in gate order. Example for 8 LEDs over 4 gates:
+          "1, 1, 2, 4".
 
       config PARAM_STATUS_LEDS
         prompt "Status leds     "

--- a/installer/Kconfig.leds
+++ b/installer/Kconfig.leds
@@ -265,12 +265,12 @@ if MMU_HAS_LEDS
         prompt "Exit led counts "
         depends on PARAM_EXIT_LEDS != ""
         help
-          Normally leave this empty; LEDs are then distributed equally among
-          all gates. For an uneven split, enter one positive integer per gate.
-          The number of entries MUST equal num_gates, and the sum of the counts
-          MUST equal the number of LEDs specified by exit_leds. Counts consume
-          the virtual chain in gate order. Example for 10 LEDs over 4 gates:
-          "1, 1, 2, 6".
+          [[BOLD]]Normally leave this empty.[[/BOLD]]
+          LEDs are then distributed equally among all gates. For an uneven
+          split, enter one positive integer per gate. The number of entries
+          MUST equal num_gates, and the sum of the counts MUST equal the number
+          of LEDs specified by exit_leds. Counts consume the virtual chain in
+          gate order. Example for 10 LEDs over 4 gates: "1, 1, 2, 6".
 
       config PARAM_ENTRY_LEDS
         prompt "Entry leds      "
@@ -283,12 +283,12 @@ if MMU_HAS_LEDS
         prompt "Entry led counts"
         depends on PARAM_ENTRY_LEDS != ""
         help
-          Normally leave this empty; LEDs are then distributed equally among
-          all gates. For an uneven split, enter one positive integer per gate.
-          The number of entries MUST equal num_gates, and the sum of the counts
-          MUST equal the number of LEDs specified by entry_leds. Counts consume
-          the virtual chain in gate order. Example for 8 LEDs over 4 gates:
-          "1, 1, 2, 4".
+          [[BOLD]]Normally leave this empty.[[/BOLD]]
+          LEDs are then distributed equally among all gates. For an uneven
+          split, enter one positive integer per gate. The number of entries
+          MUST equal num_gates, and the sum of the counts MUST equal the number
+          of LEDs specified by entry_leds. Counts consume the virtual chain in
+          gate order. Example for 8 LEDs over 4 gates: "1, 1, 2, 4".
 
       config PARAM_STATUS_LEDS
         prompt "Status leds     "

--- a/installer/Kconfig.leds
+++ b/installer/Kconfig.leds
@@ -263,6 +263,7 @@ if MMU_HAS_LEDS
 
       config PARAM_EXIT_LED_COUNTS
         prompt "Exit led counts "
+        depends on PARAM_EXIT_LEDS != ""
         help
           Optionally assign a different number of exit LEDs to each gate. Enter
           one comma-separated positive integer per gate. The counts consume the
@@ -278,6 +279,7 @@ if MMU_HAS_LEDS
 
       config PARAM_ENTRY_LED_COUNTS
         prompt "Entry led counts"
+        depends on PARAM_ENTRY_LEDS != ""
         help
           Optionally assign a different number of entry LEDs to each gate. Enter
           one comma-separated positive integer per gate. The counts consume the

--- a/installer/Kconfig.leds
+++ b/installer/Kconfig.leds
@@ -265,7 +265,7 @@ if MMU_HAS_LEDS
         prompt "Exit led counts "
         depends on PARAM_EXIT_LEDS != ""
         help
-          [[B]]Normally leave this empty.[[/B]]
+          NORMALLY LEAVE THIS EMPTY.
           LEDs are then distributed equally among all gates. For an uneven
           split, enter one positive integer per gate. The number of entries
           MUST equal num_gates, and the sum of the counts MUST equal the number
@@ -283,7 +283,7 @@ if MMU_HAS_LEDS
         prompt "Entry led counts"
         depends on PARAM_ENTRY_LEDS != ""
         help
-          [[B]]Normally leave this empty.[[/B]]
+          NORMALLY LEAVE THIS EMPTY.
           LEDs are then distributed equally among all gates. For an uneven
           split, enter one positive integer per gate. The number of entries
           MUST equal num_gates, and the sum of the counts MUST equal the number

--- a/installer/Kconfig.leds
+++ b/installer/Kconfig.leds
@@ -265,7 +265,7 @@ if MMU_HAS_LEDS
         prompt "Exit led counts "
         depends on PARAM_EXIT_LEDS != ""
         help
-          [[BOLD]]Normally leave this empty.[[/BOLD]]
+          [[B]]Normally leave this empty.[[/B]]
           LEDs are then distributed equally among all gates. For an uneven
           split, enter one positive integer per gate. The number of entries
           MUST equal num_gates, and the sum of the counts MUST equal the number
@@ -283,7 +283,7 @@ if MMU_HAS_LEDS
         prompt "Entry led counts"
         depends on PARAM_ENTRY_LEDS != ""
         help
-          [[BOLD]]Normally leave this empty.[[/BOLD]]
+          [[B]]Normally leave this empty.[[/B]]
           LEDs are then distributed equally among all gates. For an uneven
           split, enter one positive integer per gate. The number of entries
           MUST equal num_gates, and the sum of the counts MUST equal the number

--- a/test/console.py
+++ b/test/console.py
@@ -1234,18 +1234,16 @@ class Console:
                 effect = self.hh.mmu.led_manager.effect_state.get(index, {}).get(segment, '?')
                 label = ('%s %s' % (unit.name, segment)) if self.num_units > 1 else segment
                 # status and logo are not indexed by gate, so grouping them would be a lie.
-                # For the per-gate pair mmu_leds.py:101-102 has already guaranteed that the
-                # division is exact.
                 per_gate = len(data)
                 if segment in MmuLeds.PER_GATE_SEGMENTS and unit.num_gates:
-                    per_gate = max(1, len(data) // unit.num_gates)
+                    per_gate = leds.gate_led_counts(segment)
                 out.append('  led %-14s %s  [%s]'
                            % (label, self._swatches(data, per_gate), effect))
         return out
 
     def _swatches(self, data, per_gate):
         """
-        One block per LED, `per_gate` of them run together and a space between groups.
+        One block per LED, grouped by either a uniform size or a list of gate sizes.
 
         Ungrouped, ViViD's exit segment - 28 LEDs over 4 gates - renders a 117-column row,
         which soft-wraps and scribbles over the row below it (PinnedHeader.repaint writes
@@ -1268,9 +1266,15 @@ class Console:
                 r, g, b = (min(255, int(round(c * scale))) for c in (r, g, b))
                 glyph = self.LED_DIM
             cells.append(paint(glyph, fg(r, g, b, self.mode)[2:-1], self.color))
-        per_gate = max(1, per_gate)                  # or the slice below is empty and loops
-        return ' '.join(''.join(cells[i:i + per_gate])
-                        for i in range(0, len(cells), per_gate))
+        if isinstance(per_gate, int):
+            per_gate = max(1, per_gate)              # or the slice below is empty and loops
+            return ' '.join(''.join(cells[i:i + per_gate])
+                            for i in range(0, len(cells), per_gate))
+        groups, index = [], 0
+        for count in per_gate:
+            groups.append(''.join(cells[index:index + count]))
+            index += count
+        return ' '.join(groups)
 
     # A HEAVY rule marks the boundary between the status section and the log window - that
     # is the one line a reader uses to tell "state" from "output" at a glance. The top edge

--- a/test/test_mmu_console.py
+++ b/test/test_mmu_console.py
@@ -1162,6 +1162,10 @@ class TestLedSwatches(unittest.TestCase):
         # swatches were 83, i.e. a 117-column row.
         self.assertEqual(len(visible(got)), 59)
 
+    def test_uneven_led_counts_define_the_gate_boundaries(self):
+        got = self.swatches([(0., 0., 1., 0.)] * 6, [1, 2, 3])
+        self.assertEqual(got, ' '.join([self.ON, self.ON * 2, self.ON * 3]))
+
     def test_a_whole_segment_in_one_group_has_no_gaps(self):
         """How status and logo arrive - neither is indexed by gate."""
         self.assertEqual(self.swatches([(1., 1., 1., 0.)] * 4, 4), self.ON * 4)

--- a/test/test_mmu_leds.py
+++ b/test/test_mmu_leds.py
@@ -23,11 +23,36 @@
 import logging
 import unittest
 
-from test.hh import session
+from test.hh import profiles, session
 
 logging.getLogger().setLevel(logging.CRITICAL)
 
 WARMUP = 12.0       # past the 8s effect_initialized state flash
+
+UNEVEN_EXIT_LEDS = ('neopixel:_unit0_gate0_leds (1); neopixel:_unit0_gate1_leds (1); '
+                     'neopixel:_unit0_gate2_leds (1); neopixel:_unit0_gate3_leds (1); '
+                     'neopixel:_unit0_gate4_leds (1-6)')
+UNEVEN_ENTRY_LEDS = ('neopixel:_unit0_gate0_leds (7); neopixel:_unit0_gate1_leds (7); '
+                      'neopixel:_unit0_gate2_leds (7); neopixel:_unit0_gate3_leds (7); '
+                      'neopixel:_unit0_gate4_leds (7)')
+
+# Five physical chain lines deliberately contribute 1,1,1,1,6 LEDs. Without the explicit
+# count option those line breaks remain physical-chain composition only and the existing
+# equal 2,2,2,2,2 split must be preserved. With it, gate 4 owns the final six virtual LEDs.
+LEDS_LINES_ONLY = profiles.EMU.derive(
+    'leds_lines_only',
+    syms={
+        'BOARD_TYPE_EBB_GEN1': True,
+        'PARAM_CHAIN_COUNT': 7,
+        'PARAM_EXIT_LEDS': UNEVEN_EXIT_LEDS,
+        'PARAM_ENTRY_LEDS': UNEVEN_ENTRY_LEDS,
+    })
+LEDS_UNEVEN = LEDS_LINES_ONLY.derive(
+    'leds_uneven',
+    syms={
+        'PARAM_EXIT_LED_COUNTS': '1, 1, 1, 1, 6',
+        'PARAM_ENTRY_LED_COUNTS': '1, 1, 1, 1, 1',
+    })
 
 
 class LedTestCase(unittest.TestCase):
@@ -218,6 +243,9 @@ class TestAllFourSegments(unittest.TestCase):
         leds = self.unit(1).leds
         self.assertEqual(len(leds.virtual_chains['exit'].leds), 28)
         self.assertEqual(len(leds.virtual_chains['entry'].leds), 0)
+        self.assertEqual(leds.gate_led_counts('exit'), [7] * 4)
+        self.assertEqual(leds.gate_led_indexes('exit', 9), list(range(1, 8)))
+        self.assertEqual(leds.gate_led_indexes('exit', 12), list(range(22, 29)))
 
     def test_the_logo_tuple_effect_actually_lights_the_leds(self):
         """
@@ -226,6 +254,80 @@ class TestAllFourSegments(unittest.TestCase):
         """
         data = self.unit().leds.virtual_chains['logo'].get_status()['color_data']
         self.assertEqual(data, [(0., 0., 0.3, 0.)] * 3)
+
+
+class TestExplicitLedsPerGate(unittest.TestCase):
+    """An optional count list partitions the flattened virtual chain by gate."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.hh = session(LEDS_UNEVEN)
+        cls.hh.boot()
+        cls.hh.reactor.advance(WARMUP)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.hh.close()
+
+    @property
+    def leds(self):
+        return self.hh.mmu.mmu_unit(0).leds
+
+    def colors(self, segment='exit'):
+        return self.leds.virtual_chains[segment].get_status()['color_data']
+
+    def test_explicit_counts_define_each_gate(self):
+        self.assertEqual(self.leds.gate_led_counts('exit'), [1, 1, 1, 1, 6])
+        self.assertEqual(self.leds.gate_led_counts('entry'), [1, 1, 1, 1, 1])
+
+    def test_gate_indexes_run_consecutively_through_the_virtual_chain(self):
+        self.assertEqual([self.leds.gate_led_indexes('exit', gate) for gate in range(5)],
+                         [[1], [2], [3], [4], [5, 6, 7, 8, 9, 10]])
+
+    def test_a_gate_outside_the_unit_has_no_leds(self):
+        self.assertEqual(self.leds.gate_led_indexes('exit', 5), [])
+        self.assertEqual(self.leds.gate_led_indexes('exit', -1), [])
+
+    def test_painting_a_gate_lights_exactly_its_leds(self):
+        odd = (0.25, 0.5, 0.75, 0.)
+        self.hh.run_gcode('MMU_SET_LED GATE=4 EXIT_EFFECT=(0.25,0.5,0.75)')
+        data = self.colors()
+        self.assertEqual(data[4:], [odd] * 6)
+        self.assertNotIn(odd, data[:4], 'the paint bled onto another gate')
+
+    def test_per_gate_effects_use_the_same_mapping(self):
+        chain = self.leds.virtual_chains['exit']
+        by_name = {effect.name: effect for effect in
+                   self.hh.printer.lookup_object('mmu_led_effect').effects}
+        for gate, expected in enumerate([[0], [1], [2], [3], [4, 5, 6, 7, 8, 9]]):
+            effect = by_name.get('mmu_static_blue_exit_%d' % gate)
+            self.assertIsNotNone(effect, 'no per-gate effect for gate %d' % gate)
+            self.assertEqual([index for obj, index in effect.leds if obj is chain], expected)
+
+
+class TestLedCountCompatibility(unittest.TestCase):
+    def test_config_lines_do_not_implicitly_change_the_equal_split(self):
+        hh = session(LEDS_LINES_ONLY)
+        self.addCleanup(hh.close)
+        hh.boot()
+        self.assertEqual(hh.mmu.mmu_unit(0).leds.gate_led_counts('exit'), [2] * 5)
+
+    def test_invalid_explicit_counts_are_rejected(self):
+        cases = [
+            ('1, 1, 8', "must contain exactly num_gates"),
+            ('1, 1, 1, 1, 0', "must all be positive integers"),
+            ('1, 1, 1, 1, 5', "totals 9.*contains 10 LEDs"),
+        ]
+        for counts, message in cases:
+            with self.subTest(counts=counts):
+                profile = LEDS_LINES_ONLY.derive(
+                    'invalid_led_counts', syms={'PARAM_EXIT_LED_COUNTS': counts})
+                hh = session(profile)
+                try:
+                    with self.assertRaisesRegex(Exception, message):
+                        hh.boot()
+                finally:
+                    hh.close()
 
 
 class TestEffectConfiguration(LedTestCase):

--- a/test/test_mmu_profiles.py
+++ b/test/test_mmu_profiles.py
@@ -501,6 +501,8 @@ class TestEveryBootableProfile(unittest.TestCase):
             'neopixel:_unit0_gate%d_leds (5)' % gate for gate in range(5)])
         self.assertEqual(default_leds['exit_leds'].splitlines(), [
             'neopixel:_unit0_gate%d_leds (1,2,3,4)' % gate for gate in range(5)])
+        self.assertNotIn('entry_led_counts', default_leds)
+        self.assertNotIn('exit_led_counts', default_leds)
         for gate in range(5):
             chain = dict(default_parser.items(
                 'neopixel _unit0_gate%d_leds' % gate))


### PR DESCRIPTION
## Summary

- add optional exit_led_counts and entry_led_counts settings for uneven gate layouts
- keep the existing equal distribution when either setting is empty
- centralize the gate-to-virtual-LED mapping so static updates and animations use the same indexes
- expose gate-sized array editors only when the corresponding LED segment is configured
- validate entry count, positive values, and the total against the virtual chain at runtime

## Example

    [mmu_leds unit0]
    exit_leds: neopixel:my_leds (1-10)
    exit_led_counts: 1, 1, 2, 6

The count setting is normally left empty. Existing configuration line breaks retain their current physical-chain composition meaning and do not implicitly change gate boundaries.

## Tests

- make ALL=1 test: 1,358 tests passed across 47 files
- focused menuconfig, profile, LED mapping, validation, animation, static-color, compatibility, and console grouping coverage passed after the Kconfig follow-ups