### PR TITLE
Allow extruder without a TMC section — warn instead of raising

### DIFF
--- a/extras/mmu/unit/mmu_extruder_wrapper.py
+++ b/extras/mmu/unit/mmu_extruder_wrapper.py
@@ -43,19 +43,22 @@ class MmuExtruderWrapper():
 
         self.homing_extruder_stepper = None
 
-        # Ensure corresponding TMC section is loaded so endstops can be added and to prevent error later when toolhead is created
+        # Load the extruder TMC section if present - it enables software current control
+        # (tip forming) and the stallguard touch endstop. Optional: without it the driver
+        # settings are controlled in hardware, as on printers with no UART to the extruder.
         self._extruder_tmc = None
         for chip in TMC_CHIPS:
-            try:
-                section = f"{chip} {self.name}"
+            section = f"{chip} {self.name}"
+            if config.has_section(section):
                 self._extruder_tmc = self.printer.load_object(config, section)
                 logging.info(f"MMU: Loaded: [{section}]")
                 break
-            except Exception:
-                pass
 
         if self._extruder_tmc is None:
-            raise config.error(f"Extruder '{self.name}' TMC configuration not found. Required for mmu_unit {mmu_unit.name}")
+            logging.warning(
+                "MMU: Extruder '%s' on mmu_unit %s has no software-controlled TMC; "
+                "assuming motor current and driver mode are controlled in hardware"
+                % (self.name, mmu_unit.name))
 
         # Create MmuExtruderStepper for later insertion into PrinterExtruder on Toolhead (on klippy:connect)
         toolhead_section = config.getsection(self.name)

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -22,7 +22,7 @@ BOOT_DELAY = 2.5
 #
 # [extruder] needs its STEPPER options here: the shipped mmu_macro_vars.cfg [extruder]
 # carries only the extrude limits, but MmuExtruderWrapper builds an MmuExtruderStepper
-# straight off config.getsection('extruder') (mmu_extruder_wrapper.py:58-59).
+# straight off config.getsection('extruder') (mmu_extruder_wrapper.py:64-65).
 #
 # [tmc2209 extruder] is OPTIONAL - MmuExtruderWrapper degrades to hardware-controlled
 # driver settings without a <chip> extruder section (mmu_extruder_wrapper.py). It is

--- a/test/hh/bootstrap.py
+++ b/test/hh/bootstrap.py
@@ -24,9 +24,10 @@ BOOT_DELAY = 2.5
 # carries only the extrude limits, but MmuExtruderWrapper builds an MmuExtruderStepper
 # straight off config.getsection('extruder') (mmu_extruder_wrapper.py:58-59).
 #
