### PR TITLE
Stop managed fan requests from marking the printer busy

### DIFF
--- a/extras/mmu/unit/mmu_fan_manager.py
+++ b/extras/mmu/unit/mmu_fan_manager.py
@@ -186,6 +186,7 @@ class MmuFanManager:
             if not fan_name:
                 continue
 
+            current_speed = self._get_speed(fan_name, eventtime)
             mode = self._modes[index]
             if mode == FAN_OFF:
                 speed = 0.
@@ -198,12 +199,13 @@ class MmuFanManager:
                 if not temperatures:
                     speed = 0.
                 else:
-                    current_speed = self._get_speed(fan_name, eventtime)
                     temperature = max(temperatures)
                     if current_speed > 0.:
                         speed = 1. if temperature > self._off_temps[index] else 0.
                     else:
                         speed = 1. if temperature >= self._on_temps[index] else 0.
+            if speed == current_speed:
+                continue
             self._set_speed(fan_name, speed)
 
     def _get_temperatures(self, fan_index, eventtime):
@@ -300,7 +302,7 @@ class MmuFanManager:
         fan_obj = self.printer.lookup_object(fan_name, None)
         if fan_obj is None:
             return
-        fan_obj.fan.set_speed_from_command(float(speed))
+        fan_obj.fan.set_speed(float(speed))
 
     def _set_all_speeds(self, speed):
         for fan_name in self.fans:

--- a/test/hh/klippy_root/extras/fan_generic.py
+++ b/test/hh/klippy_root/extras/fan_generic.py
@@ -5,11 +5,11 @@ class Fan:
     def __init__(self):
         self.speed = 0.
 
-    def set_speed(self, print_time, value):
+    def set_speed(self, value, print_time=None):
         self.speed = float(value)
 
     def set_speed_from_command(self, value):
-        self.set_speed(None, value)
+        self.set_speed(value)
 
     def get_status(self, eventtime=None):
         return {'speed': self.speed, 'rpm': None}


### PR DESCRIPTION
Managed fans marked the printer busy for a split second on every poll (default 5 s) while idling, which disabled many buttons on the web ui for a moment and also prevented idle_timeout from acting and could leave motors engaged indefinitely.

The fan manager now sends speed changes through the async request path (fan.set_speed, as controller_fan/heater_fan use) and only on actual speed transitions, so steady-state polling issues no requests at all.

:robot: Disclosure: This changeset was created with LLM assistance. All outputs are manually reviewed and tested to the best of my abilities.