### PR TITLE
Cover multi-unit initial MMU status aggregation

### DIFF
--- a/test/test_mmu_bootup.py
+++ b/test/test_mmu_bootup.py
@@ -115,7 +115,12 @@ class TestInitialStatusSchema(unittest.TestCase):
     """The first status snapshot must establish every public subscription field."""
 
     def test_top_level_fields_do_not_change_after_ready(self):
-        for profile in ('boxturtle', 'nfc_spoolman'):
+        expected_nfc_units = {
+            'boxturtle': 0,
+            'nfc_spoolman': 1,
+            'ercf_vvd': 2,
+        }
+        for profile, nfc_units in expected_nfc_units.items():
             with self.subTest(profile=profile):
                 hh = session(profile)
                 try:
@@ -127,7 +132,10 @@ class TestInitialStatusSchema(unittest.TestCase):
 
                     self.assertEqual(set(initial), set(ready))
                     self.assertIn('nfc', initial)
-                    self.assertEqual(bool(initial['nfc']), profile == 'nfc_spoolman')
+                    self.assertEqual(len(initial['nfc']), nfc_units)
+                    if profile == 'ercf_vvd':
+                        self.assertTrue(any(st['shared'] is not None for st in initial['nfc']))
+                        self.assertTrue(any(st['gates'] for st in initial['nfc']))
                     self.assertEqual(hh.errors, [])
                 finally:
                     hh.close()


### PR DESCRIPTION
Summary:
- add the two-unit ercf_vvd profile to the initial-status schema regression test
- verify its two NFC unit records
- verify the mixed shared-reader and per-gate NFC structures are both exercised
- replace the single-profile NFC assumption with explicit expected unit counts

Tests:
- ./venv/bin/python -m unittest test.test_mmu_bootup (37 tests passed)