-# [tmc2209 extruder] is MANDATORY - MmuExtruderWrapper.__init__ raises
-# "Extruder 'extruder' TMC configuration not found" without a <chip> extruder section
-# (mmu_extruder_wrapper.py:44-55).
+# [tmc2209 extruder] is OPTIONAL - MmuExtruderWrapper degrades to hardware-controlled
+# driver settings without a <chip> extruder section (mmu_extruder_wrapper.py). It is
+# here because most profiles exercise extruder current control; TestNoExtruderTmc
+# (test/test_mmu_bootup.py) strips it to cover machines with no UART to the extruder.
 PRINTER_STUB = """
 [mcu]
 serial: /dev/null

--- a/test/hh/klippy_root/configfile.py
+++ b/test/hh/klippy_root/configfile.py
@@ -13,7 +13,7 @@
 #   extras/mmu/unit/mmu_leds.py:32-35        add_section/getsection/remove_section to
 #                                            build a real led.LEDHelper
 #   extras/mmu_led_effect.py:107-113         synthesises [_led_effect ...] sections
-#   extras/mmu/unit/mmu_extruder_wrapper.py:63-66,89-91
+#   extras/mmu/unit/mmu_extruder_wrapper.py:67-69,96-98
 #                                            removes then restores [extruder] options
 #   extras/mmu/mmu_unit.py:277-292           fileconfig.set to share gear/TMC params
 #

--- a/test/hh/klippy_root/extras/tmc.py
+++ b/test/hh/klippy_root/extras/tmc.py
@@ -16,9 +16,12 @@
 #    and extras/mmu_stepper.py:311 calls setup_pin('endstop', ...) on it. Without the
 #    chip, config load fails on an unknown pin chip.
 #
-# MmuExtruderWrapper REQUIRES a `<chip> extruder` section to exist and raises
-# otherwise (extras/mmu/unit/mmu_extruder_wrapper.py:44-55), which is why the harness
-# printer stub ships [tmc2209 extruder].
+# Like Klipper, loading a `<chip> <stepper>` section that does not exist is a config
+# error. The fake configfile's getsection() deliberately does not raise for missing
+# sections (HH's own bare-section lookups depend on that), so the loaders enforce it
+# here instead. The stub still ships [tmc2209 extruder] because most profiles exercise
+# extruder current control; TestNoExtruderTmc (test/test_mmu_bootup.py) strips it to
+# cover machines with no UART to the extruder driver.
 
 
 class TMCCommandHelper:
@@ -125,6 +128,8 @@ class TMC:
 
 def make_load_config_prefix(chip_name):
     def load_config_prefix(config):
+        if not config.fileconfig.has_section(config.get_name()):
+            raise config.error("Unable to find config section '%s'" % config.get_name())
         return TMC(config, chip_name)
     return load_config_prefix
 

--- a/test/hh/klippy_root/kinematics/extruder.py
+++ b/test/hh/klippy_root/kinematics/extruder.py
@@ -9,9 +9,9 @@
 # CRITICAL: PrinterExtruder must only build an ExtruderStepper when the section
 # actually has a step_pin, exactly as real Klipper does. That is what makes
 # MmuExtruderWrapper's option-stripping trick work - it removes [extruder]'s
-# stepper options at config time (extras/mmu/unit/mmu_extruder_wrapper.py:63-66) so
+# stepper options at config time (extras/mmu/unit/mmu_extruder_wrapper.py:67-69) so
 # no duplicate stepper is built, then restores them and swaps in its own homing
-# stepper at klippy:connect (:89-96). If this fake unconditionally built a stepper,
+# stepper at klippy:connect (:91-101). If this fake unconditionally built a stepper,
 # that whole design would go untested.
 #
 # sk_extruder is a plain token, not a chelper struct (see stepper.StepperKinematics).

--- a/test/test_mmu_bootup.py
+++ b/test/test_mmu_bootup.py
@@ -22,9 +22,11 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 import logging
+import re
 import unittest
 
 from test.hh import session
+from test.hh.bootstrap import PRINTER_STUB
 
 # HH logs a lot at INFO during construction; keep test output readable.
 logging.getLogger().setLevel(logging.CRITICAL)
@@ -471,6 +473,40 @@ class TestSensorDriving(BootedSessionMixin, unittest.TestCase):
     def test_sensor_lookup_errors_are_helpful(self):
         with self.assertRaises(KeyError):
             self.hh.sensor('no_such_sensor')
+
+
+class TestNoExtruderTmc(BootedSessionMixin, unittest.TestCase):
+    """
+    Machines whose mainboard has no UART to the extruder driver (Ender 3 V3 SE + MMX)
+    cannot carry a [tmc<chip> extruder] section. Config load and boot must succeed
+    without one: MmuExtruderWrapper degrades to hardware-controlled driver settings
+    instead of raising. Regression - v3.4.x had no such requirement and this machine
+    booted there.
+    """
+
+    PROFILE = 'mmx'
+
+    @classmethod
+    def setUpClass(cls):
+        stub = re.sub(r'^\[tmc2209 extruder\]\n(?:[^\n]*\n)*\n', '', PRINTER_STUB, flags=re.M)
+        assert 'tmc2209 extruder' not in stub  # sanity: the strip must have worked
+        cls.hh = session(cls.PROFILE, printer_stub=stub)
+        cls.hh.boot()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.hh.close()
+
+    def test_boot_succeeds_without_extruder_tmc(self):
+        self.assertEqual(self.hh.errors, [])
+
+    def test_wrapper_reports_no_extruder_tmc(self):
+        wrapper = self.hh.printer.lookup_object('mmu_extruder extruder')
+        self.assertIsNone(wrapper.extruder_tmc_obj())
+
+    def test_gear_tmc_is_unaffected(self):
+        unit = self.hh.printer.lookup_object('mmu_machine').units[0]
+        self.assertIsNotNone(unit.drives[0].tmc_obj())
 
 
 if __name__ == '__main__':

--- a/test/test_mmu_bootup.py
+++ b/test/test_mmu_bootup.py
@@ -280,7 +280,7 @@ class TestConnect(BootedSessionMixin, unittest.TestCase):
         MmuExtruderWrapper strips [extruder]'s stepper options during the section
         loop so PrinterExtruder builds no stepper, then restores them and swaps in
         its own homing-capable stepper at connect
-        (extras/mmu/unit/mmu_extruder_wrapper.py:63-66, 86-96).
+        (extras/mmu/unit/mmu_extruder_wrapper.py:67-69, 91-101).
         """
         extruder = self.hh.printer.lookup_object('extruder')
         wrappers = [o for o in self.hh.printer.objects.values()

--- a/test/test_mmu_config.py
+++ b/test/test_mmu_config.py
@@ -206,7 +206,7 @@ class TestBoxTurtleRender(unittest.TestCase):
     def test_assemble_tolerates_duplicate_extruder_section(self):
         """
         [extruder] appears in both the printer stub (stepper options, which
-        MmuExtruderWrapper needs at extras/mmu/unit/mmu_extruder_wrapper.py:58-59)
+        MmuExtruderWrapper needs at extras/mmu/unit/mmu_extruder_wrapper.py:64-65)
         and mmu_macro_vars.cfg (extrude limits). RawConfigParser(strict=False) must
         merge rather than raise.
         """


### PR DESCRIPTION
The Problem

Since v4.0.0, `MmuExtruderWrapper.__init__` raises config.error unless a [tmc<chip> extruder] section exists. Printers whose mainboard has no UART to the extruder driver (e.g. Ender 3 V3 SE + MMX) therefore cannot start klippy at all - a regression: v3.4.x had no such requirement and these machines booted.

The requirement is also stricter than the code needs: the runtime already tolerates a missing extruder TMC (tip-forming current control checks for None; the stallguard "touch" endstop only exists if the user configured it, which implies the section).

 Changes

 - MmuExtruderWrapper guards the TMC load with config.has_section() — the same pattern every other TMC load in HH uses (gear steppers, selectors) — and logs a warning in the gear-stepper style instead of raising.
 - Side benefit: a genuinely broken TMC section now surfaces its real config error instead of being swallowed by a try/except and misreported as "not found".
 - Harness: the fake TMC loader now raises for a missing section, matching real Klipper (the fake getsection() deliberately doesn't, so the bug was unreproducible before this).
 - New test TestNoExtruderTmc (mmx profile, stub stripped of [tmc2209 extruder]): fails with the reported error before the fix, passes after.

Behavior is unchanged when a TMC section is present.

I have verified "TMC-having extruder is unaffected" in hardware. I have not tested the efficacy of the fix itself for lack of hardware.

 :robot: Disclosure: This changeset was created with LLM assistance. All outputs are manually reviewed and tested to the best of my abilities.